### PR TITLE
Toyota e-TNGA: easy-win standard metrics + trip/lifetime/HVAC accumulators

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -17,8 +17,13 @@ Open Vehicle Monitor System v3 - Change log
     Within `Ticker3600`, a routine removes all timestamps older than 24 hours and updates `xsq.12v.trickle.count` by -1.
     New metric:
       xsq.12v.trickle.count             -- Count of 12V trickle-charge cycles in 24h
-
-2026-05-17 MB   3.3.006  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): populate more standard metrics that were
+    previously unset — climate flags v.e.cooling / v.e.heating, fan speed v.e.cabinfan,
+    consumption v.b.consumption, and the trip/lifetime accumulators v.b.coulomb.used/.recd
+    (+ .total), v.b.energy.used.total / .recd.total, and v.c.kwh.grid.total. The driving HVAC
+    poll (0x106E) now runs at 1 Hz so the cabin-energy integral matches the battery integrator.
+    New metric:
+      xte.v.e.hvac.kwh.drive            -- Cabin/HVAC energy used during the current trip (kWh)
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,
     charge time counters AC/DC and parked battery state times (by SOC & temperature ranges)
     (inspired by OBD Amigos)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -32,6 +32,7 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     m_v_charge_myroom  = MyMetrics.InitBool("xte.v.c.myroom", SM_STALE_MID);
     m_v_env_hvac_power = MyMetrics.InitFloat("xte.v.e.hvac.power", SM_STALE_MID, 0.0f, kW);
     m_v_env_hvac_kwh   = MyMetrics.InitFloat("xte.v.e.hvac.kwh",   SM_STALE_MID, 0.0f, kWh);
+    m_v_env_hvac_kwh_drive = MyMetrics.InitFloat("xte.v.e.hvac.kwh.drive", SM_STALE_MID, 0.0f, kWh);  // Per-trip driving cabin/HVAC energy
     m_v_charge_outcome = MyMetrics.InitInt("xte.v.c.outcome", SM_STALE_MID);
     m_v_charge_stopreq = MyMetrics.InitInt("xte.v.c.stopreq", SM_STALE_MID);
     m_v_bat_cap_full = MyMetrics.InitVector<float>("xte.v.b.cap.full", SM_STALE_HIGH, 0, AmpHours);  // 0x1D3E 8x per-module full-charge capacity (data collection)
@@ -286,6 +287,22 @@ void OvmsVehicleToyotaETNGA::SetHvacPower(float kw)
     } else {
         lastHvacEnergyLogTime = 0;   // reset so the next My-Room interval starts fresh
     }
+
+    // A/C cooling active: 0x106E is the dedicated A/C consumption channel, so any draw => cooling on.
+    StandardMetrics.ms_v_env_cooling->SetValue(kw > 0.0f);
+
+    // Driving cabin/HVAC energy: per-trip time-integral of this power while DRIVING (reset in
+    // NotifyVehicleOn). My-Room (charging) energy above and this are exclusive — different poll states.
+    if (static_cast<PollState>(m_poll_state) == PollState::DRIVING) {
+        uint32_t now = esp_log_timestamp();
+        float hours = 1.0f / 3600.0f;   // default 1 s for the first sample of the interval
+        if (lastHvacDriveEnergyLogTime != 0)
+            hours = static_cast<float>((now - lastHvacDriveEnergyLogTime) / (1000.0f * 60.0f * 60.0f));
+        m_v_env_hvac_kwh_drive->SetValue(m_v_env_hvac_kwh_drive->AsFloat() + kw * hours);
+        lastHvacDriveEnergyLogTime = now;
+    } else {
+        lastHvacDriveEnergyLogTime = 0;   // reset so the next driving interval starts fresh
+    }
 }
 
 int OvmsVehicleToyotaETNGA::CalculateChargeOutcome(const std::string& data)  { return GetRxBByte(data, 0); }  // 0x1688 26-state enum; RETAINED between sessions (does not reset on plug-in) — report must scope it per-session
@@ -421,18 +438,35 @@ void OvmsVehicleToyotaETNGA::SetBatteryPower(float power)
 
     ESP_LOGD(TAG, "Battery Energy: %f kWh", energy);
 
-    // Only log energy use/recovery while driving
+    // Coulomb count (Ah) over the same interval. Current shares the power sign (+ = discharge);
+    // ms_v_bat_current was just set from the same 0x1F9A reply (see IncomingHybridControlSystem).
+    const float charge = StandardMetrics.ms_v_bat_current->AsFloat() * hoursSinceLastUpdate;
+
+    // Only log energy/coulomb use/recovery while driving. The per-trip metrics reset in
+    // NotifyVehicleOn; the *_total accumulators are persistent (lifetime) and never reset here.
     if (static_cast<PollState>(m_poll_state) == PollState::DRIVING)
     {
         if (power > 0)
         {
             StandardMetrics.ms_v_bat_energy_used->SetValue(
                 StandardMetrics.ms_v_bat_energy_used->AsFloat() + energy);
+            StandardMetrics.ms_v_bat_energy_used_total->SetValue(
+                StandardMetrics.ms_v_bat_energy_used_total->AsFloat() + energy);
+            StandardMetrics.ms_v_bat_coulomb_used->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_used->AsFloat() + charge);
+            StandardMetrics.ms_v_bat_coulomb_used_total->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_used_total->AsFloat() + charge);
         }
         else if (power < 0)
         {
             StandardMetrics.ms_v_bat_energy_recd->SetValue(
                 StandardMetrics.ms_v_bat_energy_recd->AsFloat() - energy);
+            StandardMetrics.ms_v_bat_energy_recd_total->SetValue(
+                StandardMetrics.ms_v_bat_energy_recd_total->AsFloat() - energy);
+            StandardMetrics.ms_v_bat_coulomb_recd->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_recd->AsFloat() - charge);
+            StandardMetrics.ms_v_bat_coulomb_recd_total->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_recd_total->AsFloat() - charge);
         }
     }
 
@@ -647,6 +681,7 @@ void OvmsVehicleToyotaETNGA::SetChargerInputPower(float power)
     ESP_LOGD(TAG, "Grid Energy: %f kWh", energy);
 
     StandardMetrics.ms_v_charge_kwh_grid->SetValue(StandardMetrics.ms_v_charge_kwh_grid->AsFloat() + energy);
+    StandardMetrics.ms_v_charge_kwh_grid_total->SetValue(StandardMetrics.ms_v_charge_kwh_grid_total->AsFloat() + energy);  // persistent lifetime grid energy
 
     // Update the update time for the next energy period
     lastGridEnergyLogTime = now;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -82,6 +82,19 @@ void OvmsVehicleToyotaETNGA::IncomingAirConditionerSystem(uint16_t pid)
             break;
         }
 
+        case PID_HEATER_POWER: {
+            // 0x1086 HV electric heater power (W, 2-byte cluster, split TBD): any draw => heating active.
+            StandardMetrics.ms_v_env_heating->SetValue(GetRxBUint16(m_rxbuf, 0) > 0);
+            break;
+        }
+
+        case PID_BLOWER_LEVEL: {
+            // 0x2801 blower level (u8 1-7) -> cabin fan percentage (standard metric unit is %).
+            int level = GetRxBByte(m_rxbuf, 0);
+            StandardMetrics.ms_v_env_cabinfan->SetValue(level * 100 / 7);
+            break;
+        }
+
         // Add more cases for other PIDs if needed
 
         default:

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -45,10 +45,12 @@ static const OvmsPoller::poll_pid_t obdii_polls[] = {
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_VEHICLE_SPEED,             { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F0D speed: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_SHIFT_POSITION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1061 gear: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_ODOMETER,                  { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1FA6 odometer: DRIVING only
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,            { 0,  0, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @5s
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @1s (matches battery V/I for the cabin-energy integrator)
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE,       { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1002 ambient temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_CABIN_TEMPERATURE,         { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1001 cabin temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HVAC_SETPOINT,             { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1036 HVAC setpoint: DRIVING only
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HEATER_POWER,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1086 HV heater power: DRIVING only (>0 => v.e.heating)
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_BLOWER_LEVEL,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x2801 blower level 1-7: DRIVING only (=> v.e.cabinfan %)
 
     // Charging polls — state-machine DIDs
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,   { 0,  0, 0,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F46: not polled by sim in any charge state; 0 until confirmed useful
@@ -126,10 +128,15 @@ OvmsVehicleToyotaETNGA::~OvmsVehicleToyotaETNGA()
 void OvmsVehicleToyotaETNGA::NotifyVehicleOn()
 {
     ESP_LOGV(TAG, "Notification of vehicle on - Reset energy metrics for trip reporting");
-    // Vehicle started. Reset the trip statistics
+    // Vehicle started. Reset the trip statistics (per-trip metrics only; *_total are lifetime)
     StandardMetrics.ms_v_bat_energy_used->SetValue(0);
     StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
+    StandardMetrics.ms_v_bat_coulomb_used->SetValue(0);
+    StandardMetrics.ms_v_bat_coulomb_recd->SetValue(0);
     lastBatteryEnergyLogTime = 0;
+
+    m_v_env_hvac_kwh_drive->SetValue(0);
+    lastHvacDriveEnergyLogTime = 0;
 }
 
 void OvmsVehicleToyotaETNGA::NotifyChargeStart()
@@ -171,6 +178,16 @@ void OvmsVehicleToyotaETNGA::Ticker1(uint32_t ticker)
 
     //ESP_LOGI(TAG, "Entering Ticker1: %d", ticker);
     ResetStaleMetrics();
+
+    // Trip-average consumption (Wh/km) while driving — derived from net trip energy / distance.
+    if (static_cast<PollState>(m_poll_state) == PollState::DRIVING) {
+        float trip = StandardMetrics.ms_v_pos_trip->AsFloat();
+        if (trip > 0.1f) {
+            float net_wh = (StandardMetrics.ms_v_bat_energy_used->AsFloat()
+                          - StandardMetrics.ms_v_bat_energy_recd->AsFloat()) * 1000.0f;
+            StandardMetrics.ms_v_bat_consumption->SetValue(net_wh / trip);
+        }
+    }
 
     switch (static_cast<PollState>(m_poll_state)) {
         case PollState::SLEEP:

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -86,6 +86,7 @@ protected:
     OvmsMetricBool*  m_v_charge_myroom;   // 0x1692 byte 2 (idx 1) bit 0 = My Room active
     OvmsMetricFloat* m_v_env_hvac_power;  // 0x106E HVAC/cabin power draw (kW): OBC view (0x745) while charging, hybrid-control view (0x7D2) while driving
     OvmsMetricFloat* m_v_env_hvac_kwh;    // My-Room cabin energy (kWh): time-integral of m_v_env_hvac_power over the My-Room-active interval
+    OvmsMetricFloat* m_v_env_hvac_kwh_drive;  // Driving cabin/HVAC energy (kWh): per-trip time-integral of m_v_env_hvac_power while DRIVING (reset in NotifyVehicleOn)
     OvmsMetricInt*   m_v_charge_outcome;  // 0x1688 charging history / outcome enum
     OvmsMetricInt*   m_v_charge_stopreq;  // 0x1667 charge seq stop request (enum, partial)
     OvmsMetricVector<float>* m_v_bat_cap_full;  // 0x1D3E 8x u16 x0.01 Ah — per-module full-charge capacity (data collection)
@@ -108,6 +109,7 @@ private:
     uint32_t lastChargerEnergyLogTime;
     uint32_t lastGridEnergyLogTime;
     uint32_t lastHvacEnergyLogTime;
+    uint32_t lastHvacDriveEnergyLogTime;
 
     void InitializeMetrics();  // Initializes the metrics specific to this vehicle module
     void ResetStaleMetrics();  // Checks if state transition metrics are stale (and resets them)
@@ -289,6 +291,8 @@ enum CANPID
     PID_CHARGING_LID = 0x1625,
     PID_CHARGING_VOLTAGE_TYPE = 0x161C,
     PID_HVAC_SETPOINT = 0x1036,
+    PID_HEATER_POWER = 0x1086,            // HV electric heater power (W, 2-byte cluster, split TBD); >0 => v.e.heating
+    PID_BLOWER_LEVEL = 0x2801,            // Blower level (u8 1-7) => v.e.cabinfan %
     PID_ODOMETER = 0x1FA6,
     PID_PISW_STATUS = 0x1669,
     PID_READY_SIGNAL = 0x1076,


### PR DESCRIPTION
Implements #84.

**Standard metrics newly populated** (previously unset; apps/server/web UI pick these up automatically):
- `v.e.cooling` / `v.e.heating` (bool) — from `0x106E` A/C power and `0x1086` heater power
- `v.e.cabinfan` (%) — from `0x2801` blower level (1–7 → %)
- `v.b.consumption` (Wh/km) — trip-average from net energy / trip distance
- `v.b.coulomb.used`/`.recd` + `.total`, `v.b.energy.used.total`/`.recd.total` — integrated alongside the existing battery energy integrator (per-trip reset; `*_total` are framework-persistent)
- `v.c.kwh.grid.total` — accumulated with the per-session grid energy

**New custom metric:**
- `xte.v.e.hvac.kwh.drive` — per-trip driving cabin/HVAC energy (integral of `xte.v.e.hvac.power` while DRIVING, reset in `NotifyVehicleOn`). The existing `xte.v.e.hvac.kwh` stays charging/My-Room-scoped.

**Poll list:** DRIVING `0x106E` bumped 5s → 1s so the cabin-energy integral matches the 1s battery V/I integrator; added `0x1086` + `0x2801` on the HVAC ECU (DRIVING@10s).

**Deferred:** `v.b.cac` — `0x1D3E`/`0x1D3F` semantics unconfirmed, held out deliberately.

**Notes / for on-vehicle validation:**
- `v.e.heating` is a coarse boolean (`0x1086` u16 > 0) pending the documented byte-split confirmation — confirm it tracks the cabin heater on/off.
- `v.e.cooling` derives from the A/C-consumption channel; confirm it doesn't false-true during heater-only operation.
- coulomb/energy/grid totals are persistent — confirm they accumulate and survive reboot; `xte.v.e.hvac.kwh.drive` accrues over a drive with climate on and resets next trip.

Compile gate via this PR's CI. Not built locally (no ESP-IDF in the dev env).