### PR TITLE
Toyota e-TNGA: dynamic per-vehicle web page titles

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -301,16 +301,19 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     std::ofstream f(m_charge_session.base + ".html", std::ios::out | std::ios::trunc);
     if (!f) { ESP_LOGE(TAG, "Charge report: cannot write %s.html", m_charge_session.base.c_str()); return; }
 
+    const char* vn = MyVehicleFactory.ActiveVehicleName();
+    std::string vname = (vn && *vn) ? vn : "Toyota e-TNGA";
+
     char b[96];
     f << "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\n"
       << "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
-      << "<title>Charge report " << sbuf << "</title>\n"
+      << "<title>" << vname << " charge report " << sbuf << "</title>\n"
       << "<style>body{font:14px/1.4 system-ui,sans-serif;margin:1rem;max-width:46rem}"
       << "h1{font-size:1.3rem}h2{font-size:1.05rem;margin-top:1.3rem}"
       << "dl{display:grid;grid-template-columns:max-content 1fr;gap:.2rem .8rem}dt{font-weight:600}"
       << "table{border-collapse:collapse}td,th{border:1px solid #ddd;padding:.15rem .4rem;font-size:13px}"
       << ".est{color:#555}.note{color:#888;font-size:12px;margin-top:1.2rem}</style></head><body>\n"
-      << "<h1>Charging session report</h1>\n";
+      << "<h1>" << vname << " — charging session report</h1>\n";
 
     f << "<h2>Summary</h2>\n<dl>\n"
       << "<dt>Plug-in</dt><dd>" << sbuf << "</dd>\n<dt>Unplug</dt><dd>" << ebuf << "</dd>\n";

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -39,6 +39,14 @@ static std::string etnga_report_dir()
     return "/store/charge-reports";
 }
 
+// Friendly name of the active vehicle ("Subaru Solterra" / "Toyota bZ4X") for page titles;
+// falls back to the platform name if unavailable.
+static std::string etnga_vehicle_name()
+{
+    const char* n = MyVehicleFactory.ActiveVehicleName();
+    return (n && *n) ? std::string(n) : std::string("Toyota e-TNGA");
+}
+
 // WebInit: register the e-TNGA pages in the vehicle menu.
 // Shared by all e-TNGA vehicles (Subaru Solterra, Toyota bZ4X).
 void OvmsVehicleToyotaETNGA::WebInit()
@@ -88,7 +96,8 @@ void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
             MyConfig.SetParamValueFloat("xte", "tpms.temp.alert",     t_alert);
 
             c.head(200);
-            c.alert("success", "<p class=\"lead\">Toyota e-TNGA configuration saved.</p>");
+            std::string saved = "<p class=\"lead\">" + etnga_vehicle_name() + " configuration saved.</p>";
+            c.alert("success", saved.c_str());
         } else {
             error = "<p class=\"lead\">Error:</p><ul class=\"errorlist\">" + error + "</ul>";
             c.head(400);
@@ -104,7 +113,8 @@ void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     float t_warn  = MyConfig.GetParamValueFloat("xte", "tpms.temp.warn",       90.0f);
     float t_alert = MyConfig.GetParamValueFloat("xte", "tpms.temp.alert",     100.0f);
 
-    c.panel_start("primary", "Toyota e-TNGA configuration");
+    std::string cfgtitle = etnga_vehicle_name() + " configuration";
+    c.panel_start("primary", cfgtitle.c_str());
     c.form_start(p.uri);
 
     c.fieldset_start("TPMS alert thresholds");
@@ -144,7 +154,10 @@ void OvmsVehicleToyotaETNGA::WebDispChgMetrics(PageEntry_t& p, PageContext_t& c)
         ".night h6.metric-head { color: unset; }\n"
         "</style>\n"
         "<div class=\"panel panel-primary\">"
-          "<div class=\"panel-heading\">Toyota e-TNGA charging metrics</div>"
+          "<div class=\"panel-heading\">");
+    c.print(etnga_vehicle_name() + " charging metrics");
+    c.print(
+          "</div>"
           "<div class=\"panel-body\">"
             "<div class=\"receiver\">"
 
@@ -193,7 +206,8 @@ void OvmsVehicleToyotaETNGA::WebDispChgMetrics(PageEntry_t& p, PageContext_t& c)
 void OvmsVehicleToyotaETNGA::WebChargeReports(PageEntry_t& p, PageContext_t& c)
 {
     c.head(200);
-    c.panel_start("primary", "Charge session reports");
+    std::string rtitle = etnga_vehicle_name() + " charge reports";
+    c.panel_start("primary", rtitle.c_str());
 
     std::vector<std::string> files;
     DIR* dir = opendir(etnga_report_dir().c_str());


### PR DESCRIPTION
Web page titles now reflect the actual vehicle (Subaru Solterra vs Toyota bZ4X) via `MyVehicleFactory.ActiveVehicleName()`, instead of the hardcoded platform name 'Toyota e-TNGA'. Falls back to the platform name if unavailable.

Affected: config page panel + saved-alert, charging-metrics panel heading, charge-reports index panel, and the per-session report's `<title>`/`<h1>`. Menu labels (BMS cell monitor / Charging metrics / etc.) left generic.

CI is the compile gate; visual confirmation on-vehicle.