### PR TITLE
docs: scope Solterra/bZ4X pages to vehicle specifics, link e-TNGA base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
+      - '**/*.rst'
+      # Vehicle component docs live under vehicle/**/docs and are symlinked into
+      # docs/source; they're doc sources, not firmware inputs.
+      - 'vehicle/**/docs/**'
       - 'plugins/**'
       - 'flyer/**'
       - 'logo/**'
@@ -26,6 +30,10 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
+      - '**/*.rst'
+      # Vehicle component docs live under vehicle/**/docs and are symlinked into
+      # docs/source; they're doc sources, not firmware inputs.
+      - 'vehicle/**/docs/**'
       - 'plugins/**'
       - 'flyer/**'
       - 'logo/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,16 @@ on:
     branches: [master]
     paths:
       - 'docs/**'
+      # Vehicle component docs live under vehicle/**/docs, symlinked into docs/source.
+      - 'vehicle/**/docs/**'
+      - '**/*.rst'
       - '.github/workflows/docs.yml'
   pull_request:
     paths:
       - 'docs/**'
+      # Vehicle component docs live under vehicle/**/docs, symlinked into docs/source.
+      - 'vehicle/**/docs/**'
+      - '**/*.rst'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 

--- a/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
@@ -2,31 +2,39 @@
 Subaru Solterra
 ===============
 
-Support for Subaru Solterra.
+The Subaru Solterra is built on the :doc:`Toyota e-TNGA platform </components/vehicle_toyota_etnga/docs/index>`.
+The e-TNGA module provides the CAN polling, charging state machine, and the common support baseline shared by
+all e-TNGA vehicles. This page documents only what is specific to the Solterra; see the e-TNGA module for
+everything else.
 
 ----------------
-Support Overview
+Vehicle identity
 ----------------
+
+:Short type code: SUBSOL
+:Vehicle name: Subaru Solterra
+:Log tag: ``v-subaru-solterra``
+
+-------------
+Battery / BMS
+-------------
+
+The Solterra declares its pack-specific BMS configuration, which lets the e-TNGA platform route the
+per-cell voltage and temperature readings (polled from ``0x182E``) through the BMS API — enabling per-cell
+history, deviation flags, and pack statistics. Without this configuration (as on the bare e-TNGA baseline)
+only the raw cell-voltage metric is published.
+
+* Pack: 96S CATL, Toyota EM "Type B" cells, 24 temperature sensors
+* Cell arrangement: 96 voltages in 4 modules of 24; 24 temperatures, 6 per module
+* Accept limits: 2.5 to 4.3 V per cell; -30 to +60 °C
+* Deviation thresholds: 20 mV warn / 30 mV alert; 4 °C warn / 8 °C alert
+
+--------------------------------
+Differences from e-TNGA baseline
+--------------------------------
 
 =========================== ==============
 Function                    Support Status
 =========================== ==============
-Hardware                    Any OVMS v3 (or later) module.
-Vehicle Cable               OBD-II to DB9 Data Cable for OVMS (1441200 right, or 1139300 left)
-GSM Antenna                 1000500 Open Vehicles OVMS GSM Antenna (or any compatible antenna)
-GPS Antenna                 1020200 Universal GPS Antenna (SMA Connector) (or any compatible antenna)
-SOC Display                 Yes
-Range Display               No
-GPS Location                Yes
-Speed Display               Yes
-Temperature Display         Yes
-BMS v+t Display             No
-TPMS Display                No
-Charge Status Display       Yes
-Charge Interruption Alerts  No
-Charge Control              No
-Cabin Pre-heat/cool Control No
-Lock/Unlock Vehicle         No
-Valet Mode Control          No
-Others                      VIN
+BMS v+t Display             Yes
 =========================== ==============

--- a/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
@@ -1,39 +1,28 @@
-==============
+===========
 Toyota bZ4X
-==============
+===========
 
-Vehicle Type: **Toyota bZ4X**
+The Toyota bZ4X is built on the :doc:`Toyota e-TNGA platform </components/vehicle_toyota_etnga/docs/index>`.
+The e-TNGA module provides the CAN polling, charging state machine, and the common support baseline shared by
+all e-TNGA vehicles. This page documents only what is specific to the bZ4X; see the e-TNGA module for
+everything else.
 
-This vehicle type supports the 2023 & 2024 Toyota bZ4X.
-
-Short type code = TOYBZ4X
-Long vehicle name = Toyota bZ4X
-unique log tag = v-toyotabz4x
-unique namespace prefix = xbz
+Supported model years: 2023 and 2024.
 
 ----------------
-Support Overview
+Vehicle identity
 ----------------
 
-=========================== ==============
-Function                    Support Status
-=========================== ==============
-Hardware                    OVMS v3 (or later)
-Vehicle Cable               OBD-II to DB9 Data Cable for OVMS (1441200 right, or 1139300 left)
-GSM Antenna                 1000500 Open Vehicles OVMS GSM Antenna (or any compatible antenna)
-GPS Antenna                 1020200 Universal GPS Antenna (SMA Connector) (or any compatible antenna)
-SOC Display                 Yes
-Range Display               No
-GPS Location                Yes
-Speed Display               Yes
-Temperature Display         Yes
-BMS v+t Display             No
-TPMS Display                No
-Charge Status Display       Yes
-Charge Interruption Alerts  No
-Charge Control              No
-Cabin Pre-heat/cool Control No
-Lock/Unlock Vehicle         No
-Valet Mode Control          No
-Others                      VIN
-=========================== ==============
+:Short type code: TOYBZ4X
+:Vehicle name: Toyota bZ4X
+:Log tag: ``v-toyotabz4x``
+:Config namespace prefix: ``xbz``
+
+------------------------
+Vehicle-specific support
+------------------------
+
+The bZ4X currently adds no behavioural overrides on top of the e-TNGA platform, so its supported functions
+match the e-TNGA baseline. In particular it does not declare a BMS pack arrangement, so per-cell BMS
+voltage/temperature monitoring is not enabled — unlike the
+:doc:`Subaru Solterra </components/vehicle_subaru_solterra/docs/index>`.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -2,7 +2,15 @@
 Toyota e-TNGA platform
 ======================
 
-Support for Toyota e-TNGA platform. This module is used by Toyota bZ4X and Subaru Solterra.
+Support for the Toyota e-TNGA platform. This is a shared base module, not a directly selectable vehicle:
+it provides the CAN polling, charging state machine, and the common support baseline for the vehicles built
+on it:
+
+* :doc:`Toyota bZ4X </components/vehicle_toyota_bz4x/docs/index>`
+* :doc:`Subaru Solterra </components/vehicle_subaru_solterra/docs/index>`
+
+Those pages list only what is specific to each vehicle; the Support Overview below is the shared baseline
+they inherit.
 
 ----------------
 Support Overview


### PR DESCRIPTION
## What
The Subaru Solterra and Toyota bZ4X are both built on the **Toyota e-TNGA platform** module, but their doc pages duplicated the shared support-overview table and never mentioned the dependency.

Restructured so each vehicle page:
- States it's built on the e-TNGA platform and **links to it** (links are bidirectional — e-TNGA links back to both vehicles).
- Lists **only what is unique** to that vehicle:
  - **Solterra**: identity + its pack-specific BMS configuration (96S CATL "Type B"), which is what enables per-cell voltage/temperature monitoring on top of the e-TNGA polling → BMS v+t = Yes (a genuine difference from baseline).
  - **bZ4X**: identity (type code, `xbz` namespace, 2023–2024 model years); no behavioural overrides, so it tracks the e-TNGA baseline.
- Defers the shared support baseline + PID polling + charging state machine to the e-TNGA page.

## CI path filters
Vehicle component docs live under `vehicle/**/docs` (symlinked into `docs/source`), so a docs-only change there is under `vehicle/**` — which previously triggered the *firmware* build and **not** the docs build. Fixed both filters to route `.rst` / vehicle-doc changes to the docs build.

## Verification
Built the full docs tree locally with Sphinx in strict mode (`make html SPHINXOPTS="-W --keep-going"`) → `build succeeded`, exit 0. Confirmed all three cross-reference links render in the HTML.