### PR TITLE
Toyota e-TNGA: HVAC power metric (driving + charging) + My-Room cabin energy

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -605,15 +605,15 @@ canonical order ``[FL, FR, RL, RR]`` (indices 0–3):
      - OVMS name
      - Unit
      - Meaning
-   * - ``v.tp.p``
+   * - ``v.t.pressure``
      - ``ms_v_tpms_pressure``
      - kPa
      - Tyre pressures
-   * - ``v.tp.t``
+   * - ``v.t.temp``
      - ``ms_v_tpms_temp``
      - °C
      - Tyre temperatures
-   * - ``v.tp.alert``
+   * - ``v.t.alert``
      - ``ms_v_tpms_alert``
      - enum
      - 0 = normal, 1 = warning, 2 = alert
@@ -711,5 +711,5 @@ Notes
   stationary for an extended period.
 * **No-sensor slots publish 0 and are excluded from alerts.** A slot whose
   pressure raw byte is 0 is treated as unpopulated; the corresponding
-  ``v.tp.p`` element is published as 0.0 and is skipped when evaluating
+  ``v.t.pressure`` element is published as 0.0 and is skipped when evaluating
   alert thresholds.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -453,10 +453,11 @@ Charge-report supporting channels
 ----------------------------------
 
 These four metrics feed the in-module charge report (work item D).
-``xte.v.c.myroom`` and ``xte.v.c.acpwr`` are polled only in the
-``CHARGE_AC`` and ``CHARGE_DC`` states; ``xte.v.c.outcome`` and
-``xte.v.c.stopreq`` are also polled in ``CHARGE_HANDSHAKE`` and
-``CHARGE_WAIT``.
+``xte.v.c.myroom`` is polled only in the ``CHARGE_AC`` and ``CHARGE_DC``
+states; ``xte.v.e.hvac.power`` is polled in those charge states (from the
+OBC, ``0x745``) **and** in ``DRIVING`` (from the hybrid control ECU,
+``0x7D2``); ``xte.v.c.outcome`` and ``xte.v.c.stopreq`` are also polled in
+``CHARGE_HANDSHAKE`` and ``CHARGE_WAIT``.
 
 .. list-table::
    :header-rows: 1
@@ -471,19 +472,24 @@ These four metrics feed the in-module charge report (work item D).
      - bool
      - My Room active — cabin run on grid power while plugged in or
        charging.  This is the only on-bus live My-Room signal.
-   * - ``xte.v.c.acpwr``
+   * - ``xte.v.e.hvac.power``
      - ``0x106E``
      - kW
-     - A/C consumption power (cabin / HVAC draw).  Decoded as
-       ``u8 × 0.05 kW/LSB`` at offset 0.  ``0x106E`` is a dedicated
-       cabin-power PID, so the My-Room cabin energy is the **direct
-       time-integral of this channel** (∫ acpwr dt over the
-       My-Room-active interval) — *not* an EVSE-to-cabin
-       (input − pack) split.  The old delta method was AC-only and
-       read 0 for DC (``0x161D`` charger-input is 0 during DC), so the
-       direct integral is used for both AC and DC (confirmed
-       2026-06-03; host ``charge_report_writer.py`` / ``analyze-myroom``
-       use the same direct integral).
+     - HVAC / cabin power draw.  Decoded as ``u8 × 0.05 kW/LSB`` at
+       offset 0.  Sourced from the OBC (``0x745``) while charging and from
+       the hybrid control ECU (``0x7D2``) while driving, so it tracks
+       cabin/HVAC power in both contexts.
+   * - ``xte.v.e.hvac.kwh``
+     - (derived)
+     - kWh
+     - My-Room cabin energy — the **direct time-integral of**
+       ``xte.v.e.hvac.power`` over the My-Room-active interval (reset at
+       charge start).  ``0x106E`` is a dedicated cabin-power PID, so this
+       is valid for both AC and DC — *not* an EVSE-to-cabin (input − pack)
+       split.  The old delta method was AC-only and read 0 for DC
+       (``0x161D`` charger-input is 0 during DC).  Confirmed 2026-06-03;
+       host ``charge_report_writer.py`` / ``analyze-myroom`` use the same
+       direct integral.
    * - ``xte.v.c.outcome``
      - ``0x1688``
      - enum

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -30,7 +30,8 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     m_v_charge_out_tgt   = MyMetrics.InitInt("xte.v.c.chgotgt", SM_STALE_MID);
     m_v_charge_ac_usable = MyMetrics.InitInt("xte.v.c.acusbl", SM_STALE_MID);
     m_v_charge_myroom  = MyMetrics.InitBool("xte.v.c.myroom", SM_STALE_MID);
-    m_v_charge_acpwr   = MyMetrics.InitFloat("xte.v.c.acpwr", SM_STALE_MID, 0.0f, kW);
+    m_v_env_hvac_power = MyMetrics.InitFloat("xte.v.e.hvac.power", SM_STALE_MID, 0.0f, kW);
+    m_v_env_hvac_kwh   = MyMetrics.InitFloat("xte.v.e.hvac.kwh",   SM_STALE_MID, 0.0f, kWh);
     m_v_charge_outcome = MyMetrics.InitInt("xte.v.c.outcome", SM_STALE_MID);
     m_v_charge_stopreq = MyMetrics.InitInt("xte.v.c.stopreq", SM_STALE_MID);
     m_v_bat_cap_full = MyMetrics.InitVector<float>("xte.v.b.cap.full", SM_STALE_HIGH, 0, AmpHours);  // 0x1D3E 8x per-module full-charge capacity (data collection)
@@ -272,7 +273,25 @@ float OvmsVehicleToyotaETNGA::CalculateAcConsumption(const std::string& data)
     // 1-indexed = offset 0.) Host charge_csv_writer.py / analyze-myroom decoders agree (b[0]).
     return static_cast<float>(GetRxBByte(data, 0)) * 0.05f;
 }
-void OvmsVehicleToyotaETNGA::SetAcConsumption(float kw) { m_v_charge_acpwr->SetValue(kw); }
+void OvmsVehicleToyotaETNGA::SetHvacPower(float kw)
+{
+    m_v_env_hvac_power->SetValue(kw);
+
+    // My-Room cabin energy: 0x106E is a dedicated cabin-power channel, so cabin energy is its
+    // direct time-integral over the My-Room-active interval — valid for both AC and DC (the old
+    // 0x161D charger-input delta read 0 during DC). Integrate ONLY while My Room is active; this
+    // same power metric is also polled while DRIVING (from 0x7D2), which must not feed cabin energy.
+    if (m_v_charge_myroom->AsBool()) {
+        uint32_t now = esp_log_timestamp();
+        float hours = 1.0f / 3600.0f;   // default 1 s for the first sample of the interval
+        if (lastHvacEnergyLogTime != 0)
+            hours = static_cast<float>((now - lastHvacEnergyLogTime) / (1000.0f * 60.0f * 60.0f));
+        m_v_env_hvac_kwh->SetValue(m_v_env_hvac_kwh->AsFloat() + kw * hours);
+        lastHvacEnergyLogTime = now;
+    } else {
+        lastHvacEnergyLogTime = 0;   // reset so the next My-Room interval starts fresh
+    }
+}
 
 int OvmsVehicleToyotaETNGA::CalculateChargeOutcome(const std::string& data)  { return GetRxBByte(data, 0); }  // 0x1688 26-state enum; RETAINED between sessions (does not reset on plug-in) — report must scope it per-session
 void OvmsVehicleToyotaETNGA::SetChargeOutcome(int v) { m_v_charge_outcome->SetValue(v); }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -140,6 +140,13 @@ void OvmsVehicleToyotaETNGA::IncomingHybridControlSystem(uint16_t pid)
             break;
         }
 
+        case PID_AC_CONSUMPTION: {
+            // HVAC power while driving — 0x106E from the hybrid control ECU (0x7D2); the OBC
+            // (0x745) only answers while charging. Same decode, routes to the unified metric.
+            SetHvacPower(CalculateAcConsumption(m_rxbuf));
+            break;
+        }
+
         // Add more cases for other PIDs if needed
 
         default:
@@ -274,7 +281,7 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
             break;
         }
         case PID_AC_CONSUMPTION: {
-            SetAcConsumption(CalculateAcConsumption(m_rxbuf));
+            SetHvacPower(CalculateAcConsumption(m_rxbuf));
             break;
         }
         case PID_CHARGE_HISTORY: {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -45,6 +45,7 @@ static const OvmsPoller::poll_pid_t obdii_polls[] = {
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_VEHICLE_SPEED,             { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F0D speed: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_SHIFT_POSITION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1061 gear: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_ODOMETER,                  { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1FA6 odometer: DRIVING only
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,            { 0,  0, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @5s
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE,       { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1002 ambient temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_CABIN_TEMPERATURE,         { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1001 cabin temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HVAC_SETPOINT,             { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1036 HVAC setpoint: DRIVING only
@@ -145,6 +146,9 @@ void OvmsVehicleToyotaETNGA::NotifyChargeStart()
 
     StandardMetrics.ms_v_charge_kwh_grid->SetValue(0);
     lastGridEnergyLogTime = 0;
+
+    m_v_env_hvac_kwh->SetValue(0);
+    lastHvacEnergyLogTime = 0;
     
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -84,7 +84,8 @@ protected:
     OvmsMetricInt*   m_v_charge_out_tgt;   // 0x161E b3-4 target-from-charger (raw, scale deferred)
     OvmsMetricInt*   m_v_charge_ac_usable; // 0x1665 useable power (raw, scale deferred)
     OvmsMetricBool*  m_v_charge_myroom;   // 0x1692 byte 2 (idx 1) bit 0 = My Room active
-    OvmsMetricFloat* m_v_charge_acpwr;    // 0x106E A/C consumption power (kW)
+    OvmsMetricFloat* m_v_env_hvac_power;  // 0x106E HVAC/cabin power draw (kW): OBC view (0x745) while charging, hybrid-control view (0x7D2) while driving
+    OvmsMetricFloat* m_v_env_hvac_kwh;    // My-Room cabin energy (kWh): time-integral of m_v_env_hvac_power over the My-Room-active interval
     OvmsMetricInt*   m_v_charge_outcome;  // 0x1688 charging history / outcome enum
     OvmsMetricInt*   m_v_charge_stopreq;  // 0x1667 charge seq stop request (enum, partial)
     OvmsMetricVector<float>* m_v_bat_cap_full;  // 0x1D3E 8x u16 x0.01 Ah — per-module full-charge capacity (data collection)
@@ -106,6 +107,7 @@ private:
     uint32_t lastBatteryEnergyLogTime;
     uint32_t lastChargerEnergyLogTime;
     uint32_t lastGridEnergyLogTime;
+    uint32_t lastHvacEnergyLogTime;
 
     void InitializeMetrics();  // Initializes the metrics specific to this vehicle module
     void ResetStaleMetrics();  // Checks if state transition metrics are stale (and resets them)
@@ -213,7 +215,7 @@ private:
     void SetChargerOutputTargetRaw(int v);
     void SetAcUsableRaw(int v);
     void SetMyRoom(bool active);
-    void SetAcConsumption(float kw);
+    void SetHvacPower(float kw);
     void SetChargeOutcome(int v);
     void SetChargeStopReq(int v);
 


### PR DESCRIPTION
## Summary
- **Rename** `xte.v.c.acpwr` → **`xte.v.e.hvac.power`** (kW) — `0x106E` is a general climate-power signal, not a charge metric.
- **Driving coverage:** poll `0x106E` from the **Hybrid Control ECU (`0x7D2`) in DRIVING** (the OBC at `0x745` only answers while charging), so HVAC power now populates on the road as well as while plugged in. Both sources route through `SetHvacPower()`.
- **New `xte.v.e.hvac.kwh`** (kWh) — My-Room cabin energy = **direct time-integral of the HVAC power** over the `xte.v.c.myroom`-active interval; valid for both AC and DC (the old `0x161D` charger-input delta read 0 during DC). Reset at charge start. Grid energy (`v.c.kwh.grid`) is left untouched — no overlap with the charger-input integrator.
- **TPMS doc fix** (separate commit): the metric-name table used `v.tp.p`/`v.tp.t`/`v.tp.alert`, which aren't real metrics — corrected to `v.t.pressure`/`v.t.temp`/`v.t.alert` (the actual `ms_v_tpms_*` vector metrics).

Solterra inherits all of this unchanged.

## Commits
- `etnga docs: correct TPMS metric names (v.t.pressure/temp/alert, not v.tp.*)`
- `etnga: HVAC power metric (driving + charging) + My-Room cabin energy`

## Test Plan
- [ ] CI build passes (no host test suite — hardware project)
- [ ] On-vehicle: `0x7D2` answers `0x106E` while driving → `v.e.hvac.power` populates on the road
- [ ] On-vehicle: a real **My-Room** session accumulates `v.e.hvac.kwh` (and it resets at charge start); does **not** accumulate while merely driving
- [ ] Spot-check `v.e.hvac.power` during AC and DC charging still tracks (via OBC `0x745`)

## Notes
- This PR bundles two logical changes (HVAC feature + TPMS doc fix). The commits are cleanly separated and can be split into two PRs if preferred.
- `changes.txt` entry deferred (e-TNGA not yet announced there).