### PR TITLE
Toyota e-TNGA: adaptive sleep cooldown backoff + info-level sleep logs

### DIFF
--- a/docs/superpowers/plans/2026-06-04-etnga-sleep-cooldown-backoff.md
+++ b/docs/superpowers/plans/2026-06-04-etnga-sleep-cooldown-backoff.md
@@ -1,0 +1,408 @@
+# e-TNGA Adaptive Sleep Cooldown Backoff — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the parked 12V duty cycle by escalating the sleep cooldown on consecutive no-activity sleeps, while keeping the 12V-rise wake as a responsive escape.
+
+**Architecture:** A single escalation index (`m_sleep_backoff_idx`) selects a cooldown from a hardcoded schedule `{10,30,60,120,300}`s. Cooldown arming is centralized in `TransitionToSleepState()`; real activity (drive / charge / charge-door / 12V wake) resets the index to 0. All logic lives in `etnga_poll_states.cpp` + 2 header members.
+
+**Tech Stack:** C++ (ESP-IDF 3.3, legacy `make`), OVMS3 vehicle framework. Component: `vehicle/OVMS.V3/components/vehicle_toyota_etnga`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-etnga-sleep-cooldown-backoff-design.md`
+
+---
+
+## Testing note (read first)
+
+This is a hardware project with **no host unit-test suite** (per `CLAUDE.md`: "tests run
+on-device"). The per-task verification here is therefore a **clean incremental build**
+(`make`), not a unit test. Final acceptance is **on-vehicle log observation** (Task 5),
+which is the spec's acceptance gate. Do not look for or invent a host test harness.
+
+All work happens in the existing worktree on branch `feature/etnga-sleep-cooldown-backoff`
+(`/home/devuser/wt-etnga-sleep-cooldown`). Improvement #1 (info-level sleep logs) is already
+committed on this branch.
+
+## Build prerequisite (one-time, before Task 1's build step)
+
+The worktree needs an `sdkconfig` with the e-TNGA vehicle enabled before `make` will work:
+
+```bash
+cd /home/devuser/wt-etnga-sleep-cooldown/vehicle/OVMS.V3
+# Reuse the main checkout's config if present, else seed + select:
+cp /home/devuser/Open-Vehicle-Monitoring-System-3/vehicle/OVMS.V3/sdkconfig sdkconfig 2>/dev/null \
+  || cp support/sdkconfig.default.hw31 sdkconfig
+# Ensure CONFIG_OVMS_VEHICLE_TOYOTA_ETNGA=y (via `make menuconfig` → OVMS - Vehicle Support,
+# or confirm it is already set):
+grep -q '^CONFIG_OVMS_VEHICLE_TOYOTA_ETNGA=y' sdkconfig && echo "etnga enabled" || echo "ENABLE etnga in menuconfig"
+```
+
+**Build command used as verification throughout:**
+`cd /home/devuser/wt-etnga-sleep-cooldown/vehicle/OVMS.V3 && make -j$(nproc)`
+Expected: compiles `etnga_poll_states.o`, links `build/ovms3.bin`, exits 0. (First build is
+slow; later builds are incremental and only recompile the changed file.)
+
+---
+
+## Task 1: Add header state + helper declaration
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h`
+
+- [ ] **Step 1: Add the two backoff members**
+
+Find:
+```cpp
+    bool m_allow_wake = true;  // Used to implement a cooldown timer if the vehicle is put into sleep
+    int m_sleep_entry_time = 0;  // Used to track the time that cooldown timer started
+```
+Replace with:
+```cpp
+    bool m_allow_wake = true;  // Used to implement a cooldown timer if the vehicle is put into sleep
+    int m_sleep_entry_time = 0;  // Used to track the time that cooldown timer started
+    int m_sleep_cooldown_secs = 10;  // Cooldown window (s) that applied to the current sleep
+    int m_sleep_backoff_idx = 0;     // Index into SLEEP_COOLDOWN_SECS; escalates on consecutive no-activity sleeps
+```
+
+- [ ] **Step 2: Declare the reset helper**
+
+Find:
+```cpp
+    void TransitionToChargeDcState();
+
+    void RequestVIN();
+```
+Replace with:
+```cpp
+    void TransitionToChargeDcState();
+
+    void ResetSleepBackoff();   // reset cooldown escalation to the base step (real activity seen)
+
+    void RequestVIN();
+```
+
+- [ ] **Step 3: Build to verify it still compiles** (unused members/undeclared-but-uncalled helper are fine)
+
+Run: `cd /home/devuser/wt-etnga-sleep-cooldown/vehicle/OVMS.V3 && make -j$(nproc)`
+Expected: exit 0. (A header-only change with no new references compiles cleanly.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/devuser/wt-etnga-sleep-cooldown add vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+git -C /home/devuser/wt-etnga-sleep-cooldown commit -m "etnga: add sleep cooldown backoff state + reset helper decl"
+```
+
+---
+
+## Task 2: Schedule, reset helper, and centralized cooldown arming
+
+This adds the schedule + `ResetSleepBackoff()`, moves cooldown arming into
+`TransitionToSleepState()`, and removes the now-duplicated arming from the three forced-sleep
+sites. After this task the index escalates but `HandleSleepState` still uses the old fixed
+`> 10` check (changed in Task 3) — intermediate state compiles and is safe.
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp`
+
+- [ ] **Step 1: Add schedule + ResetSleepBackoff() above HandleSleepState**
+
+Find:
+```cpp
+//    CHARGE_DC (6)         : DC fast charging in progress
+
+void OvmsVehicleToyotaETNGA::HandleSleepState()
+```
+Replace with:
+```cpp
+//    CHARGE_DC (6)         : DC fast charging in progress
+
+// Escalating sleep cooldown schedule (seconds). Each consecutive no-activity sleep uses the
+// next entry; real activity (drive/charge/charge-door/12V wake) resets to [0]. Caps at the
+// last entry. See ResetSleepBackoff() and TransitionToSleepState().
+static const int SLEEP_COOLDOWN_SECS[] = {10, 30, 60, 120, 300};
+static const int SLEEP_COOLDOWN_STEPS  = sizeof(SLEEP_COOLDOWN_SECS) / sizeof(SLEEP_COOLDOWN_SECS[0]);
+
+void OvmsVehicleToyotaETNGA::ResetSleepBackoff()
+{
+    m_sleep_backoff_idx = 0;
+}
+
+void OvmsVehicleToyotaETNGA::HandleSleepState()
+```
+
+- [ ] **Step 2: Centralize cooldown arming in TransitionToSleepState**
+
+Find:
+```cpp
+void OvmsVehicleToyotaETNGA::TransitionToSleepState()
+{
+    m_armed_for_charge = false;
+    SetPollState(PollState::SLEEP);
+    SetAwake(false);
+}
+```
+Replace with:
+```cpp
+void OvmsVehicleToyotaETNGA::TransitionToSleepState()
+{
+    int monotonic = StandardMetrics.ms_m_monotonic->AsInt();
+    m_armed_for_charge = false;
+    // Arm the escalating cooldown: ignore CAN-frame wakes for the current window, then step
+    // the index up (clamped) so the next consecutive no-activity sleep waits longer.
+    // ResetSleepBackoff() returns the index to 0 on real activity.
+    m_sleep_entry_time = monotonic;
+    m_sleep_cooldown_secs = SLEEP_COOLDOWN_SECS[m_sleep_backoff_idx];
+    m_allow_wake = false;
+    if (m_sleep_backoff_idx < SLEEP_COOLDOWN_STEPS - 1)
+        m_sleep_backoff_idx++;
+    SetPollState(PollState::SLEEP);
+    SetAwake(false);
+}
+```
+
+- [ ] **Step 3: Remove duplicated arming — door-watch forced sleep**
+
+Find:
+```cpp
+            ESP_LOGI(TAG, "Vehicle awake for over 300s with no activity — forcing sleep state");
+            m_sleep_entry_time = monotonic;
+            m_allow_wake = false;
+            TransitionToSleepState();
+```
+Replace with:
+```cpp
+            ESP_LOGI(TAG, "Vehicle awake for over 300s with no activity — forcing sleep state");
+            TransitionToSleepState();
+```
+
+- [ ] **Step 4: Remove duplicated arming — cable-watch forced sleep**
+
+Find:
+```cpp
+        ESP_LOGI(TAG, "Armed 15min, no cable plug-in — giving up");
+        m_sleep_entry_time = monotonic;
+        m_allow_wake = false;
+        TransitionToSleepState();
+```
+Replace with:
+```cpp
+        ESP_LOGI(TAG, "Armed 15min, no cable plug-in — giving up");
+        TransitionToSleepState();
+```
+
+- [ ] **Step 5: Remove duplicated arming — charge-wait bus-dead sleep**
+
+Find:
+```cpp
+        // Bus went dead during scheduled wait (OBC slept or gateway isolated OBD)
+        m_sleep_entry_time = StandardMetrics.ms_m_monotonic->AsInt();
+        m_allow_wake = false;
+        TransitionToSleepState();
+```
+Replace with:
+```cpp
+        // Bus went dead during scheduled wait (OBC slept or gateway isolated OBD)
+        TransitionToSleepState();
+```
+
+- [ ] **Step 6: Build**
+
+Run: `cd /home/devuser/wt-etnga-sleep-cooldown/vehicle/OVMS.V3 && make -j$(nproc)`
+Expected: exit 0. (Note: `monotonic` is still used elsewhere in `HandleAwakeState` — lines for
+`m_cable_watch_start` and `m_v_env_awaketime` — so no unused-variable warning.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /home/devuser/wt-etnga-sleep-cooldown add vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+git -C /home/devuser/wt-etnga-sleep-cooldown commit -m "etnga: centralize escalating sleep cooldown in TransitionToSleepState"
+```
+
+---
+
+## Task 3: Apply the cooldown window + reset on 12V wake
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp`
+
+- [ ] **Step 1: Use the per-sleep cooldown in HandleSleepState + log the duration**
+
+Find:
+```cpp
+    if (!m_allow_wake)
+    {
+        if ((monotonic - m_sleep_entry_time) > 10)
+        {
+            ESP_LOGI(TAG, "Cooling off period ended, allowing wake");
+            m_allow_wake = true;
+        }
+    }
+```
+Replace with:
+```cpp
+    if (!m_allow_wake)
+    {
+        if ((monotonic - m_sleep_entry_time) > m_sleep_cooldown_secs)
+        {
+            ESP_LOGI(TAG, "Cooling off period ended (%ds), allowing wake", m_sleep_cooldown_secs);
+            m_allow_wake = true;
+        }
+    }
+```
+
+- [ ] **Step 2: Reset backoff on the 12V-rise wake (the responsive escape)**
+
+Find:
+```cpp
+        ESP_LOGI(TAG, "Aux 12V has exceeded the threshold");
+        // Send a CAN reset.
+        esp_err_t result = m_can2->Reset();
+```
+Replace with:
+```cpp
+        ESP_LOGI(TAG, "Aux 12V has exceeded the threshold");
+        // Real power-up — resume responsive cooldowns.
+        ResetSleepBackoff();
+        // Send a CAN reset.
+        esp_err_t result = m_can2->Reset();
+```
+
+- [ ] **Step 3: Build**
+
+Run: `cd /home/devuser/wt-etnga-sleep-cooldown/vehicle/OVMS.V3 && make -j$(nproc)`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/devuser/wt-etnga-sleep-cooldown add vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+git -C /home/devuser/wt-etnga-sleep-cooldown commit -m "etnga: apply escalating cooldown window + reset on 12V wake"
+```
+
+---
+
+## Task 4: Reset backoff on the remaining real-activity events
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp`
+
+- [ ] **Step 1: Reset on entering DRIVING**
+
+Find:
+```cpp
+void OvmsVehicleToyotaETNGA::TransitionToDrivingState()
+{
+    m_armed_for_charge = false;
+    SetPollState(PollState::DRIVING);
+```
+Replace with:
+```cpp
+void OvmsVehicleToyotaETNGA::TransitionToDrivingState()
+{
+    m_armed_for_charge = false;
+    ResetSleepBackoff();   // real drive — resume responsive cooldowns
+    SetPollState(PollState::DRIVING);
+```
+
+- [ ] **Step 2: Reset on entering CHARGE_HANDSHAKE**
+
+Find:
+```cpp
+void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
+{
+    m_armed_for_charge = false;  // arm state consumed on entering handshake
+    m_charge_state_entry = StandardMetrics.ms_m_monotonic->AsInt();
+```
+Replace with:
+```cpp
+void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
+{
+    m_armed_for_charge = false;  // arm state consumed on entering handshake
+    ResetSleepBackoff();   // charge session beginning — resume responsive cooldowns
+    m_charge_state_entry = StandardMetrics.ms_m_monotonic->AsInt();
+```
+
+- [ ] **Step 3: Reset when the charge door opens (arm)**
+
+Find:
+```cpp
+        if (lid_open) {
+            // Charge door just opened: arm and start the 15-min cable watch
+            m_armed_for_charge = true;
+            m_cable_watch_start = monotonic;
+        }
+```
+Replace with:
+```cpp
+        if (lid_open) {
+            // Charge door just opened: arm and start the 15-min cable watch
+            m_armed_for_charge = true;
+            m_cable_watch_start = monotonic;
+            ResetSleepBackoff();   // deliberate user action — resume responsive cooldowns
+        }
+```
+
+- [ ] **Step 4: Clean full build**
+
+Run: `cd /home/devuser/wt-etnga-sleep-cooldown/vehicle/OVMS.V3 && make -j$(nproc)`
+Expected: exit 0, links `build/ovms3.bin`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/devuser/wt-etnga-sleep-cooldown add vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+git -C /home/devuser/wt-etnga-sleep-cooldown commit -m "etnga: reset sleep backoff on drive/charge/charge-door activity"
+```
+
+---
+
+## Task 5: On-vehicle acceptance (manual, post-merge-candidate)
+
+No host tests exist; this is the real acceptance gate from the spec. Not run in-session —
+record results when flashed to the module.
+
+- [ ] **Step 1: Flash the build to the module**
+
+Per memory `howto_ovms_fast_deploy`: install via `ota flash http` from os-k3s (`sd mount`
+first), reachable through the `solterra-ovms` SSH alias. Do **not** use destructive `module`
+commands.
+
+- [ ] **Step 2: Confirm the ramp**
+
+Park and let it cycle; in `/sd/logs/log.txt` confirm successive lines:
+`Cooling off period ended (10s), allowing wake` → `(30s)` → `(60s)` → `(120s)` → `(300s)`.
+
+- [ ] **Step 3: Confirm 12V reset**
+
+Trigger a 12V-rise wake; confirm `Aux 12V has exceeded the threshold` followed by the **next**
+`Cooling off period ended (10s…)` (index reset to base).
+
+- [ ] **Step 4: Confirm activity resets**
+
+Confirm a real drive (DRIVING) and a charge plug-in each return the next cooldown to `(10s)`.
+
+- [ ] **Step 5: (Optional) measure drain**
+
+Compare `ms_v_bat_12v_voltage` across parked windows before/after for actual sag improvement.
+
+---
+
+## changes.txt (deferred — confirm with maintainer)
+
+e-TNGA has no `changes.txt` presence yet (in-development vehicle). Per the earlier decision,
+hold the release-note entry until the vehicle is announced as a whole, or add a bullet now if
+preferred. Not included as a code task.
+
+---
+
+## Self-review (completed by plan author)
+
+- **Spec coverage:** schedule → T2; members → T1; centralized arming + duplicate removal (3
+  sites) → T2; cooldown window + duration log → T3; 12V reset → T3; DRIVING/charge/charge-door
+  resets → T4; on-vehicle validation → T5; #1 logging already committed. All spec sections map
+  to a task.
+- **Placeholder scan:** none — every code step shows full find/replace text.
+- **Type consistency:** `m_sleep_backoff_idx`, `m_sleep_cooldown_secs`, `SLEEP_COOLDOWN_SECS`,
+  `SLEEP_COOLDOWN_STEPS`, `ResetSleepBackoff()` are spelled identically in the header (T1) and
+  every use (T2–T4).

--- a/docs/superpowers/specs/2026-06-04-etnga-sleep-cooldown-backoff-design.md
+++ b/docs/superpowers/specs/2026-06-04-etnga-sleep-cooldown-backoff-design.md
@@ -1,0 +1,161 @@
+# e-TNGA adaptive sleep cooldown backoff — design
+
+**Date:** 2026-06-04
+**Author:** Jerry Kezar
+**Component:** `vehicle/OVMS.V3/components/vehicle_toyota_etnga`
+**Branch:** `feature/etnga-sleep-cooldown-backoff`
+
+## Problem
+
+Review of the 2026-06-04 drive logs showed the state machine behaving correctly,
+but with a high parked-but-bus-noisy **duty cycle**. After a drive the module
+repeatedly cycled:
+
+```
+AWAKE ~300s (door-watch watchdog) → forced SLEEP → 10s cooldown → CAN frame re-wakes → AWAKE …
+```
+
+The forced-sleep cooldown is a fixed 10s (`HandleSleepState`), and after it
+expires the next stray CAN2 frame sets `ms_v_env_awake` again and drags the
+module back to a full 5-minute AWAKE poll cycle. Observed steady state was
+roughly **~77% awake** while parked with an intermittently-live bus — wasted
+12V draw with no driving or charging happening.
+
+The natural `env_awake`-stale `AWAKE→SLEEP` path (when the bus genuinely goes
+quiet) is *not* cooldown-latched at all, which also produces rapid ~3s
+`SLEEP→AWAKE` bounces.
+
+## Goal
+
+Reduce the parked duty cycle by **escalating the sleep cooldown** on consecutive
+no-activity sleeps, while keeping the module responsive to a real return via the
+existing **12V-rise wake** escape. No change to driving/charging behavior.
+
+This is a 12V-drain mitigation. Actual drain improvement must be confirmed
+on-vehicle; the design is bounded so the worst case is "ignore CAN for up to the
+current cooldown, ≤5 min, but still wake on a 12V power-up."
+
+## Design
+
+### State
+
+A single shared escalation index selects from a hardcoded cooldown schedule.
+All logic stays in `etnga_poll_states.cpp`.
+
+- **Schedule** (file-scope `static const` in `etnga_poll_states.cpp`):
+  `SLEEP_COOLDOWN_SECS[] = {10, 30, 60, 120, 300}` (seconds; cap 5 min).
+- **New members** (`vehicle_toyota_etnga.h`):
+  - `int m_sleep_backoff_idx = 0;` — index into the schedule.
+  - `int m_sleep_cooldown_secs = 10;` — the cooldown that applied to the
+    *current* sleep (captured at sleep entry, read in `HandleSleepState`).
+- **New helper** (`etnga_poll_states.cpp`): `void ResetSleepBackoff()` →
+  `m_sleep_backoff_idx = 0;`
+
+### Arming (escalate) — centralized in `TransitionToSleepState()`
+
+`TransitionToSleepState()` becomes the single place that arms the cooldown.
+On every sleep it:
+
+1. sets `m_sleep_entry_time = monotonic`
+2. captures `m_sleep_cooldown_secs = SLEEP_COOLDOWN_SECS[m_sleep_backoff_idx]`
+3. sets `m_allow_wake = false`
+4. increments `m_sleep_backoff_idx`, clamped to the last schedule entry
+
+Because every `AWAKE→SLEEP` / `CHARGE_WAIT→SLEEP` edge already routes through
+`TransitionToSleepState()`, this uniformly covers all four sleep sites:
+
+- door-watch forced sleep (`HandleAwakeState`, 300s)
+- cable-watch forced sleep (`HandleAwakeState`, 900s)
+- charge-wait bus-dead sleep (`HandleChargeWaitState`)
+- natural `env_awake`-stale sleep (`HandleAwakeState`)
+
+The three forced sites therefore **drop their now-duplicated**
+`m_sleep_entry_time = …; m_allow_wake = false;` lines (handled centrally), and
+the natural-stale site gains cooldown arming for free — which also damps the
+3s `SLEEP→AWAKE` bounces.
+
+### Cooldown expiry — `HandleSleepState()`
+
+Change the fixed check from `> 10` to `> m_sleep_cooldown_secs`, and log the
+actual duration:
+
+```cpp
+if (!m_allow_wake) {
+    if ((monotonic - m_sleep_entry_time) > m_sleep_cooldown_secs) {
+        ESP_LOGI(TAG, "Cooling off period ended (%ds), allowing wake", m_sleep_cooldown_secs);
+        m_allow_wake = true;
+    }
+}
+```
+
+### Reset (`idx = 0`) — real activity snaps back to responsive
+
+`ResetSleepBackoff()` is called at the four real-activity points:
+
+| Point | Location |
+|-------|----------|
+| Enter DRIVING | `TransitionToDrivingState()` |
+| Enter charge handshake | `TransitionToChargeHandshakeState()` |
+| 12V-rise wake | `HandleSleepState()` 12V branch (before `TransitionToAwakeState`) |
+| Charge door opens (arm) | `HandleAwakeState()`, the `lid_open` arm block |
+
+Bare CAN-frame wakes that only reach `AWAKE` (no drive/charge) do **not** reset
+— that is the mechanism that lets the ramp climb during persistent parked
+chatter.
+
+### 12V escape (the responsiveness guarantee)
+
+The existing 12V-rise wake path in `HandleSleepState()`
+(`ms_v_bat_12v_voltage > ref + 0.2`) is **not** gated by `m_allow_wake`, so it
+already fires during a cooldown. This design preserves that and adds a
+`ResetSleepBackoff()` call so a real power-up resumes responsive (10s)
+cooldowns. This escape is what makes the long end of the ramp safe: while CAN is
+ignored (≤5 min), a genuine return that raises 12V still wakes immediately.
+
+## Expected behavior
+
+- Parked-with-chatter steady-state duty cycle drops from ~77% toward ~50%
+  (300s awake watchdog + 300s capped cooldown), ramping over ~4 cycles after
+  parking.
+- First sleep after any real activity is still 10s — a returning driver is
+  caught by CAN while `idx` is low, and by the 12V escape once it has climbed.
+- Cleanly-parked car (bus goes quiet, stays asleep) only sleeps once, so `idx`
+  stays low — escalation only builds under active cycling, exactly the drain
+  scenario.
+
+## Risks
+
+- **12V reliability is load-bearing at the aggressive end.** If a wake powers the
+  bus but not the 12V rail above `ref + 0.2`, CAN is ignored for up to the
+  current cooldown (≤5 min). The existing code already trusts this 12V signal, so
+  no new assumption is introduced — but the backoff leans on it harder.
+  On-vehicle measurement is the acceptance gate.
+- Behavior change to a 12V-critical loop: validate on the real module before
+  merging.
+
+## Validation
+
+No host unit tests (hardware project). Acceptance is on-vehicle:
+
+1. `make` builds clean.
+2. Flash; park and let it cycle. Confirm in logs the ramp:
+   `Cooling off period ended (10s/30s/60s/120s/300s)`.
+3. Confirm a 12V-rise wake logs `Aux 12V has exceeded the threshold` and the
+   *next* cooldown is back to 10s (reset worked).
+4. Confirm a real drive and a charge plug-in each reset to 10s.
+5. Optionally compare `ms_v_bat_12v_voltage` across parked windows for actual
+   sag improvement.
+
+## Out of scope (YAGNI)
+
+- Making the schedule config-tunable via `xte` params (revisit only if repeated
+  on-vehicle tuning proves necessary).
+- Shortening the 300s AWAKE door-watch watchdog (the other duty-cycle lever) —
+  separate change, separate validation.
+
+## Bundled change
+
+This branch also carries improvement **#1** (observability): the two watchdog
+reason logs promoted `ESP_LOGD → ESP_LOGI`, plus a reason line on the natural
+`env_awake`-stale sleep, so production (info-level) logs show *why* the module
+slept. This directly supports validating the backoff above.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -587,7 +587,9 @@ Tyre pressure and temperature data are retrieved from the TPMS ECU via the
 gateway sub-target ``0x2A`` at address ``0x750``, using the module's
 ``ISOTP_EXTADR`` mixed-addressing mode.  This is the first gateway-relay poll
 in the eTNGA module.  Readings are collected every 60 seconds while in the
-``AWAKE`` or ``DRIVING`` poll states.
+``DRIVING`` poll state.  The gateway sub-target ``0x2A`` only answers while the
+car is driving (or in *My Room*); parked-asleep and during charging it does not
+respond, so polling it in ``AWAKE`` only produced timeouts and was dropped.
 
 Metrics
 -------

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -37,9 +37,9 @@ void OvmsVehicleToyotaETNGA::HandleSleepState()
     
     if (!m_allow_wake)
     {
-        if ((monotonic - m_sleep_entry_time) > 10)
+        if ((monotonic - m_sleep_entry_time) > m_sleep_cooldown_secs)
         {
-            ESP_LOGI(TAG, "Cooling off period ended, allowing wake");
+            ESP_LOGI(TAG, "Cooling off period ended (%ds), allowing wake", m_sleep_cooldown_secs);
             m_allow_wake = true;
         }
     }
@@ -50,6 +50,8 @@ void OvmsVehicleToyotaETNGA::HandleSleepState()
     } else if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > (StandardMetrics.ms_v_bat_12v_voltage_ref->AsFloat()+0.2f)) {
         // Voltage is high. Maybe awake as well...
         ESP_LOGI(TAG, "Aux 12V has exceeded the threshold");
+        // Real power-up — resume responsive cooldowns.
+        ResetSleepBackoff();
         // Send a CAN reset.
         esp_err_t result = m_can2->Reset();
         if (result == ESP_OK) {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -24,7 +24,7 @@
 // next entry; real activity (drive/charge/charge-door/12V wake) resets to [0]. Caps at the
 // last entry. See ResetSleepBackoff() and TransitionToSleepState().
 static const int SLEEP_COOLDOWN_SECS[] = {10, 30, 60, 120, 300};
-static const int SLEEP_COOLDOWN_STEPS  = sizeof(SLEEP_COOLDOWN_SECS) / sizeof(SLEEP_COOLDOWN_SECS[0]);
+static const int SLEEP_COOLDOWN_STEPS  = (int)(sizeof(SLEEP_COOLDOWN_SECS) / sizeof(SLEEP_COOLDOWN_SECS[0]));
 
 void OvmsVehicleToyotaETNGA::ResetSleepBackoff()
 {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -76,6 +76,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
 
     if (!StandardMetrics.ms_v_env_awake->AsBool()) {
         // No CAN communication - bus is dead, go to sleep
+        ESP_LOGI(TAG, "CAN bus idle (env_awake cleared) — sleeping");
         TransitionToSleepState();
         return;
     }
@@ -103,7 +104,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
             m_cable_watch_start = monotonic;
         } else if (monotonic - m_v_env_awaketime->AsInt() > 300) {
             // Door watch expired (5 min in AWAKE, charge door never opened) → sleep
-            ESP_LOGD(TAG, "Vehicle awake for over 300s with no activity — forcing sleep state");
+            ESP_LOGI(TAG, "Vehicle awake for over 300s with no activity — forcing sleep state");
             m_sleep_entry_time = monotonic;
             m_allow_wake = false;
             TransitionToSleepState();
@@ -111,7 +112,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
         }
     } else if (monotonic - m_cable_watch_start > 900) {
         // Cable watch expired (15 min armed, no cable plug-in) → sleep
-        ESP_LOGD(TAG, "Armed 15min, no cable plug-in — giving up");
+        ESP_LOGI(TAG, "Armed 15min, no cable plug-in — giving up");
         m_sleep_entry_time = monotonic;
         m_allow_wake = false;
         TransitionToSleepState();

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -20,6 +20,17 @@
 //    CHARGE_AC (5)         : AC charging in progress
 //    CHARGE_DC (6)         : DC fast charging in progress
 
+// Escalating sleep cooldown schedule (seconds). Each consecutive no-activity sleep uses the
+// next entry; real activity (drive/charge/charge-door/12V wake) resets to [0]. Caps at the
+// last entry. See ResetSleepBackoff() and TransitionToSleepState().
+static const int SLEEP_COOLDOWN_SECS[] = {10, 30, 60, 120, 300};
+static const int SLEEP_COOLDOWN_STEPS  = sizeof(SLEEP_COOLDOWN_SECS) / sizeof(SLEEP_COOLDOWN_SECS[0]);
+
+void OvmsVehicleToyotaETNGA::ResetSleepBackoff()
+{
+    m_sleep_backoff_idx = 0;
+}
+
 void OvmsVehicleToyotaETNGA::HandleSleepState()
 {
     int monotonic = StandardMetrics.ms_m_monotonic->AsInt();
@@ -105,16 +116,12 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
         } else if (monotonic - m_v_env_awaketime->AsInt() > 300) {
             // Door watch expired (5 min in AWAKE, charge door never opened) → sleep
             ESP_LOGI(TAG, "Vehicle awake for over 300s with no activity — forcing sleep state");
-            m_sleep_entry_time = monotonic;
-            m_allow_wake = false;
             TransitionToSleepState();
             return;
         }
     } else if (monotonic - m_cable_watch_start > 900) {
         // Cable watch expired (15 min armed, no cable plug-in) → sleep
         ESP_LOGI(TAG, "Armed 15min, no cable plug-in — giving up");
-        m_sleep_entry_time = monotonic;
-        m_allow_wake = false;
         TransitionToSleepState();
         return;
     }
@@ -185,8 +192,6 @@ void OvmsVehicleToyotaETNGA::HandleChargeWaitState()
     }
     if (!StandardMetrics.ms_v_env_awake->AsBool()) {
         // Bus went dead during scheduled wait (OBC slept or gateway isolated OBD)
-        m_sleep_entry_time = StandardMetrics.ms_m_monotonic->AsInt();
-        m_allow_wake = false;
         TransitionToSleepState();
         return;
     }
@@ -237,7 +242,16 @@ void OvmsVehicleToyotaETNGA::HandleChargeDcState()
 
 void OvmsVehicleToyotaETNGA::TransitionToSleepState()
 {
+    int monotonic = StandardMetrics.ms_m_monotonic->AsInt();
     m_armed_for_charge = false;
+    // Arm the escalating cooldown: ignore CAN-frame wakes for the current window, then step
+    // the index up (clamped) so the next consecutive no-activity sleep waits longer.
+    // ResetSleepBackoff() returns the index to 0 on real activity.
+    m_sleep_entry_time = monotonic;
+    m_sleep_cooldown_secs = SLEEP_COOLDOWN_SECS[m_sleep_backoff_idx];
+    m_allow_wake = false;
+    if (m_sleep_backoff_idx < SLEEP_COOLDOWN_STEPS - 1)
+        m_sleep_backoff_idx++;
     SetPollState(PollState::SLEEP);
     SetAwake(false);
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -115,6 +115,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
             // Charge door just opened: arm and start the 15-min cable watch
             m_armed_for_charge = true;
             m_cable_watch_start = monotonic;
+            ResetSleepBackoff();   // deliberate user action — resume responsive cooldowns
         } else if (monotonic - m_v_env_awaketime->AsInt() > 300) {
             // Door watch expired (5 min in AWAKE, charge door never opened) → sleep
             ESP_LOGI(TAG, "Vehicle awake for over 300s with no activity — forcing sleep state");
@@ -292,6 +293,7 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
 void OvmsVehicleToyotaETNGA::TransitionToDrivingState()
 {
     m_armed_for_charge = false;
+    ResetSleepBackoff();   // real drive — resume responsive cooldowns
     SetPollState(PollState::DRIVING);
     m_v_pos_trip_start->SetStale(true);
     RequestVIN();
@@ -300,6 +302,7 @@ void OvmsVehicleToyotaETNGA::TransitionToDrivingState()
 void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
 {
     m_armed_for_charge = false;  // arm state consumed on entering handshake
+    ResetSleepBackoff();   // charge session beginning — resume responsive cooldowns
     m_charge_state_entry = StandardMetrics.ms_m_monotonic->AsInt();
     SetPollState(PollState::CHARGE_HANDSHAKE);
     SetChargingStatus(false);    // not yet delivering energy (AC/DC states set true)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -107,8 +107,11 @@ OvmsVehicleToyotaETNGA::OvmsVehicleToyotaETNGA()
     // Init CAN
     RegisterCanBus(2, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);
 
-    // Set polling state
-    TransitionToSleepState();
+    // Set polling state directly (not via TransitionToSleepState, which would arm a
+    // sleep cooldown and advance the backoff index — neither is wanted at boot).
+    m_armed_for_charge = false;
+    SetPollState(PollState::SLEEP);
+    SetAwake(false);
 
     // Set polling PID list
     PollSetPidList(m_can2, obdii_polls);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -50,6 +50,8 @@ protected:
 
     bool m_allow_wake = true;  // Used to implement a cooldown timer if the vehicle is put into sleep
     int m_sleep_entry_time = 0;  // Used to track the time that cooldown timer started
+    int m_sleep_cooldown_secs = 10;  // Cooldown window (s) that applied to the current sleep
+    int m_sleep_backoff_idx = 0;     // Index into SLEEP_COOLDOWN_SECS; escalates on consecutive no-activity sleeps
 
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
     int  m_cable_watch_start = 0;      // monotonic s when armed (15-min cable watch)
@@ -235,6 +237,8 @@ private:
     void TransitionToChargeWaitState();
     void TransitionToChargeAcState();
     void TransitionToChargeDcState();
+
+    void ResetSleepBackoff();   // reset cooldown escalation to the base step (real activity seen)
 
     void RequestVIN();
     void IncomingVINSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, CAN_frame_format_t format, const std::string &data);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -50,7 +50,7 @@ protected:
 
     bool m_allow_wake = true;  // Used to implement a cooldown timer if the vehicle is put into sleep
     int m_sleep_entry_time = 0;  // Used to track the time that cooldown timer started
-    int m_sleep_cooldown_secs = 10;  // Cooldown window (s) that applied to the current sleep
+    int m_sleep_cooldown_secs = 10;  // Cooldown window (s) for the current sleep; default must equal SLEEP_COOLDOWN_SECS[0]
     int m_sleep_backoff_idx = 0;     // Index into SLEEP_COOLDOWN_SECS; escalates on consecutive no-activity sleeps
 
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
@@ -230,6 +230,7 @@ private:
     void HandleChargeWaitState();
     void HandleChargeAcState();
     void HandleChargeDcState();
+    void ResetSleepBackoff();   // reset cooldown escalation to the base step (real activity seen)
     void TransitionToSleepState();
     void TransitionToAwakeState();
     void TransitionToDrivingState();
@@ -237,8 +238,6 @@ private:
     void TransitionToChargeWaitState();
     void TransitionToChargeAcState();
     void TransitionToChargeDcState();
-
-    void ResetSleepBackoff();   // reset cooldown escalation to the base step (real activity seen)
 
     void RequestVIN();
     void IncomingVINSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, CAN_frame_format_t format, const std::string &data);


### PR DESCRIPTION
## Summary
- **Adaptive sleep cooldown backoff** to cut the parked 12V duty cycle. On consecutive no-activity sleeps the cooldown escalates `10 → 30 → 60 → 120 → 300s` (capped). Cooldown arming is centralized in `TransitionToSleepState()`.
- **Resets to base (10s) on real activity:** entering DRIVING, entering a charge session, the charge door opening, and a 12V-rise wake. Bare CAN-frame wakes that only reach AWAKE do not reset — that's what lets the ramp build while parked.
- **12V-rise wake preserved as the responsive escape** (un-gated by the cooldown) and now also resets the backoff, so a real power-up resumes responsive listening even at the aggressive end.
- **Observability (#1):** forced-sleep watchdog reasons promoted `ESP_LOGD → ESP_LOGI`, plus a reason line on the natural `env_awake`-stale sleep, so info-level logs show *why* the module slept (used to validate the ramp).
- Design **spec** and implementation **plan** under `docs/superpowers/`.

Observed motivation: 2026-06-04 parked logs showed ~77% awake duty cycle from forced-sleep/CAN-wake cycling; this targets ~50% while keeping wake responsiveness via the 12V escape.

## Test Plan
- [ ] CI build passes (no host test suite — hardware project; tests run on-device)
- [ ] On-vehicle: confirm the ramp in logs — `Cooling off period ended (10s)` → `(30s)` → `(60s)` → `(120s)` → `(300s)`
- [ ] On-vehicle: a 12V-rise wake (`Aux 12V has exceeded the threshold`) resets the next cooldown to `(10s)`
- [ ] On-vehicle: a real drive and a charge plug-in each reset the next cooldown to `(10s)`
- [ ] (optional) compare `ms_v_bat_12v_voltage` across parked windows for actual sag improvement

## Notes
- `changes.txt` entry intentionally **deferred** — e-TNGA is not yet announced there.
- Solterra inherits this unchanged (thin subclass).