### PR TITLE
ci: add GitHub Actions firmware build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,4 +72,8 @@ jobs:
         run: |
           export PATH="$TOOLCHAIN_DIR/bin:$PATH"
           cp support/sdkconfig.default.hw31 sdkconfig
+          # The committed preset predates some Kconfig options (new vehicles etc.).
+          # `make defconfig` fills any missing/new options with their defaults
+          # non-interactively, avoiding the interactive prompt that aborts in CI.
+          make defconfig
           make -j"$(nproc)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,3 +103,19 @@ jobs:
           # 4. Normalise the edited config (no new prompts now) and build.
           make defconfig
           make -j"$(nproc)"
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ovms3-firmware
+          # ovms3.bin is the app image (flash via `ota flash vfs`, as
+          # scripts/ovms-deploy.sh does). The other three are also needed for a
+          # fresh serial flash (`make flash`). if-no-files-found: error so a
+          # silently-missing binary fails the job instead of producing an empty zip.
+          path: |
+            vehicle/OVMS.V3/build/ovms3.bin
+            vehicle/OVMS.V3/build/bootloader/bootloader.bin
+            vehicle/OVMS.V3/build/partitions.bin
+            vehicle/OVMS.V3/build/ota_data_initial.bin
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: Firmware build
+
+# Compile-checks the OVMS.V3 firmware on every push and pull request, mirroring
+# the legacy .travis.yml build (ESP-IDF 3.3.x make build, hw3.1 sdkconfig preset).
+# This only verifies the firmware compiles; there is no on-device test stage.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Cancel an in-progress run when a newer commit is pushed to the same ref.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned to match .travis.yml / .devcontainer to keep CI reproducible.
+  TOOLCHAIN_URL: https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-97-gc752ad5-5.2.0.tar.gz
+  IDF_REPO: https://github.com/openvehicles/esp-idf.git
+  IDF_PATH: ${{ github.workspace }}/esp/esp-idf
+  TOOLCHAIN_DIR: ${{ github.workspace }}/esp/xtensa-esp32-elf
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          # mongoose, zlib, libzip, wolfssh, wolfssl are git submodules and are
+          # required for a full firmware build.
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bison ccache dos2unix flex gperf libncurses-dev wget
+
+      # ESP-IDF 3.3.x ships pinned, older Python deps; 3.8 installs them cleanly.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Cache xtensa toolchain
+        id: cache-toolchain
+        uses: actions/cache@v4
+        with:
+          path: esp/xtensa-esp32-elf
+          key: xtensa-esp32-elf-1.22.0-97-gc752ad5-5.2.0
+
+      - name: Download xtensa toolchain
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p esp
+          wget -qO- "$TOOLCHAIN_URL" | tar xz -C esp
+
+      - name: Clone ESP-IDF (openvehicles fork)
+        run: |
+          git clone --recurse-submodules --depth 1 "$IDF_REPO" "$IDF_PATH"
+
+      - name: Install ESP-IDF Python requirements
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r "$IDF_PATH/requirements.txt"
+
+      - name: Build firmware (hw3.1 preset)
+        working-directory: vehicle/OVMS.V3
+        run: |
+          export PATH="$TOOLCHAIN_DIR/bin:$PATH"
+          cp support/sdkconfig.default.hw31 sdkconfig
+          make -j"$(nproc)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,11 @@
 name: Firmware build
 
-# Compile-checks the OVMS.V3 firmware on every push and pull request, mirroring
-# the legacy .travis.yml build (ESP-IDF 3.3.x make build, hw3.1 sdkconfig preset).
-# This only verifies the firmware compiles; there is no on-device test stage.
+# Compile-checks the OVMS.V3 firmware on every push and pull request, using the
+# legacy ESP-IDF 3.3.x make build with the hw3.1 sdkconfig preset. To keep CI
+# fast and failures attributable to our own code, only the base (NONE) stub plus
+# the vehicle modules under development are compiled (see ENABLE_VEHICLES below),
+# not the full vehicle set. This only verifies compilation; there is no on-device
+# test stage.
 
 on:
   push:
@@ -67,13 +70,36 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r "$IDF_PATH/requirements.txt"
 
-      - name: Build firmware (hw3.1 preset)
+      - name: Build firmware (base + vehicle modules under development)
         working-directory: vehicle/OVMS.V3
+        env:
+          # Vehicle module toggles to compile, on top of the base NONE stub.
+          # The Toyota e-TNGA base class has no toggle of its own — it compiles
+          # automatically whenever Solterra or bZ4X is enabled.
+          ENABLE_VEHICLES: >-
+            CONFIG_OVMS_VEHICLE_SUBARU_SOLTERRA
+            CONFIG_OVMS_VEHICLE_TOYOTA_BZ4X
         run: |
           export PATH="$TOOLCHAIN_DIR/bin:$PATH"
           cp support/sdkconfig.default.hw31 sdkconfig
-          # The committed preset predates some Kconfig options (new vehicles etc.).
-          # `make defconfig` fills any missing/new options with their defaults
-          # non-interactively, avoiding the interactive prompt that aborts in CI.
+
+          # 1. Realise a complete config non-interactively. The committed preset
+          #    predates some Kconfig options; `defconfig` fills them with their
+          #    defaults instead of prompting (which aborts under CI's redirected
+          #    stdin). After this, every vehicle toggle is materialised in sdkconfig.
+          make defconfig
+
+          # 2. Turn every specific-vehicle toggle off (keep only the base NONE
+          #    stub) so CI builds just our modules — faster, and failures are
+          #    attributable to our own code. Vehicle toggles are booleans (=y);
+          #    the int framework params (=<number>) don't match and are untouched.
+          sed -ri '/^CONFIG_OVMS_VEHICLE_NONE=y$/!s/^(CONFIG_OVMS_VEHICLE_[A-Z0-9_]+)=y$/# \1 is not set/' sdkconfig
+
+          # 3. Enable the modules under development (e-TNGA follows transitively).
+          for sym in $ENABLE_VEHICLES; do
+            printf '%s=y\n' "$sym" >> sdkconfig
+          done
+
+          # 4. Normalise the edited config (no new prompts now) and build.
           make defconfig
           make -j"$(nproc)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,26 @@ name: Firmware build
 on:
   push:
     branches: [master]
+    # Skip the firmware build for changes that can't affect it (docs, web
+    # plugins, marketing assets). A mixed change still builds, because
+    # paths-ignore only skips when *every* changed file matches.
+    # (Kept in sync with the pull_request list below — Actions YAML doesn't
+    # reliably support anchors, so the list is duplicated deliberately.)
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'plugins/**'
+      - 'flyer/**'
+      - 'logo/**'
+      - '.readthedocs.yaml'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'plugins/**'
+      - 'flyer/**'
+      - 'logo/**'
+      - '.readthedocs.yaml'
   workflow_dispatch:
 
 # Cancel an in-progress run when a newer commit is pushed to the same ref.
@@ -22,8 +41,17 @@ env:
   # Pinned to match .travis.yml / .devcontainer to keep CI reproducible.
   TOOLCHAIN_URL: https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-97-gc752ad5-5.2.0.tar.gz
   IDF_REPO: https://github.com/openvehicles/esp-idf.git
+  # Pinned commit of the (frozen 3.3.x) esp-idf fork, so the clone can be cached.
+  # Bump this SHA to pull in upstream esp-idf changes; it also keys the cache.
+  IDF_REF: 9063c8662ca5d67b5490c1503bd4377b380feed3
   IDF_PATH: ${{ github.workspace }}/esp/esp-idf
   TOOLCHAIN_DIR: ${{ github.workspace }}/esp/xtensa-esp32-elf
+  # ccache caches compiled objects across runs; the heavy framework libs
+  # (wolfssl, wolfssh, mongoose, ...) rarely change, so warm builds are far
+  # faster than the ~2min cold compile.
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 500M
+  CCACHE_COMPILERCHECK: content
 
 jobs:
   build:
@@ -61,14 +89,37 @@ jobs:
           mkdir -p esp
           wget -qO- "$TOOLCHAIN_URL" | tar xz -C esp
 
-      - name: Clone ESP-IDF (openvehicles fork)
+      - name: Cache ESP-IDF
+        id: cache-idf
+        uses: actions/cache@v4
+        with:
+          path: esp/esp-idf
+          key: esp-idf-${{ env.IDF_REF }}
+
+      - name: Clone ESP-IDF (openvehicles fork, pinned)
+        if: steps.cache-idf.outputs.cache-hit != 'true'
         run: |
-          git clone --recurse-submodules --depth 1 "$IDF_REPO" "$IDF_PATH"
+          # Shallow-fetch only the pinned commit and its submodules.
+          git init "$IDF_PATH"
+          git -C "$IDF_PATH" remote add origin "$IDF_REPO"
+          git -C "$IDF_PATH" fetch --depth 1 origin "$IDF_REF"
+          git -C "$IDF_PATH" checkout --detach FETCH_HEAD
+          git -C "$IDF_PATH" submodule update --init --recursive --depth 1
 
       - name: Install ESP-IDF Python requirements
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r "$IDF_PATH/requirements.txt"
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          # Per-commit key with a rolling fallback, so each run starts from the
+          # most recent cache and saves its own updated copy.
+          key: ccache-${{ github.sha }}
+          restore-keys: |
+            ccache-
 
       - name: Build firmware (base + vehicle modules under development)
         working-directory: vehicle/OVMS.V3
@@ -80,7 +131,18 @@ jobs:
             CONFIG_OVMS_VEHICLE_SUBARU_SOLTERRA
             CONFIG_OVMS_VEHICLE_TOYOTA_BZ4X
         run: |
-          export PATH="$TOOLCHAIN_DIR/bin:$PATH"
+          # Route the cross-compilers through ccache via a PATH shim: invoked as
+          # e.g. xtensa-esp32-elf-gcc, ccache finds the real compiler next on PATH.
+          # ESP-IDF 3.3 make has no native ccache switch, so this masquerade is
+          # how we hook it in.
+          SHIM="$RUNNER_TEMP/ccache-shim"
+          mkdir -p "$SHIM"
+          for c in xtensa-esp32-elf-gcc xtensa-esp32-elf-g++ xtensa-esp32-elf-c++ xtensa-esp32-elf-cc; do
+            ln -sf "$(command -v ccache)" "$SHIM/$c"
+          done
+          export PATH="$SHIM:$TOOLCHAIN_DIR/bin:$PATH"
+          ccache --zero-stats
+
           cp support/sdkconfig.default.hw31 sdkconfig
 
           # 1. Realise a complete config non-interactively. The committed preset
@@ -103,6 +165,8 @@ jobs:
           # 4. Normalise the edited config (no new prompts now) and build.
           make defconfig
           make -j"$(nproc)"
+
+          ccache --show-stats
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+# Note on cache warmth: GitHub scopes caches by branch/ref. Caches saved by a
+# pull_request run live in that PR's scope; a push to master saves to master's
+# scope, which every PR and master run can then read. So the first run after a
+# given cache is created is cold; subsequent same-scope runs are warm.
+
 env:
   # Pinned to match .travis.yml / .devcontainer to keep CI reproducible.
   TOOLCHAIN_URL: https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-97-gc752ad5-5.2.0.tar.gz

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Docs build
+
+# Builds the Sphinx documentation the same way upstream's Read the Docs build
+# does (see .readthedocs.yaml): Ubuntu 22.04, Python 3.11, the dependencies in
+# docs/source/requirements.txt, and a Sphinx HTML build of docs/source. Runs
+# only when docs change — the firmware workflow ignores docs/, so the two are
+# complementary. The rendered HTML is uploaded as an artifact for PR preview.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        # No submodules: the docs build doesn't need the firmware submodules.
+
+      # Match the Python version Read the Docs uses (.readthedocs.yaml).
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: docs/source/requirements.txt
+
+      - name: Install Sphinx dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Sphinx itself is pulled in transitively by sphinx_rtd_theme /
+          # sphinx_mdinclude, matching the RTD reproducible-build setup.
+          python -m pip install -r docs/source/requirements.txt
+
+      - name: Build HTML docs
+        working-directory: docs
+        # `make html` -> sphinx-build of source/ into build/html, exactly as
+        # documented in docs/README.md. Non-zero exit on Sphinx errors fails CI.
+        run: make html
+
+      - name: Upload rendered docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ovms-docs-html
+          path: docs/build/html
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,9 +47,11 @@ jobs:
 
       - name: Build HTML docs
         working-directory: docs
-        # `make html` -> sphinx-build of source/ into build/html, exactly as
-        # documented in docs/README.md. Non-zero exit on Sphinx errors fails CI.
-        run: make html
+        # `make html` -> sphinx-build of source/ into build/html (per docs/README.md).
+        # -W promotes Sphinx warnings (broken refs, malformed RST, missing files)
+        # to errors; --keep-going reports every warning before failing rather than
+        # stopping at the first.
+        run: make html SPHINXOPTS="-W --keep-going"
 
       - name: Upload rendered docs
         uses: actions/upload-artifact@v4

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2/docs/index.rst
@@ -164,9 +164,9 @@ Activate headlights for ~30 seconds:
 - **Command**: ``xrz2 lighting``
 - **Coming Home Feature**: Automatically activates when locking if configured (see Web Configuration)
 
-------------------------
+-------------------------
 Scheduled Preconditioning
-------------------------
+-------------------------
 
 Set up automatic climate control using the global OVMS scheduler.
 
@@ -264,9 +264,9 @@ If experiencing issues:
 - Look for "DCDC:" messages in logs
 - Check for preconditioning detection messages if DC/DC stops unexpectedly
 
--------------------
+--------------------
 Advanced Diagnostics
--------------------
+--------------------
 
 The Zoe PH2 integration includes DDT (Diagnostic Tool) commands for ECU configuration.
 
@@ -479,9 +479,9 @@ Beyond standard OVMS metrics, the Zoe PH2 integration provides:
 
 Persistent helper metrics such as ``xrz2.b.chg.start``, ``xrz2.b.used.start``, ``xrz2.b.recd.start`` and ``xrz2.v.pos.odometer.start`` are used internally for session and trip calculations, but can also be inspected for debugging.
 
--------------
+--------------
 Shell Commands
--------------
+--------------
 
 **Poller Control**
 
@@ -525,8 +525,8 @@ The Renault Zoe Phase 2 uses a CAN security gateway, making the OBD port normall
 
 This is why V-CAN connection is required for remote control features.
 
-------------------
+-------------------
 Community & Support
-------------------
+-------------------
 
 Forum: https://www.goingelectric.de/forum/viewtopic.php?p=2327071


### PR DESCRIPTION
## What

Adds `.github/workflows/build.yml` — a GitHub Actions workflow that compile-checks the OVMS.V3 firmware on push to `master`, on every PR, and via manual dispatch.

## Why

The repo's only firmware CI was `.travis.yml` (Travis CI for OSS is largely deprecated). This reproduces that build on GitHub Actions so PRs to this fork get a compile check.

## Details

Mirrors the validated `.travis.yml` / devcontainer setup:
- xtensa ESP32 toolchain + `openvehicles/esp-idf` fork (ESP-IDF 3.3.x, legacy `make` build)
- copies `support/sdkconfig.default.hw31` → `sdkconfig`, runs `make -j`

Plus two things Travis handled implicitly that Actions needs explicitly:
- **`submodules: recursive`** — mongoose, zlib, libzip, wolfssh, wolfssl are required for the build
- toolchain **caching**

Scope: compile check only — no on-device test stage. Uses `pull_request` (not `pull_request_target`), so fork PRs run read-only with no secret exposure.

## Not yet verified

I could not run Actions locally. The fragile part is ESP-IDF 3.3.x's pinned, old Python deps (runner pinned to Python 3.8 to maximize compatibility). **This PR's own CI run is the first real test** — expect possible follow-ups around the `requirements.txt` install or apt package names on Ubuntu 22.04.