### PR TITLE
Toyota e-TNGA: fix ABRP is_dcfc (wire v.c.mode) + remove dead charge-mode path

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -186,11 +186,6 @@ bool OvmsVehicleToyotaETNGA::CalculateChargingDoorStatus(const std::string& data
     return GetRxBBit(data, 1, 1);
 }
 
-int OvmsVehicleToyotaETNGA::CalculateChargeMode(const std::string& data)
-{
-    return GetRxBInt8(data, 0);
-}
-
 int OvmsVehicleToyotaETNGA::CalculateAcOpStatus(const std::string& data) { return GetRxBInt8(data, 0); }
 void OvmsVehicleToyotaETNGA::SetAcOpStatus(int v) { m_v_charge_ac_op->SetValue(v); }
 int OvmsVehicleToyotaETNGA::CalculateHlcState(const std::string& data) { return GetRxBByte(data, 0); }
@@ -550,13 +545,6 @@ void OvmsVehicleToyotaETNGA::SetBatteryVoltage(float voltage)
 {
     LogMetricChange(StandardMetrics.ms_v_bat_voltage, voltage, "Voltage", "V");
     StandardMetrics.ms_v_bat_voltage->SetValue(voltage);
-}
-
-void OvmsVehicleToyotaETNGA::SetChargeMode(int chargeMode)
-{
-    const std::string chargeModeValue = (chargeMode == 0x00) ? "Standard" : "Performance";
-    LogMetricChange(StandardMetrics.ms_v_charge_mode, chargeModeValue, "Charge Mode");
-    StandardMetrics.ms_v_charge_mode->SetValue(chargeModeValue);
 }
 
 void OvmsVehicleToyotaETNGA::SetChargingStatus(bool status)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -168,12 +168,6 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
             break;
         }
 
-        case PID_CHARGING_CONTROL_STATUS: {
-            int chargeMode = CalculateChargeMode(m_rxbuf);
-            SetChargeMode(chargeMode);
-            break;
-        }
-
         case PID_CONTROL_SYSTEM_MODE: {
             int controlMode = CalculateControlMode(m_rxbuf);
             SetControlMode(controlMode);
@@ -208,7 +202,7 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
 
         case PID_CHARGER_INPUT_POWER: {
             // Only valid during AC charging
-            if (StandardMetrics.ms_v_charge_inprogress->AsBool() && std::string(StandardMetrics.ms_v_charge_mode->AsString()) == "Standard") {
+            if (m_poll_state == PollState::CHARGE_AC) {
                 float chargerInputPower = CalculateChargerInputPower(m_rxbuf);
                 SetChargerInputPower(chargerInputPower);
             }
@@ -415,47 +409,6 @@ void OvmsVehicleToyotaETNGA::DiagnosticSession()
     else
     {
         ESP_LOGW(TAG, "DiagnosticSession: Failed with error code %d", res);
-    }
-}
-
-void OvmsVehicleToyotaETNGA::RequestChargeMode()
-{
-    std::string response;
-    int chargeMode;
-    int maxRetries = 5;
-    int retryCount = 0;
-    int res = POLLSINGLE_TIMEOUT;  // non-OK sentinel so the retry loop runs at least once
-
-    while (retryCount < maxRetries && res != POLLSINGLE_OK)
-    {
-        res = PollSingleRequest(
-            m_can2,
-            PLUG_IN_CONTROL_SYSTEM_TX,
-            PLUG_IN_CONTROL_SYSTEM_RX,
-            VEHICLE_POLL_TYPE_READDATA,
-            PID_CHARGING_CONTROL_STATUS,
-            response,
-            1000,
-            ISOTP_STD
-        );
-
-        if (res == POLLSINGLE_OK)
-        {
-            // Request successful
-            chargeMode = response[0] & 0xFF;
-            SetChargeMode(chargeMode);
-            break;
-        }
-        else
-        {
-            retryCount++;
-            ESP_LOGW(TAG, "RequestChargeMode: Request failed with error code %d. Retrying (%d/%d)", res, retryCount, maxRetries);
-        }
-    }
-
-    if (res != POLLSINGLE_OK)
-    {
-        ESP_LOGE(TAG, "RequestChargeMode: Maximum retries reached. Request failed with error code %d", res);
     }
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -279,11 +279,13 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
     // AC/DC normally exit via CHARGE_WAIT; this branch is a safety net for any future direct AC/DC->AWAKE path.
     if (oldState == PollState::CHARGE_AC || oldState == PollState::CHARGE_DC) {
         StandardMetrics.ms_v_charge_state->SetValue("done");
+        StandardMetrics.ms_v_charge_mode->SetValue("");   // clear AC/DC indicator on session end
         if (m_charge_session.in_session)
             ESP_LOGI(TAG, "Charge session closed");
         m_charge_session = ChargeSessionState{};   // reset (clears in_session)
     } else if (oldState == PollState::CHARGE_HANDSHAKE || oldState == PollState::CHARGE_WAIT) {
         StandardMetrics.ms_v_charge_state->SetValue("");
+        StandardMetrics.ms_v_charge_mode->SetValue("");
         if (m_charge_session.in_session)
             ESP_LOGI(TAG, "Charge session closed");
         m_charge_session = ChargeSessionState{};   // reset (clears in_session)
@@ -330,6 +332,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeAcState()
     SetPollState(PollState::CHARGE_AC);
     SetChargingStatus(true);
     SetChargeState(PollState::CHARGE_AC);
+    StandardMetrics.ms_v_charge_mode->SetValue("standard");      // AC charging (OVMS-standard v.c.mode)
 }
 
 void OvmsVehicleToyotaETNGA::TransitionToChargeDcState()
@@ -338,4 +341,5 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeDcState()
     SetPollState(PollState::CHARGE_DC);
     SetChargingStatus(true);
     SetChargeState(PollState::CHARGE_DC);
+    StandardMetrics.ms_v_charge_mode->SetValue("performance");   // DC fast charge -> ABRP is_dcfc (v.c.mode == "performance")
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -51,7 +51,6 @@ static const OvmsPoller::poll_pid_t obdii_polls[] = {
 
     // Charging polls — state-machine DIDs
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,   { 0,  0, 0,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F46: not polled by sim in any charge state; 0 until confirmed useful
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_CONTROL_STATUS,  { 0,  0, 0,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1668: sim uses 0x1684 (PID_AC_CHARGING_OP_STATUS); 0x1668 not in sim charge lists
   { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_PISW_STATUS,              { 0,  5, 0,  1, 30, 10, 10}, 0, ISOTP_STD }, // 0x1669 PISW: AWAKE=5 (Task 5); HS=1,WAIT=30,AC=10,DC=10 (sim)
   { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_VOLTAGE_TYPE,    { 0,  0, 0,  5,  0,  0,  0}, 0, ISOTP_STD }, // 0x161C VTYPE: HS=5s only (sim: HANDSHAKE=5, absent elsewhere)
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -134,7 +134,6 @@ private:
     float CalculateBatteryVoltage(const std::string& data);
     float CalculateCabinTemperature(const std::string& data);
     int CalculateAcOpStatus(const std::string& data);
-    int CalculateChargeMode(const std::string& data);
     int CalculateChargeType(const std::string& data);
     int CalculateHlcState(const std::string& data);
     int CalculatePISWRaw(const std::string& data);
@@ -182,7 +181,6 @@ private:
     void SetBatteryTemperatureStatistics(const std::vector<float>& temperatures);
     void SetBatteryVoltage(float voltage);
     void SetCabinTemperature(float temperature);
-    void SetChargeMode(int chargeMode);
     void SetChargeType(int chargeType);
     void SetChargeState(PollState state);
     void SetChargerInputPower(float power);
@@ -242,7 +240,6 @@ private:
     void RequestVIN();
     void IncomingVINSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, CAN_frame_format_t format, const std::string &data);
     void IncomingVINFail(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, int errorcode);
-    void RequestChargeMode();
     void RequestChargeType();
     void DiagnosticSession();
     
@@ -287,7 +284,6 @@ enum CANPID
     PID_CHARGER_INPUT_POWER = 0x161D,
     PID_CONTROL_SYSTEM_MODE = 0x10D1,
     PID_CHARGING_CONTROL_INFORMATION = 0x1689,
-    PID_CHARGING_CONTROL_STATUS = 0x1668,
     PID_CHARGING_LID = 0x1625,
     PID_CHARGING_VOLTAGE_TYPE = 0x161C,
     PID_HVAC_SETPOINT = 0x1036,


### PR DESCRIPTION
## Summary
ABRP derives `is_dcfc` from `v.c.mode == 'performance'`, but e-TNGA **never wrote `v.c.mode`** — `PID_CHARGING_CONTROL_STATUS` (`0x1668`) had an all-zero poll row and `RequestChargeMode()` had no caller, so `SetChargeMode()` never ran. So `is_dcfc` was always false, and the AC grid-power gate (keyed on `v.c.mode == "Standard"`) never fired either.

- Drive `v.c.mode` from the AC/DC poll states (the state machine already distinguishes them via the HLC handshake): `"performance"` on `CHARGE_DC` (→ ABRP `is_dcfc`), `"standard"` on `CHARGE_AC`, cleared on session end.
- Re-gate the AC charger-input-power handler on the `CHARGE_AC` poll state instead of the dead `v.c.mode == "Standard"` string.
- Remove the now-dead `0x1668` poll row + handler, `CalculateChargeMode`, `SetChargeMode`, `RequestChargeMode`, and the enum.

Solterra inherits unchanged. DC path still needs confirmation on a real DCFC session (CHARGE_DC entry is the only unvalidated link).

## Test Plan
- [ ] CI build
- [ ] On-vehicle: a real DC fast charge sets `v.c.mode = performance` → ABRP `is_dcfc` flips true; AC charge sets `standard`