### PR TITLE
[TEST BUILD — do not merge] e-TNGA combined: web UI + report browser + metrics + charge report

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -17,6 +17,11 @@ Open Vehicle Monitor System v3 - Change log
     Within `Ticker3600`, a routine removes all timestamps older than 24 hours and updates `xsq.12v.trickle.count` by -1.
     New metric:
       xsq.12v.trickle.count             -- Count of 12V trickle-charge cycles in 24h
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): at the end of each charging session the module
+    now writes a self-contained HTML charge report to /store/charge-reports/<timestamp>.html
+    (SOC delta, energy delivered + from grid, peak/avg power, battery-temp range, AC/DC, outcome).
+    The newest 50 reports are kept. This first version covers single-phase, live-telemetry
+    sessions; multi-phase, sleep-survival and limiting-side attribution are planned follow-ups.
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -17,8 +17,13 @@ Open Vehicle Monitor System v3 - Change log
     Within `Ticker3600`, a routine removes all timestamps older than 24 hours and updates `xsq.12v.trickle.count` by -1.
     New metric:
       xsq.12v.trickle.count             -- Count of 12V trickle-charge cycles in 24h
-
-2026-05-17 MB   3.3.006  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): populate more standard metrics that were
+    previously unset — climate flags v.e.cooling / v.e.heating, fan speed v.e.cabinfan,
+    consumption v.b.consumption, and the trip/lifetime accumulators v.b.coulomb.used/.recd
+    (+ .total), v.b.energy.used.total / .recd.total, and v.c.kwh.grid.total. The driving HVAC
+    poll (0x106E) now runs at 1 Hz so the cabin-energy integral matches the battery integrator.
+    New metric:
+      xte.v.e.hvac.kwh.drive            -- Cabin/HVAC energy used during the current trip (kWh)
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,
     charge time counters AC/DC and parked battery state times (by SOC & temperature ranges)
     (inspired by OBD Amigos)

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -17,6 +17,9 @@ Open Vehicle Monitor System v3 - Change log
     Within `Ticker3600`, a routine removes all timestamps older than 24 hours and updates `xsq.12v.trickle.count` by -1.
     New metric:
       xsq.12v.trickle.count             -- Count of 12V trickle-charge cycles in 24h
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): added web UI pages in the Vehicle menu —
+    BMS cell monitor, a live charging-metrics dashboard, and a configuration page that exposes
+    the TPMS alert thresholds (previously settable only via the `config` command).
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -18,8 +18,9 @@ Open Vehicle Monitor System v3 - Change log
     New metric:
       xsq.12v.trickle.count             -- Count of 12V trickle-charge cycles in 24h
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): added web UI pages in the Vehicle menu —
-    BMS cell monitor, a live charging-metrics dashboard, and a configuration page that exposes
-    the TPMS alert thresholds (previously settable only via the `config` command).
+    BMS cell monitor, a live charging-metrics dashboard, a configuration page that exposes
+    the TPMS alert thresholds (previously settable only via the `config` command), and a
+    charge-reports browser that lists and opens the stored /store/charge-reports/ HTML reports.
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -1,0 +1,175 @@
+/*
+   Project:       Open Vehicle Monitor System
+   Module:        Vehicle Toyota e-TNGA platform — charge session report
+   Date:          5th June 2026
+
+   (C) 2026       Jerry Kezar <solterra@kezarnet.com>
+
+   Licensed under the MIT License. See the LICENSE file for details.
+
+   Writes a self-contained HTML report to /store/charge-reports/ at the end of each
+   charging session (plug-in to unplug). This is the first increment: a single-phase,
+   live-telemetry summary. Multi-phase tracking, sleep-survival / summary-mode,
+   limiting-side attribution, the per-sample timeline and the error DID-dump
+   (see solterra-can docs/charging_state_machine_architecture.md §6) are follow-ups.
+*/
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdio.h>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+#include "ovms_log.h"
+#include "metrics_standard.h"
+#include "vehicle_toyota_etnga.h"
+
+#define CHARGE_REPORT_DIR  "/store/charge-reports"
+static const int CHARGE_REPORT_MAX = 50;   // retain at most this many reports
+
+// Live aggregation while charging: peak power, battery-temp range, and the current phase type.
+// Called every tick from HandleChargeAcState / HandleChargeDcState.
+void OvmsVehicleToyotaETNGA::UpdateChargeSessionStats()
+{
+    if (!m_charge_session.in_session)
+        return;
+
+    float p = StandardMetrics.ms_v_charge_power->AsFloat();
+    if (p > m_charge_session.peak_power)
+        m_charge_session.peak_power = p;
+
+    float t = StandardMetrics.ms_v_bat_temp->AsFloat();
+    if (!m_charge_session.temp_seen) {
+        m_charge_session.temp_min = m_charge_session.temp_max = t;
+        m_charge_session.temp_seen = true;
+    } else if (t < m_charge_session.temp_min) {
+        m_charge_session.temp_min = t;
+    } else if (t > m_charge_session.temp_max) {
+        m_charge_session.temp_max = t;
+    }
+
+    m_charge_session.is_dc = (static_cast<PollState>(m_poll_state) == PollState::CHARGE_DC);
+}
+
+// Retain only the newest CHARGE_REPORT_MAX .html reports (timestamp filenames sort chronologically).
+static void PruneChargeReports(const char* tag)
+{
+    DIR* dir = opendir(CHARGE_REPORT_DIR);
+    if (!dir)
+        return;
+
+    std::vector<std::string> files;
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != NULL) {
+        std::string name = ent->d_name;
+        if (name.size() > 5 && name.compare(name.size() - 5, 5, ".html") == 0)
+            files.push_back(name);
+    }
+    closedir(dir);
+
+    if ((int) files.size() <= CHARGE_REPORT_MAX)
+        return;
+
+    std::sort(files.begin(), files.end());
+    int to_delete = (int) files.size() - CHARGE_REPORT_MAX;
+    for (int i = 0; i < to_delete; i++) {
+        std::string path = std::string(CHARGE_REPORT_DIR "/") + files[i];
+        if (unlink(path.c_str()) == 0)
+            ESP_LOGD(tag, "Charge report pruned: %s", files[i].c_str());
+    }
+}
+
+// Write the session-end report. No-op if no meaningful energy was delivered (plug-in then unplug).
+void OvmsVehicleToyotaETNGA::GenerateChargeReport()
+{
+    const float energy_kwh = StandardMetrics.ms_v_charge_kwh->AsFloat();
+    if (energy_kwh < 0.05f) {
+        ESP_LOGD(TAG, "Charge report skipped: only %.3f kWh delivered", energy_kwh);
+        return;
+    }
+
+    const float grid_kwh  = StandardMetrics.ms_v_charge_kwh_grid->AsFloat();
+    const int   end_soc   = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+    const int   start_soc = m_charge_session.start_soc;
+    int duration_s = StandardMetrics.ms_m_monotonic->AsInt() - m_charge_session.start_monotonic;
+    if (duration_s < 0)
+        duration_s = 0;
+    const float avg_kw  = (duration_s > 0) ? energy_kwh / (duration_s / 3600.0f) : 0.0f;
+    const int   outcome = m_v_charge_outcome->AsInt();
+
+    // Time formatting (UTC). start_utc is 0 / tiny if the clock was never synced.
+    const bool time_ok = (m_charge_session.start_utc > 1000000000);   // ~2001 sanity floor
+    char start_buf[40] = "(clock not synced)";
+    char end_buf[40]   = "(clock not synced)";
+    char fname[80];
+    if (time_ok) {
+        time_t st = (time_t) m_charge_session.start_utc;
+        time_t et = st + duration_s;
+        struct tm tmv;
+        gmtime_r(&st, &tmv); strftime(start_buf, sizeof(start_buf), "%Y-%m-%d %H:%M:%S UTC", &tmv);
+        gmtime_r(&et, &tmv); strftime(end_buf,   sizeof(end_buf),   "%Y-%m-%d %H:%M:%S UTC", &tmv);
+        gmtime_r(&st, &tmv); strftime(fname, sizeof(fname), CHARGE_REPORT_DIR "/%Y%m%dT%H%M%SZ.html", &tmv);
+    } else {
+        snprintf(fname, sizeof(fname), CHARGE_REPORT_DIR "/charge-%d.html", m_charge_session.start_monotonic);
+    }
+
+    const int dh = duration_s / 3600, dm = (duration_s % 3600) / 60, ds = duration_s % 60;
+
+    mkdir(CHARGE_REPORT_DIR, 0755);   // ensure the directory exists (ignores EEXIST)
+
+    std::ofstream f(fname, std::ios::out | std::ios::trunc);
+    if (!f) {
+        ESP_LOGE(TAG, "Charge report: cannot write %s", fname);
+        return;
+    }
+
+    char buf[64];
+    f << "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\n"
+      << "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+      << "<title>Charge report " << start_buf << "</title>\n"
+      << "<style>body{font:14px/1.4 system-ui,sans-serif;margin:1rem;max-width:42rem}"
+      << "h1{font-size:1.3rem}dl{display:grid;grid-template-columns:max-content 1fr;gap:.2rem .8rem}"
+      << "dt{font-weight:600}.note{color:#888;font-size:12px;margin-top:1.2rem}</style></head><body>\n"
+      << "<h1>Charging session report</h1>\n<dl>\n"
+      << "<dt>Plug-in</dt><dd>" << start_buf << "</dd>\n"
+      << "<dt>Unplug</dt><dd>"  << end_buf   << "</dd>\n";
+
+    snprintf(buf, sizeof(buf), "%dh %02dm %02ds", dh, dm, ds);
+    f << "<dt>Duration</dt><dd>" << buf << "</dd>\n"
+      << "<dt>Type</dt><dd>" << (m_charge_session.is_dc ? "DC fast" : "AC") << "</dd>\n";
+
+    snprintf(buf, sizeof(buf), "%d%% &rarr; %d%% (+%d%%)", start_soc, end_soc,
+             (start_soc >= 0 ? end_soc - start_soc : 0));
+    f << "<dt>SOC</dt><dd>" << buf << "</dd>\n";
+
+    snprintf(buf, sizeof(buf), "%.2f kWh", energy_kwh);
+    f << "<dt>Energy delivered</dt><dd>" << buf << "</dd>\n";
+    snprintf(buf, sizeof(buf), "%.2f kWh", grid_kwh);
+    f << "<dt>Energy from grid</dt><dd>" << buf << "</dd>\n";
+    snprintf(buf, sizeof(buf), "%.1f kW peak / %.2f kW avg", m_charge_session.peak_power, avg_kw);
+    f << "<dt>Power</dt><dd>" << buf << "</dd>\n";
+
+    if (m_charge_session.temp_seen) {
+        snprintf(buf, sizeof(buf), "%.0f&deg;C &rarr; %.0f&deg;C",
+                 m_charge_session.temp_min, m_charge_session.temp_max);
+        f << "<dt>Battery temp</dt><dd>" << buf << "</dd>\n";
+    }
+
+    snprintf(buf, sizeof(buf), "0x%02X", outcome & 0xFF);
+    f << "<dt>Outcome (0x1688)</dt><dd>" << buf << "</dd>\n</dl>\n";
+
+    f << "<p class=\"note\">Generated on-module by OVMS (Toyota e-TNGA). Single-phase summary; "
+         "average power is over the whole plug-in interval. Multi-phase, sleep-survival, "
+         "limiting-side attribution and the per-sample timeline are not yet included.</p>\n"
+         "</body></html>\n";
+    f.close();
+
+    ESP_LOGI(TAG, "Charge report written: %s (%.2f kWh, %d%%->%d%%)", fname, energy_kwh, start_soc, end_soc);
+
+    PruneChargeReports(TAG);
+}

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -32,6 +32,7 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     m_v_charge_myroom  = MyMetrics.InitBool("xte.v.c.myroom", SM_STALE_MID);
     m_v_env_hvac_power = MyMetrics.InitFloat("xte.v.e.hvac.power", SM_STALE_MID, 0.0f, kW);
     m_v_env_hvac_kwh   = MyMetrics.InitFloat("xte.v.e.hvac.kwh",   SM_STALE_MID, 0.0f, kWh);
+    m_v_env_hvac_kwh_drive = MyMetrics.InitFloat("xte.v.e.hvac.kwh.drive", SM_STALE_MID, 0.0f, kWh);  // Per-trip driving cabin/HVAC energy
     m_v_charge_outcome = MyMetrics.InitInt("xte.v.c.outcome", SM_STALE_MID);
     m_v_charge_stopreq = MyMetrics.InitInt("xte.v.c.stopreq", SM_STALE_MID);
     m_v_bat_cap_full = MyMetrics.InitVector<float>("xte.v.b.cap.full", SM_STALE_HIGH, 0, AmpHours);  // 0x1D3E 8x per-module full-charge capacity (data collection)
@@ -286,6 +287,22 @@ void OvmsVehicleToyotaETNGA::SetHvacPower(float kw)
     } else {
         lastHvacEnergyLogTime = 0;   // reset so the next My-Room interval starts fresh
     }
+
+    // A/C cooling active: 0x106E is the dedicated A/C consumption channel, so any draw => cooling on.
+    StandardMetrics.ms_v_env_cooling->SetValue(kw > 0.0f);
+
+    // Driving cabin/HVAC energy: per-trip time-integral of this power while DRIVING (reset in
+    // NotifyVehicleOn). My-Room (charging) energy above and this are exclusive — different poll states.
+    if (static_cast<PollState>(m_poll_state) == PollState::DRIVING) {
+        uint32_t now = esp_log_timestamp();
+        float hours = 1.0f / 3600.0f;   // default 1 s for the first sample of the interval
+        if (lastHvacDriveEnergyLogTime != 0)
+            hours = static_cast<float>((now - lastHvacDriveEnergyLogTime) / (1000.0f * 60.0f * 60.0f));
+        m_v_env_hvac_kwh_drive->SetValue(m_v_env_hvac_kwh_drive->AsFloat() + kw * hours);
+        lastHvacDriveEnergyLogTime = now;
+    } else {
+        lastHvacDriveEnergyLogTime = 0;   // reset so the next driving interval starts fresh
+    }
 }
 
 int OvmsVehicleToyotaETNGA::CalculateChargeOutcome(const std::string& data)  { return GetRxBByte(data, 0); }  // 0x1688 26-state enum; RETAINED between sessions (does not reset on plug-in) — report must scope it per-session
@@ -421,18 +438,35 @@ void OvmsVehicleToyotaETNGA::SetBatteryPower(float power)
 
     ESP_LOGD(TAG, "Battery Energy: %f kWh", energy);
 
-    // Only log energy use/recovery while driving
+    // Coulomb count (Ah) over the same interval. Current shares the power sign (+ = discharge);
+    // ms_v_bat_current was just set from the same 0x1F9A reply (see IncomingHybridControlSystem).
+    const float charge = StandardMetrics.ms_v_bat_current->AsFloat() * hoursSinceLastUpdate;
+
+    // Only log energy/coulomb use/recovery while driving. The per-trip metrics reset in
+    // NotifyVehicleOn; the *_total accumulators are persistent (lifetime) and never reset here.
     if (static_cast<PollState>(m_poll_state) == PollState::DRIVING)
     {
         if (power > 0)
         {
             StandardMetrics.ms_v_bat_energy_used->SetValue(
                 StandardMetrics.ms_v_bat_energy_used->AsFloat() + energy);
+            StandardMetrics.ms_v_bat_energy_used_total->SetValue(
+                StandardMetrics.ms_v_bat_energy_used_total->AsFloat() + energy);
+            StandardMetrics.ms_v_bat_coulomb_used->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_used->AsFloat() + charge);
+            StandardMetrics.ms_v_bat_coulomb_used_total->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_used_total->AsFloat() + charge);
         }
         else if (power < 0)
         {
             StandardMetrics.ms_v_bat_energy_recd->SetValue(
                 StandardMetrics.ms_v_bat_energy_recd->AsFloat() - energy);
+            StandardMetrics.ms_v_bat_energy_recd_total->SetValue(
+                StandardMetrics.ms_v_bat_energy_recd_total->AsFloat() - energy);
+            StandardMetrics.ms_v_bat_coulomb_recd->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_recd->AsFloat() - charge);
+            StandardMetrics.ms_v_bat_coulomb_recd_total->SetValue(
+                StandardMetrics.ms_v_bat_coulomb_recd_total->AsFloat() - charge);
         }
     }
 
@@ -647,6 +681,7 @@ void OvmsVehicleToyotaETNGA::SetChargerInputPower(float power)
     ESP_LOGD(TAG, "Grid Energy: %f kWh", energy);
 
     StandardMetrics.ms_v_charge_kwh_grid->SetValue(StandardMetrics.ms_v_charge_kwh_grid->AsFloat() + energy);
+    StandardMetrics.ms_v_charge_kwh_grid_total->SetValue(StandardMetrics.ms_v_charge_kwh_grid_total->AsFloat() + energy);  // persistent lifetime grid energy
 
     // Update the update time for the next energy period
     lastGridEnergyLogTime = now;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -82,6 +82,19 @@ void OvmsVehicleToyotaETNGA::IncomingAirConditionerSystem(uint16_t pid)
             break;
         }
 
+        case PID_HEATER_POWER: {
+            // 0x1086 HV electric heater power (W, 2-byte cluster, split TBD): any draw => heating active.
+            StandardMetrics.ms_v_env_heating->SetValue(GetRxBUint16(m_rxbuf, 0) > 0);
+            break;
+        }
+
+        case PID_BLOWER_LEVEL: {
+            // 0x2801 blower level (u8 1-7) -> cabin fan percentage (standard metric unit is %).
+            int level = GetRxBByte(m_rxbuf, 0);
+            StandardMetrics.ms_v_env_cabinfan->SetValue(level * 100 / 7);
+            break;
+        }
+
         // Add more cases for other PIDs if needed
 
         default:

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -207,6 +207,8 @@ void OvmsVehicleToyotaETNGA::HandleChargeAcState()
     // timeouts — only an explicit fresh PISW=Unconnected (0x00) read or a clean phase-end
     // (ac_op==0x00) terminates the session.  On unlock the OBC answers again and these
     // handlers resume normally.  Do not add timeout-based session teardown here.
+    UpdateChargeSessionStats();   // aggregate peak power / temp range / type for the session report
+
     int pisw = m_v_charge_pisw_raw->AsInt();
     int ac_op = m_v_charge_ac_op->AsInt();
 
@@ -228,6 +230,8 @@ void OvmsVehicleToyotaETNGA::HandleChargeDcState()
     // in_session do NOT tear down the session.  Only an explicit fresh PISW=Unconnected
     // (0x00) read or hlc==0xFF (HLC Unconnected) terminates the DC phase.  On unlock the
     // OBC answers again and polling resumes.  Do not add timeout-based session teardown here.
+    UpdateChargeSessionStats();   // aggregate peak power / temp range / type for the session report
+
     int pisw = m_v_charge_pisw_raw->AsInt();
     int hlc = m_v_charge_hlc->AsInt();
 
@@ -280,14 +284,18 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
     if (oldState == PollState::CHARGE_AC || oldState == PollState::CHARGE_DC) {
         StandardMetrics.ms_v_charge_state->SetValue("done");
         StandardMetrics.ms_v_charge_mode->SetValue("");   // clear AC/DC indicator on session end
-        if (m_charge_session.in_session)
+        if (m_charge_session.in_session) {
             ESP_LOGI(TAG, "Charge session closed");
+            GenerateChargeReport();   // write the session-end HTML report (no-op if no energy delivered)
+        }
         m_charge_session = ChargeSessionState{};   // reset (clears in_session)
     } else if (oldState == PollState::CHARGE_HANDSHAKE || oldState == PollState::CHARGE_WAIT) {
         StandardMetrics.ms_v_charge_state->SetValue("");
         StandardMetrics.ms_v_charge_mode->SetValue("");
-        if (m_charge_session.in_session)
+        if (m_charge_session.in_session) {
             ESP_LOGI(TAG, "Charge session closed");
+            GenerateChargeReport();   // write the session-end HTML report (no-op if no energy delivered)
+        }
         m_charge_session = ChargeSessionState{};   // reset (clears in_session)
     }
 }
@@ -312,6 +320,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
     if (!m_charge_session.in_session) {
         m_charge_session.in_session = true;
         m_charge_session.start_monotonic = StandardMetrics.ms_m_monotonic->AsInt();
+        m_charge_session.start_utc = StandardMetrics.ms_m_timeutc->AsInt();
         m_charge_session.start_soc = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
         ESP_LOGI(TAG, "Charge session opened (SOC %d%%)", m_charge_session.start_soc);
     }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -1,0 +1,170 @@
+/*
+   Project:       Open Vehicle Monitor System
+   Module:        Vehicle Toyota e-TNGA platform — web UI
+   Date:          5th June 2026
+
+   (C) 2026       Jerry Kezar <solterra@kezarnet.com>
+
+   Licensed under the MIT License. See the LICENSE file for details.
+*/
+
+#include <sdkconfig.h>
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+
+#include "ovms_config.h"
+#include "ovms_metrics.h"
+#include "ovms_webserver.h"
+#include "metrics_standard.h"
+
+#include "vehicle_toyota_etnga.h"
+
+// WebInit: register the e-TNGA pages in the vehicle menu.
+// Shared by all e-TNGA vehicles (Subaru Solterra, Toyota bZ4X).
+void OvmsVehicleToyotaETNGA::WebInit()
+{
+    MyWebServer.RegisterPage("/bms/cellmon", "BMS cell monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/xte/charge", "Charging metrics", WebDispChgMetrics, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/xte/config", "Configuration", WebCfgFeatures, PageMenu_Vehicle, PageAuth_Cookie);
+}
+
+void OvmsVehicleToyotaETNGA::WebDeInit()
+{
+    MyWebServer.DeregisterPage("/bms/cellmon");
+    MyWebServer.DeregisterPage("/xte/charge");
+    MyWebServer.DeregisterPage("/xte/config");
+}
+
+// WebCfgFeatures: configure the e-TNGA TPMS alert thresholds (config namespace "xte").
+// These are otherwise only settable from the shell `config` command.
+void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
+{
+    std::string error;
+    char buf[32];
+
+    if (c.method == "POST") {
+        float p_warn  = atof(c.getvar("tpms_p_warn").c_str());
+        float p_alert = atof(c.getvar("tpms_p_alert").c_str());
+        float t_warn  = atof(c.getvar("tpms_t_warn").c_str());
+        float t_alert = atof(c.getvar("tpms_t_alert").c_str());
+
+        // Validate: pressures positive; alert at/below warn (low pressure is worse),
+        // temperature alert at/above warn (high temperature is worse).
+        if (p_warn <= 0 || p_alert <= 0)
+            error += "<li>Tyre pressure thresholds must be greater than zero.</li>";
+        if (p_alert > p_warn)
+            error += "<li>Pressure alert should be at or below the warning threshold (lower pressure is worse).</li>";
+        if (t_alert < t_warn)
+            error += "<li>Temperature alert should be at or above the warning threshold (higher temperature is worse).</li>";
+
+        if (error == "") {
+            MyConfig.SetParamValueFloat("xte", "tpms.pressure.warn",  p_warn);
+            MyConfig.SetParamValueFloat("xte", "tpms.pressure.alert", p_alert);
+            MyConfig.SetParamValueFloat("xte", "tpms.temp.warn",      t_warn);
+            MyConfig.SetParamValueFloat("xte", "tpms.temp.alert",     t_alert);
+
+            c.head(200);
+            c.alert("success", "<p class=\"lead\">Toyota e-TNGA configuration saved.</p>");
+        } else {
+            error = "<p class=\"lead\">Error:</p><ul class=\"errorlist\">" + error + "</ul>";
+            c.head(400);
+            c.alert("danger", error.c_str());
+        }
+    } else {
+        c.head(200);
+    }
+
+    // Read current config (defaults mirror etnga_tpms.cpp):
+    float p_warn  = MyConfig.GetParamValueFloat("xte", "tpms.pressure.warn",  240.0f);
+    float p_alert = MyConfig.GetParamValueFloat("xte", "tpms.pressure.alert", 220.0f);
+    float t_warn  = MyConfig.GetParamValueFloat("xte", "tpms.temp.warn",       90.0f);
+    float t_alert = MyConfig.GetParamValueFloat("xte", "tpms.temp.alert",     100.0f);
+
+    c.panel_start("primary", "Toyota e-TNGA configuration");
+    c.form_start(p.uri);
+
+    c.fieldset_start("TPMS alert thresholds");
+
+    snprintf(buf, sizeof(buf), "%.0f", p_warn);
+    c.input("number", "Pressure warning", "tpms_p_warn", buf, "Default: 240",
+        "<p>Warn when a tyre drops to this pressure.</p>", "min=\"0\" step=\"1\"", "kPa");
+    snprintf(buf, sizeof(buf), "%.0f", p_alert);
+    c.input("number", "Pressure alert", "tpms_p_alert", buf, "Default: 220",
+        "<p>Alert when a tyre drops to this pressure (at or below the warning level).</p>", "min=\"0\" step=\"1\"", "kPa");
+    snprintf(buf, sizeof(buf), "%.0f", t_warn);
+    c.input("number", "Temperature warning", "tpms_t_warn", buf, "Default: 90",
+        "<p>Warn when a tyre reaches this temperature.</p>", "step=\"1\"", "&deg;C");
+    snprintf(buf, sizeof(buf), "%.0f", t_alert);
+    c.input("number", "Temperature alert", "tpms_t_alert", buf, "Default: 100",
+        "<p>Alert when a tyre reaches this temperature (at or above the warning level).</p>", "step=\"1\"", "&deg;C");
+
+    c.fieldset_end();
+
+    c.print("<hr>");
+    c.input_button("default", "Save");
+    c.form_end();
+    c.panel_end();
+    c.done();
+}
+
+// WebDispChgMetrics: live charging dashboard. Values auto-update via the
+// framework's data-metric mechanism (script.js polls /api/status).
+void OvmsVehicleToyotaETNGA::WebDispChgMetrics(PageEntry_t& p, PageContext_t& c)
+{
+    c.head(200);
+    PAGE_HOOK("body.pre");
+
+    c.print(
+        "<style>\n"
+        "h6.metric-head { margin-bottom: 0; color: #676767; font-size: 15px; }\n"
+        ".night h6.metric-head { color: unset; }\n"
+        "</style>\n"
+        "<div class=\"panel panel-primary\">"
+          "<div class=\"panel-heading\">Toyota e-TNGA charging metrics</div>"
+          "<div class=\"panel-body\">"
+            "<div class=\"receiver\">"
+
+              "<div class=\"clearfix\">"
+                "<div class=\"metric progress\" data-metric=\"v.b.soc\" data-prec=\"1\">"
+                  "<div class=\"progress-bar value-low text-left\" role=\"progressbar\" aria-valuenow=\"0\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width:0%\">"
+                    "<div><span class=\"label\">SoC</span><span class=\"value\">?</span><span class=\"unit\">%</span></div>"
+                  "</div>"
+                "</div>"
+              "</div>"
+
+              "<div class=\"clearfix\">"
+                "<h6 class=\"metric-head\">Battery</h6>"
+                "<div class=\"metric number\" data-metric=\"v.b.power\" data-prec=\"3\"><span class=\"label\">Power</span><span class=\"value\">?</span><span class=\"unit\">kW</span></div>"
+                "<div class=\"metric number\" data-metric=\"v.b.voltage\" data-prec=\"1\"><span class=\"label\">Voltage</span><span class=\"value\">?</span><span class=\"unit\">V</span></div>"
+                "<div class=\"metric number\" data-metric=\"v.b.current\" data-prec=\"1\"><span class=\"label\">Current</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
+                "<div class=\"metric number\" data-metric=\"v.b.temp\" data-prec=\"1\"><span class=\"label\">Temp</span><span class=\"value\">?</span><span class=\"unit\">&deg;C</span></div>"
+              "</div>"
+
+              "<div class=\"clearfix\">"
+                "<h6 class=\"metric-head\">Charger</h6>"
+                "<div class=\"metric text\" data-metric=\"v.c.state\"><span class=\"label\">State</span><span class=\"value\">?</span></div>"
+                "<div class=\"metric text\" data-metric=\"v.c.type\"><span class=\"label\">Type</span><span class=\"value\">?</span></div>"
+                "<div class=\"metric number\" data-metric=\"v.c.power\" data-prec=\"3\"><span class=\"label\">Power</span><span class=\"value\">?</span><span class=\"unit\">kW</span></div>"
+                "<div class=\"metric number\" data-metric=\"v.c.voltage\" data-prec=\"1\"><span class=\"label\">Voltage</span><span class=\"value\">?</span><span class=\"unit\">V</span></div>"
+                "<div class=\"metric number\" data-metric=\"v.c.current\" data-prec=\"1\"><span class=\"label\">Current</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
+              "</div>"
+
+              "<div class=\"clearfix\">"
+                "<h6 class=\"metric-head\">Session energy</h6>"
+                "<div class=\"metric number\" data-metric=\"v.c.kwh\" data-prec=\"2\"><span class=\"label\">Charged</span><span class=\"value\">?</span><span class=\"unit\">kWh</span></div>"
+                "<div class=\"metric number\" data-metric=\"v.c.kwh.grid\" data-prec=\"2\"><span class=\"label\">From grid</span><span class=\"value\">?</span><span class=\"unit\">kWh</span></div>"
+                "<div class=\"metric number\" data-metric=\"xte.v.e.hvac.kwh\" data-prec=\"3\"><span class=\"label\">Cabin (My Room)</span><span class=\"value\">?</span><span class=\"unit\">kWh</span></div>"
+              "</div>"
+
+            "</div>"
+          "</div>"
+        "</div>");
+
+    PAGE_HOOK("body.post");
+    c.done();
+}
+
+#endif // CONFIG_OVMS_COMP_WEBSERVER

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -13,14 +13,20 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <dirent.h>
 #include <string>
+#include <vector>
+#include <algorithm>
 
 #include "ovms_config.h"
 #include "ovms_metrics.h"
 #include "ovms_webserver.h"
+#include "ovms_utils.h"
 #include "metrics_standard.h"
 
 #include "vehicle_toyota_etnga.h"
+
+#define CHARGE_REPORT_DIR "/store/charge-reports"
 
 // WebInit: register the e-TNGA pages in the vehicle menu.
 // Shared by all e-TNGA vehicles (Subaru Solterra, Toyota bZ4X).
@@ -28,6 +34,8 @@ void OvmsVehicleToyotaETNGA::WebInit()
 {
     MyWebServer.RegisterPage("/bms/cellmon", "BMS cell monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
     MyWebServer.RegisterPage("/xte/charge", "Charging metrics", WebDispChgMetrics, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/xte/reports", "Charge reports", WebChargeReports, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/xte/report", "Charge report", WebChargeReport, PageMenu_None, PageAuth_Cookie);
     MyWebServer.RegisterPage("/xte/config", "Configuration", WebCfgFeatures, PageMenu_Vehicle, PageAuth_Cookie);
 }
 
@@ -35,6 +43,8 @@ void OvmsVehicleToyotaETNGA::WebDeInit()
 {
     MyWebServer.DeregisterPage("/bms/cellmon");
     MyWebServer.DeregisterPage("/xte/charge");
+    MyWebServer.DeregisterPage("/xte/reports");
+    MyWebServer.DeregisterPage("/xte/report");
     MyWebServer.DeregisterPage("/xte/config");
 }
 
@@ -164,6 +174,72 @@ void OvmsVehicleToyotaETNGA::WebDispChgMetrics(PageEntry_t& p, PageContext_t& c)
         "</div>");
 
     PAGE_HOOK("body.post");
+    c.done();
+}
+
+// WebChargeReports: index of saved charge-session reports (newest first).
+// Each entry links to WebChargeReport, which streams the stored HTML file.
+void OvmsVehicleToyotaETNGA::WebChargeReports(PageEntry_t& p, PageContext_t& c)
+{
+    c.head(200);
+    c.panel_start("primary", "Charge session reports");
+
+    std::vector<std::string> files;
+    DIR* dir = opendir(CHARGE_REPORT_DIR);
+    if (dir) {
+        struct dirent* ent;
+        while ((ent = readdir(dir)) != NULL) {
+            std::string name = ent->d_name;
+            if (name.size() > 5 && name.compare(name.size() - 5, 5, ".html") == 0)
+                files.push_back(name);
+        }
+        closedir(dir);
+    }
+
+    if (files.empty()) {
+        c.print("<p>No charge reports yet. A report is written at the end of each charging session.</p>");
+    } else {
+        std::sort(files.rbegin(), files.rend());   // newest first (timestamp filenames sort chronologically)
+        c.print("<ul class=\"list-unstyled\">");
+        for (size_t i = 0; i < files.size(); i++) {
+            std::string enc = c.encode_html(files[i]);
+            c.printf("<li><a href=\"/xte/report?file=%s\" target=\"_blank\">%s</a></li>", enc.c_str(), enc.c_str());
+        }
+        c.print("</ul>");
+    }
+
+    c.panel_end();
+    c.done();
+}
+
+// WebChargeReport: stream one saved report as raw HTML (no page chrome), via ?file=<name>.
+void OvmsVehicleToyotaETNGA::WebChargeReport(PageEntry_t& p, PageContext_t& c)
+{
+    std::string file = c.getvar("file");
+
+    // Validate: a .html basename only — reject path traversal (no '/', no "..").
+    bool valid = (file.size() > 5 && file.compare(file.size() - 5, 5, ".html") == 0
+                  && file.find('/') == std::string::npos
+                  && file.find("..") == std::string::npos);
+    if (!valid) {
+        c.head(400, "Content-Type: text/plain; charset=utf-8");
+        c.print("Invalid report name\n");
+        c.done();
+        return;
+    }
+
+    extram::string content;
+    std::string path = std::string(CHARGE_REPORT_DIR "/") + file;
+    if (load_file(path, content) != 0) {
+        c.head(404, "Content-Type: text/plain; charset=utf-8");
+        c.print("Report not found\n");
+        c.done();
+        return;
+    }
+
+    // Stream the stored document verbatim (it is already a complete, self-contained HTML page).
+    c.head(200, "Content-Type: text/html; charset=utf-8\r\nCache-Control: no-cache");
+    c.print(content);
     c.done();
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -116,11 +116,18 @@ OvmsVehicleToyotaETNGA::OvmsVehicleToyotaETNGA()
     // Set polling PID list
     PollSetPidList(m_can2, obdii_polls);
     PollSetThrottling(0);
+
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+    WebInit();
+#endif
 }
 
 OvmsVehicleToyotaETNGA::~OvmsVehicleToyotaETNGA()
 {
     ESP_LOGI(TAG, "Shutdown Toyota eTNGA platform module");
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+    WebDeInit();
+#endif
 }
 
 void OvmsVehicleToyotaETNGA::NotifyVehicleOn()

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -45,10 +45,12 @@ static const OvmsPoller::poll_pid_t obdii_polls[] = {
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_VEHICLE_SPEED,             { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F0D speed: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_SHIFT_POSITION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1061 gear: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_ODOMETER,                  { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1FA6 odometer: DRIVING only
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,            { 0,  0, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @5s
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @1s (matches battery V/I for the cabin-energy integrator)
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE,       { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1002 ambient temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_CABIN_TEMPERATURE,         { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1001 cabin temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HVAC_SETPOINT,             { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1036 HVAC setpoint: DRIVING only
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HEATER_POWER,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1086 HV heater power: DRIVING only (>0 => v.e.heating)
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_BLOWER_LEVEL,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x2801 blower level 1-7: DRIVING only (=> v.e.cabinfan %)
 
     // Charging polls — state-machine DIDs
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,   { 0,  0, 0,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F46: not polled by sim in any charge state; 0 until confirmed useful
@@ -126,10 +128,15 @@ OvmsVehicleToyotaETNGA::~OvmsVehicleToyotaETNGA()
 void OvmsVehicleToyotaETNGA::NotifyVehicleOn()
 {
     ESP_LOGV(TAG, "Notification of vehicle on - Reset energy metrics for trip reporting");
-    // Vehicle started. Reset the trip statistics
+    // Vehicle started. Reset the trip statistics (per-trip metrics only; *_total are lifetime)
     StandardMetrics.ms_v_bat_energy_used->SetValue(0);
     StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
+    StandardMetrics.ms_v_bat_coulomb_used->SetValue(0);
+    StandardMetrics.ms_v_bat_coulomb_recd->SetValue(0);
     lastBatteryEnergyLogTime = 0;
+
+    m_v_env_hvac_kwh_drive->SetValue(0);
+    lastHvacDriveEnergyLogTime = 0;
 }
 
 void OvmsVehicleToyotaETNGA::NotifyChargeStart()
@@ -171,6 +178,16 @@ void OvmsVehicleToyotaETNGA::Ticker1(uint32_t ticker)
 
     //ESP_LOGI(TAG, "Entering Ticker1: %d", ticker);
     ResetStaleMetrics();
+
+    // Trip-average consumption (Wh/km) while driving — derived from net trip energy / distance.
+    if (static_cast<PollState>(m_poll_state) == PollState::DRIVING) {
+        float trip = StandardMetrics.ms_v_pos_trip->AsFloat();
+        if (trip > 0.1f) {
+            float net_wh = (StandardMetrics.ms_v_bat_energy_used->AsFloat()
+                          - StandardMetrics.ms_v_bat_energy_recd->AsFloat()) * 1000.0f;
+            StandardMetrics.ms_v_bat_consumption->SetValue(net_wh / trip);
+        }
+    }
 
     switch (static_cast<PollState>(m_poll_state)) {
         case PollState::SLEEP:

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -86,6 +86,7 @@ protected:
     OvmsMetricBool*  m_v_charge_myroom;   // 0x1692 byte 2 (idx 1) bit 0 = My Room active
     OvmsMetricFloat* m_v_env_hvac_power;  // 0x106E HVAC/cabin power draw (kW): OBC view (0x745) while charging, hybrid-control view (0x7D2) while driving
     OvmsMetricFloat* m_v_env_hvac_kwh;    // My-Room cabin energy (kWh): time-integral of m_v_env_hvac_power over the My-Room-active interval
+    OvmsMetricFloat* m_v_env_hvac_kwh_drive;  // Driving cabin/HVAC energy (kWh): per-trip time-integral of m_v_env_hvac_power while DRIVING (reset in NotifyVehicleOn)
     OvmsMetricInt*   m_v_charge_outcome;  // 0x1688 charging history / outcome enum
     OvmsMetricInt*   m_v_charge_stopreq;  // 0x1667 charge seq stop request (enum, partial)
     OvmsMetricVector<float>* m_v_bat_cap_full;  // 0x1D3E 8x u16 x0.01 Ah — per-module full-charge capacity (data collection)
@@ -108,6 +109,7 @@ private:
     uint32_t lastChargerEnergyLogTime;
     uint32_t lastGridEnergyLogTime;
     uint32_t lastHvacEnergyLogTime;
+    uint32_t lastHvacDriveEnergyLogTime;
 
     void InitializeMetrics();  // Initializes the metrics specific to this vehicle module
     void ResetStaleMetrics();  // Checks if state transition metrics are stale (and resets them)
@@ -289,6 +291,8 @@ enum CANPID
     PID_CHARGING_LID = 0x1625,
     PID_CHARGING_VOLTAGE_TYPE = 0x161C,
     PID_HVAC_SETPOINT = 0x1036,
+    PID_HEATER_POWER = 0x1086,            // HV electric heater power (W, 2-byte cluster, split TBD); >0 => v.e.heating
+    PID_BLOWER_LEVEL = 0x2801,            // Blower level (u8 1-7) => v.e.cabinfan %
     PID_ODOMETER = 0x1FA6,
     PID_PISW_STATUS = 0x1669,
     PID_READY_SIGNAL = 0x1076,

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -58,9 +58,15 @@ protected:
     int  m_charge_state_entry = 0;     // monotonic s of last charge-state entry (handshake 60s timer)
 
     struct ChargeSessionState {
-        bool in_session = false;
-        int  start_monotonic = 0;
-        int  start_soc = -1;
+        bool  in_session = false;
+        int   start_monotonic = 0;
+        int   start_soc = -1;
+        int   start_utc = 0;          // wallclock (epoch s) at session open — report timestamp/filename
+        bool  is_dc = false;          // last observed charge phase type (DC fast vs AC)
+        float peak_power = 0.0f;      // max charge power seen (kW)
+        bool  temp_seen = false;      // whether temp_min/max have been initialised
+        float temp_min = 0.0f;        // battery temperature range over the session (degC)
+        float temp_max = 0.0f;
     };
     ChargeSessionState m_charge_session;
 
@@ -111,6 +117,10 @@ private:
 
     void InitializeMetrics();  // Initializes the metrics specific to this vehicle module
     void ResetStaleMetrics();  // Checks if state transition metrics are stale (and resets them)
+
+    // Charge session report (etnga_charge_report.cpp)
+    void UpdateChargeSessionStats();   // live aggregation while charging (peak power, temp range, type)
+    void GenerateChargeReport();       // write the session-end HTML report to /store/charge-reports/
 
     // Incoming message handling functions
     void IncomingAirConditionerSystem(uint16_t pid);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -13,6 +13,9 @@
 
 #include <string>
 #include "vehicle.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+#include "ovms_webserver.h"
+#endif
 
 // Control states
 enum ControlState {
@@ -44,6 +47,14 @@ public:
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
 
     void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+    // Webserver subsystem (implementation: etnga_web.cpp)
+    void WebInit();
+    void WebDeInit();
+    static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
+    static void WebDispChgMetrics(PageEntry_t& p, PageContext_t& c);
+#endif // CONFIG_OVMS_COMP_WEBSERVER
 
 protected:
     std::string m_rxbuf;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -54,6 +54,8 @@ public:
     void WebDeInit();
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     static void WebDispChgMetrics(PageEntry_t& p, PageContext_t& c);
+    static void WebChargeReports(PageEntry_t& p, PageContext_t& c);   // index of saved charge reports
+    static void WebChargeReport(PageEntry_t& p, PageContext_t& c);    // stream one report (raw HTML)
 #endif // CONFIG_OVMS_COMP_WEBSERVER
 
 protected:


### PR DESCRIPTION
**Integration build for on-vehicle testing — NOT for merge.**

Combines the four CI-green e-TNGA branches so they can be flashed and validated together:
- #83 web UI (BMS / charge dashboard / config)
- #88 web charge-report browser (`/xte/reports` + viewer)
- #85 easy-win standard metrics + trip/lifetime/HVAC accumulators
- #86 charge session report (HTML) v1

Merge was clean except `changes.txt` (kept all entries). Purpose of this PR is solely to trigger the CI firmware build and produce the `ovms3-firmware` artifact (incl. `ovms3.bin`) for flashing via `ota flash http`. The individual PRs remain the ones to review/merge.

On-vehicle checklists live on #83, #85, #86, #88.