### PR TITLE
console: fix vfs tail follow-mode use-after-free on session disconnect

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -6,6 +6,11 @@ Open Vehicle Monitor System v3 - Change log
     could return an all-zero digest state when mbedtls_sha256_clone() snapshotted it mid-handshake,
     tripping the IDF fault-injection abort(). SHA now runs in software (AES/MPI hardware accel kept);
     matches the hw3.0 preset, which already had hardware SHA disabled. Rebuild + reflash required.
+- Console: Fix crash (LoadProhibited use-after-free) when an SSH or Telnet session running a
+    command in follow mode (e.g. "vfs tail <file>") was closed or dropped without Ctrl-C. The
+    follow-mode command task kept running and wrote to its now-freed session writer. The writer
+    now tracks its active follow-mode task, and console teardown stops and joins it before
+    freeing the connection. Affects any follow-mode command (OvmsCommandTask), not just vfs tail.
 
 
 2026-05-17 MB   3.3.006  OTA release

--- a/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
+++ b/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
@@ -340,6 +340,9 @@ ConsoleSSH::ConsoleSSH(OvmsSSH* server, struct mg_connection* nc)
 
 ConsoleSSH::~ConsoleSSH()
   {
+  // Stop any follow-mode command task (e.g. "vfs tail") before freeing the
+  // transport it writes to, otherwise it would dereference a freed writer.
+  TerminateCommandTask();
   WOLFSSH* ssh = m_ssh;
   m_ssh = NULL;
   wolfSSH_free(ssh);

--- a/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.cpp
+++ b/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.cpp
@@ -182,6 +182,9 @@ ConsoleTelnet::ConsoleTelnet(struct mg_connection* nc)
 
 ConsoleTelnet::~ConsoleTelnet()
   {
+  // Stop any follow-mode command task (e.g. "vfs tail") before freeing the
+  // transport it writes to, otherwise it would dereference a freed writer.
+  TerminateCommandTask();
   telnet_t *telnet = m_telnet;
   m_telnet = NULL;
   telnet_free(telnet);

--- a/vehicle/OVMS.V3/main/ovms_command.cpp
+++ b/vehicle/OVMS.V3/main/ovms_command.cpp
@@ -80,10 +80,41 @@ OvmsWriter::OvmsWriter()
   m_insert = NULL;
   m_userData = NULL;
   m_monitoring = false;
+  m_curtask = NULL;
   }
 
 OvmsWriter::~OvmsWriter()
   {
+  // Backstop: stop any follow-mode command task still bound to this writer.
+  // Interactive consoles that own a transport should call this earlier (before
+  // freeing that transport); here it only guards writers that did not.
+  TerminateCommandTask();
+  }
+
+void OvmsWriter::RegisterCommandTask(OvmsCommandTask* task)
+  {
+  m_curtask = task;
+  }
+
+void OvmsWriter::DeregisterCommandTask(OvmsCommandTask* task)
+  {
+  if (m_curtask == task)
+    m_curtask = NULL;
+  }
+
+void OvmsWriter::TerminateCommandTask()
+  {
+  // Ask the active follow-mode command task (if any) to stop, then wait until
+  // it has fully exited. The task clears its registration (m_curtask) as its
+  // last action that touches this writer, so once we observe it cleared the
+  // task can no longer dereference us. This relies on no concurrent Ctrl-C
+  // termination, which holds during connection-close teardown.
+  OvmsCommandTask* task = m_curtask;
+  if (task == NULL)
+    return;
+  task->RequestStop();
+  while (m_curtask == task)
+    vTaskDelay(pdMS_TO_TICKS(20));
   }
 
 void OvmsWriter::Exit()
@@ -1744,8 +1775,12 @@ bool OvmsCommandTask::Run()
     case OCS_RunLoop:
       // start task:
       writer->RegisterInsertCallback(Terminator, (void*) this);
+      // Register before Instantiate() so the task is never started while
+      // unregistered (it could otherwise finish and deregister before we set it).
+      writer->RegisterCommandTask(this);
       if (!Instantiate())
         {
+        writer->DeregisterCommandTask(this);
         delete this;
         return false;
         }
@@ -1772,6 +1807,9 @@ OvmsCommandTask::~OvmsCommandTask()
   if (m_state == OCS_StopRequested)
     writer->puts("^C");
   writer->DeregisterInsertCallback(Terminator);
+  // Must be the last access to writer: it releases a console blocked in
+  // TerminateCommandTask(), which may then free the writer.
+  writer->DeregisterCommandTask(this);
   if (argv)
     {
     for (int i=0; i < argc; i++)

--- a/vehicle/OVMS.V3/main/ovms_command.h
+++ b/vehicle/OVMS.V3/main/ovms_command.h
@@ -54,6 +54,7 @@
 class OvmsWriter;
 class OvmsCommand;
 class OvmsCommandMap;
+class OvmsCommandTask;
 class LogBuffers;
 typedef bool (*InsertCallback)(OvmsWriter* writer, void* userData, char);
 
@@ -81,6 +82,16 @@ class OvmsWriter
     virtual void ProcessChar(char c) {}
 
   public:
+    // Lifecycle of a follow-mode (OCS_RunLoop) command task bound to this writer.
+    // At most one such task can be active at a time (console input is captured by
+    // the command's Ctrl-C Terminator while it runs). TerminateCommandTask() must
+    // be called by a console before it frees any transport it owns, so the task
+    // can no longer dereference this writer after it is destroyed.
+    void RegisterCommandTask(OvmsCommandTask* task);
+    void DeregisterCommandTask(OvmsCommandTask* task);
+    void TerminateCommandTask();
+
+  public:
     // Used to notify the writer of a migration of a file within the VFS
     virtual const std::string GetPath() { return std::string(""); }
     virtual void SetPath(const std::string& path) {}
@@ -98,6 +109,7 @@ class OvmsWriter
     InsertCallback m_insert;
     void* m_userData;
     bool m_monitoring;
+    OvmsCommandTask* m_curtask;          // active follow-mode command task, or NULL
   };
 
 template <typename T>
@@ -328,6 +340,7 @@ class OvmsCommandTask : public TaskBase
     static bool Terminator(OvmsWriter* writer, void* userdata, char ch);
     bool IsRunning() { return m_state == OCS_RunLoop; }
     bool IsTerminated() { return m_state == OCS_StopRequested; }
+    void RequestStop() { m_state = OCS_StopRequested; }
 
   protected:
     int verbosity;


### PR DESCRIPTION
## Summary

Fixes #73 — a `LoadProhibited` use-after-free crash when an SSH/Telnet session running a command in **follow mode** (`OCS_RunLoop`, e.g. `vfs tail <file>`) is closed or dropped **without Ctrl-C**.

The follow-mode command runs its `Service()` loop on its own task, writing to the launching session's `OvmsWriter` through a raw pointer. The only stop path was the Ctrl-C `Terminator` insert callback. On a dropped/closed connection the console (an `OvmsWriter`) is destroyed while the task keeps running, so the next `writer->write()` dereferences a freed object (zeroed vtable) → crash. Confirmed by decoding two independent crashes (`EXCVADDR 0x10`, `A8=0`, task `tail`) to `ovms_vfs.cpp:756` = `writer->write(buf, len);`.

## Fix

`OvmsWriter` now tracks its single active follow-mode task (at most one can run, since console input is captured by the `Terminator` while it runs):

- `RegisterCommandTask`/`DeregisterCommandTask` — the task registers before it is started and deregisters as its **last** access to the writer.
- `TerminateCommandTask()` — requests the task to stop (`OCS_StopRequested`) and **waits** until it has fully exited and released the writer.
- `ConsoleSSH`/`ConsoleTelnet` call `TerminateCommandTask()` as the first action of their destructors, **before** freeing their transport (`m_ssh`/`m_telnet`), with a backstop in `~OvmsWriter()`.

Cooperative stop+join is used rather than `vTaskDelete` so a task is never force-killed mid-`write()` while it may hold a lock. The wait is race-free for the connection-close path (no concurrent Ctrl-C while the close handler runs). Generic to any `OvmsCommandTask`, not just `vfs tail`.

## Affected files
- `main/ovms_command.{h,cpp}` — writer task tracking + stop/join; register/deregister wiring
- `components/console_ssh/src/console_ssh.cpp`, `components/console_telnet/src/console_telnet.cpp` — stop task before freeing transport
- `changes.txt`

## Testing
- Compile: via this PR's "Firmware build" CI (no local toolchain available).
- **On-device validation still required** (touches console lifecycle): start `vfs tail` over SSH, drop the session without Ctrl-C, confirm no crash; re-check normal Ctrl-C exit and a clean `vfs tail -<n>` one-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)