### PR TITLE
docs: refresh e-TNGA / Solterra / bZ4X docs to match current code

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
@@ -38,3 +38,20 @@ Function                    Support Status
 =========================== ==============
 BMS v+t Display             Yes
 =========================== ==============
+
+Config namespace
+----------------
+
+The Solterra inherits the ``xte`` config namespace from the e-TNGA base.  All
+configuration parameters (e.g. TPMS alert thresholds) use the ``[xte]`` instance::
+
+    config set xte tpms.pressure.warn 240
+
+Web UI
+------
+
+All e-TNGA web UI pages are available on the Solterra; see the
+:doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the
+full list.  Notably, ``/bms/cellmon`` is fully populated for the Solterra
+because it declares the BMS pack arrangement — per-cell voltage and
+temperature history, deviation flags, and pack statistics are all enabled.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
@@ -15,8 +15,8 @@ Vehicle identity
 
 :Short type code: TOYBZ4X
 :Vehicle name: Toyota bZ4X
-:Log tag: ``v-toyotabz4x``
-:Config namespace prefix: ``xbz``
+:Log tag: ``v-toyota-bz4x``
+:Config namespace prefix: ``xte`` (inherited from e-TNGA base; bZ4X registers no namespace of its own)
 
 ------------------------
 Vehicle-specific support
@@ -26,3 +26,13 @@ The bZ4X currently adds no behavioural overrides on top of the e-TNGA platform, 
 match the e-TNGA baseline. In particular it does not declare a BMS pack arrangement, so per-cell BMS
 voltage/temperature monitoring is not enabled — unlike the
 :doc:`Subaru Solterra </components/vehicle_subaru_solterra/docs/index>`.
+
+Web UI
+------
+
+All e-TNGA web UI pages are available on the bZ4X; see the
+:doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the
+full list.  Note that ``/bms/cellmon`` will appear in the menu but shows
+no cell data because the bZ4X does not declare a BMS pack arrangement.
+The charging pages (``/xte/charge``, ``/xte/reports``) and the TPMS
+configuration page (``/xte/config``) work normally.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -28,7 +28,7 @@ Range Display               No
 GPS Location                Yes
 Speed Display               Yes
 Temperature Display         Yes
-BMS v+t Display             No
+BMS v+t Display             No (base class only; see note below)
 TPMS Display                Yes
 Charge Status Display       Yes
 Charge Interruption Alerts  No
@@ -39,32 +39,583 @@ Valet Mode Control          No
 Others                      VIN
 =========================== ==============
 
+.. note::
+
+   **BMS v+t Display** is ``No`` for the bare e-TNGA baseline because the base class does not
+   declare a pack arrangement.  Raw per-cell voltages (DID ``0x182E``) and temperatures
+   (DID ``0x1814``) **are** polled while driving and during DC charging — but without a pack
+   arrangement they are stored directly in the cell-voltage/temperature vector metrics rather
+   than being routed through the BMS min/max/deviation API.  Subclasses that declare the pack
+   arrangement (notably the Subaru Solterra) therefore show ``BMS v+t Display: Yes`` and get
+   full per-cell history, deviation flags, and pack statistics automatically.
+
 PID Polling Logic
 =================
 
-State transition variables should be polled frequently (10s) for the states they contribute to
-* PID_READY_SIGNAL                  { 0, 10, 10, 0}     
-* PID_CHARGING_LID                  { 0, 10, 0, 10}
-* PID_PISW_STATUS                   { 0, 0, 0, 10}
-* PID_CHARGING                      { 0, 0, 0, 10}
+The poll list uses seven columns corresponding to the seven ``PollState`` values.  The number in
+each column is the poll interval in seconds (``0`` = not polled in that state).  All rows use
+``ISOTP_STD`` addressing unless noted.
 
-Driving polls used for efficiency and power integration should be updated frequently (1s)
-* PID_BATTERY_VOLTAGE_AND_CURRENT   { 0, 1, 1, 1}   - Consider using a different PID for charging power
-* PID_ODOMETER                      { 0, 0, 1, 0}
-* PID_VEHICLE_SPEED                 { 0, 0, 1, 0}
+.. list-table::
+   :header-rows: 1
+   :widths: 22 10 8 8 8 8 8 8 10 20
 
-Some 'environmental' PIDs can be checked less frequently
-* PID_AMBIENT_TEMPERATURE           { 0, 60, 60, 60}
-* PID_BATTERY_TEMPERATURES          { 0, 60, 60, 60}
-* PID_SHIFT_POSITION                { 0, 0, 15, 0}
+   * - PID (DID)
+     - ECU
+     - SLEEP
+     - AWAKE
+     - DRIVING
+     - HS
+     - WAIT
+     - AC
+     - DC
+     - Purpose
+   * - ``PID_CONTROL_SYSTEM_MODE`` (``0x10D1``)
+     - Plug-In Control
+     - 0
+     - 1
+     - 1
+     - 1
+     - 1
+     - 1
+     - 1
+     - Control mode (CS_NONE / CS_DRIVING / CS_CHARGING); all active states @1 s
+   * - ``PID_CHARGING_LID`` (``0x1625``)
+     - Plug-In Control
+     - 0
+     - 10
+     - 10
+     - 0
+     - 0
+     - 0
+     - 0
+     - Charge lid open/closed; AWAKE + DRIVING only
+   * - ``PID_BATTERY_SOC`` (``0x1738``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 1
+     - 1
+     - SOC; DRIVING + AC + DC @1 s
+   * - ``PID_BATTERY_SOC_BMS`` (``0x1F5B``)
+     - HV Battery
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 1
+     - 1
+     - BMS SOC; mirrors ``PID_BATTERY_SOC`` pattern
+   * - ``PID_READY_SIGNAL`` (``0x1076``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 0
+     - 0
+     - Ready / READY lamp; DRIVING only
+   * - ``PID_BATTERY_VOLTAGE_AND_CURRENT`` (``0x1F9A``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 1
+     - 1
+     - Pack voltage + current; DRIVING + AC + DC @1 s
+   * - ``PID_BATTERY_TEMPERATURES`` (``0x1814``)
+     - HV Battery
+     - 0
+     - 0
+     - 10
+     - 0
+     - 0
+     - 0
+     - 20
+     - Cell-temperature array; DRIVING@10 s, DC@20 s
+   * - ``PID_BATTERY_CELL_VOLTAGES`` (``0x182E``)
+     - HV Battery
+     - 0
+     - 0
+     - 5
+     - 0
+     - 0
+     - 0
+     - 30
+     - Per-cell voltages (96 cells); DRIVING@5 s, DC@30 s
+   * - ``PID_BATTERY_CAPACITY`` (``0x1D3E``)
+     - HV Battery
+     - 0
+     - 60
+     - 120
+     - 0
+     - 0
+     - 60
+     - 60
+     - 8× per-module full-charge capacity (Ah); data collection
+   * - ``PID_BATTERY_CAPACITY_ALT`` (``0x1D3F``)
+     - HV Battery
+     - 0
+     - 60
+     - 120
+     - 0
+     - 0
+     - 60
+     - 60
+     - 8× parallel capacity array; function unconfirmed; data collection
+   * - ``PID_VEHICLE_SPEED`` (``0x1F0D``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 0
+     - 0
+     - Vehicle speed; DRIVING only
+   * - ``PID_SHIFT_POSITION`` (``0x1061``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 0
+     - 0
+     - Gear selector position; DRIVING only
+   * - ``PID_ODOMETER`` (``0x1FA6``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 0
+     - 0
+     - Odometer; DRIVING only
+   * - ``PID_AC_CONSUMPTION`` / driving (``0x106E``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 0
+     - 0
+     - HVAC power while driving @1 s; feeds cabin-energy integrator
+   * - ``PID_AMBIENT_TEMPERATURE`` (``0x1002``)
+     - Air Conditioner
+     - 0
+     - 0
+     - 10
+     - 0
+     - 0
+     - 0
+     - 0
+     - Ambient temperature; DRIVING only
+   * - ``PID_CABIN_TEMPERATURE`` (``0x1001``)
+     - Air Conditioner
+     - 0
+     - 0
+     - 10
+     - 0
+     - 0
+     - 0
+     - 0
+     - Cabin temperature; DRIVING only
+   * - ``PID_HVAC_SETPOINT`` (``0x1036``)
+     - Air Conditioner
+     - 0
+     - 0
+     - 10
+     - 0
+     - 0
+     - 0
+     - 0
+     - HVAC setpoint; DRIVING only
+   * - ``PID_HEATER_POWER`` (``0x1086``)
+     - Air Conditioner
+     - 0
+     - 0
+     - 10
+     - 0
+     - 0
+     - 0
+     - 0
+     - HV heater power; DRIVING only (>0 → ``v.e.heating``)
+   * - ``PID_BLOWER_LEVEL`` (``0x2801``)
+     - Air Conditioner
+     - 0
+     - 0
+     - 10
+     - 0
+     - 0
+     - 0
+     - 0
+     - Blower level 1–7; DRIVING only (→ ``v.e.cabinfan`` %)
+   * - ``PID_AMBIENT_TEMPERATURE_EV`` (``0x1F46``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - Not polled in any state; deferred until confirmed useful
+   * - ``PID_PISW_STATUS`` (``0x1669``)
+     - Plug-In Control
+     - 0
+     - 5
+     - 0
+     - 1
+     - 30
+     - 10
+     - 10
+     - PISW cable-seated signal; AWAKE@5 s (wake-reconcile); HS/AC/DC dense
+   * - ``PID_CHARGING_VOLTAGE_TYPE`` (``0x161C``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 5
+     - 0
+     - 0
+     - 0
+     - Charger power-supply voltage type (Type 1 / Type 2); HANDSHAKE@5 s only
+   * - ``PID_AC_CHARGING_OP_STATUS`` (``0x1684``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 1
+     - 30
+     - 1
+     - 1
+     - AC charger operation status; drives HANDSHAKE→AC transition
+   * - ``PID_HLC_STATE`` (``0x1666``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 1
+     - 30
+     - 0
+     - 1
+     - DC HLC state; drives HANDSHAKE→DC / DC→WAIT transitions
+   * - ``PID_MIN_PERMISSION_POWER`` (``0x16A1``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 1
+     - 1
+     - Minimum charging permission power (taper floor); AC + DC @1 s
+   * - ``PID_TARGET_CHARGING_CURRENT`` (``0x166D``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 1
+     - 1
+     - Target charging current set by vehicle; AC + DC @1 s
+   * - ``PID_BATTERY_CHARGING_POWER`` (``0x10D4``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 1
+     - 1
+     - Battery-delivered charge power (valid AC + DC); AC + DC @1 s
+   * - ``PID_CHARGER_INPUT_POWER`` (``0x161D``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 5
+     - 5
+     - Grid input power (AC only; 0 during DC); AC + DC @5 s
+   * - ``PID_DC_CHARGER_PRESENT_CURRENT`` (``0x166C``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 1
+     - DC station present current → ``v.c.current``; DC @1 s
+   * - ``PID_DC_CHARGER_PRESENT_VOLTAGE`` (``0x166B``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 1
+     - DC station present voltage → ``v.c.voltage``; DC @1 s
+   * - ``PID_DC_CHARGER_MAX_POWER`` (``0x166A``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 5
+     - DC station max power (negotiated); DC @5 s
+   * - ``PID_DC_CHARGER_MAX_CURRENT`` (``0x1679``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 5
+     - DC station max current (CCS contract); DC @5 s
+   * - ``PID_DC_CHARGER_MAX_VOLTAGE`` (``0x1681``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 5
+     - DC station max voltage (CCS contract); DC @5 s
+   * - ``PID_CHARGER_STATE_CLUSTER`` (``0x1619``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 1
+     - 0
+     - AC charger state cluster (target power, op status, current limit); AC @1 s
+   * - ``PID_CHARGER_OUTPUT_POWER`` (``0x161E``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 5
+     - 0
+     - AC charger output cluster (output + target power raw); AC @5 s
+   * - ``PID_AC_USABLE_POWER`` (``0x1665``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 5
+     - 0
+     - A/C useable power raw; AC @5 s
+   * - ``PID_MYROOM`` (``0x1692``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 5
+     - 5
+     - My Room active flag; AC + DC @5 s
+   * - ``PID_AC_CONSUMPTION`` / charging (``0x106E``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 0
+     - 0
+     - 2
+     - 2
+     - HVAC/cabin power while charging (OBC); AC + DC @2 s
+   * - ``PID_CHARGE_HISTORY`` (``0x1688``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 5
+     - 10
+     - 5
+     - 5
+     - Charging History outcome enum (``xte.v.c.outcome``); HS/WAIT/AC/DC
+   * - ``PID_CHARGE_STOP_REQ`` (``0x1667``)
+     - Plug-In Control
+     - 0
+     - 0
+     - 0
+     - 1
+     - 30
+     - 5
+     - 5
+     - Charge stop request from CCM; HS dense, WAIT/AC/DC sparse
+   * - ``PID_TPMS_CORNERS`` (``0x2021``) *ISOTP_EXTADR*
+     - TPMS GW (``0x750``/``0x2A``)
+     - 0
+     - 0
+     - 60
+     - 0
+     - 0
+     - 0
+     - 0
+     - Slot→corner remap table; DRIVING @60 s
+   * - ``PID_TPMS_PRESSURES`` (``0x1005``) *ISOTP_EXTADR*
+     - TPMS GW (``0x750``/``0x2A``)
+     - 0
+     - 0
+     - 60
+     - 0
+     - 0
+     - 0
+     - 0
+     - TPMS pressures; DRIVING @60 s
+   * - ``PID_TPMS_TEMPS`` (``0x1004``) *ISOTP_EXTADR*
+     - TPMS GW (``0x750``/``0x2A``)
+     - 0
+     - 0
+     - 60
+     - 0
+     - 0
+     - 0
+     - 0
+     - TPMS temperatures; DRIVING @60 s
 
-Battery SOC PID should be measured frequently (15s)
-* PID_BATTERY_SOC                   { 0, 15, 15, 15}
+Column headers: **HS** = CHARGE_HANDSHAKE, **WAIT** = CHARGE_WAIT, **AC** = CHARGE_AC,
+**DC** = CHARGE_DC.  ``0`` = not polled in that state.
 
-Some PIDs are on demand only
-* PID_VIN
-* PID_CHARGING_CONTROL_STATUS       - Determines if vehicle is charging
-* PID_CHARGING_VOLTAGE_TYPE         - Determines type1, type2, or ccs
+The following PID is declared in the source but **not currently polled** (all columns are 0)
+and is noted for future use:
+
+* ``PID_CHARGING_CONTROL_INFORMATION`` (``0x1689``) — deferred.
+
+Web UI
+======
+
+The following pages are registered by ``WebInit()`` for all e-TNGA vehicles and appear in the
+vehicle menu of the OVMS web interface.  Page titles use the active vehicle name (e.g. "Subaru
+Solterra" or "Toyota bZ4X").
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - URL
+     - Menu
+     - Purpose
+   * - ``/bms/cellmon``
+     - Vehicle
+     - BMS cell monitor — per-cell voltage and temperature display.  Populated only for
+       vehicles that declare a BMS pack arrangement (e.g. Solterra); empty for the base
+       e-TNGA and bZ4X.
+   * - ``/xte/charge``
+     - Vehicle
+     - Live charging metrics dashboard — key charge telemetry during a session.
+   * - ``/xte/reports``
+     - Vehicle
+     - Saved charge-report browser — lists stored session reports with links to the HTML
+       report and the per-sample CSV download.
+   * - ``/xte/report``
+     - (none)
+     - Serves one stored report or CSV by filename (linked from ``/xte/reports``).
+   * - ``/xte/config``
+     - Vehicle
+     - TPMS alert threshold configuration — sets ``[xte] tpms.*`` config parameters via a
+       form rather than the shell ``config set`` command.
+
+Charge session report
+=====================
+
+At the end of each charging session (plug-in to unplug), the module writes a self-contained
+HTML report and a fine-grained per-sample CSV to the charge-report directory.  The directory
+is ``/sd/charge-reports/`` when an SD card is mounted, falling back to
+``/store/charge-reports/`` on internal flash.  The newest 50 sessions are retained; older
+sessions (both ``.html`` and ``.csv``) are pruned automatically.  Orphan CSV files whose
+session never produced an HTML report (e.g. aborted sessions) are also removed at close.
+
+Report contents
+---------------
+
+The self-contained HTML report includes:
+
+* **Summary** — plug-in and unplug timestamps (UTC), duration, plug-in GPS location (with
+  OpenStreetMap link), ambient temperature range, charge type (AC / DC fast), SOC start→end,
+  delivered energy (kWh) and grid energy (kWh), peak and average power, battery temperature
+  range, and the 0x1688 outcome decoded to a human-readable label (e.g. "DC Charging Stop
+  (System)") with raw hex fallback for unknown codes.
+* **Inline SVG power/SOC chart** — downsampled (≤300 points) delivered-power trace and a
+  light SOC overlay, rendered on-module without any external dependencies.
+* **Session event log** — timestamped table of state-machine events (plug-in, charge phases
+  started/ended, unplug).
+* **Estimates** — charging efficiency (AC sessions, where grid kWh is available) and implied
+  pack capacity derived from delivered Ah and SOC delta.
+* **Link to the per-sample CSV** — download the raw time-series data for offline analysis.
+
+Per-sample CSV columns
+----------------------
+
+The CSV is streamed to disk one row per second during active charging (``CHARGE_AC`` or
+``CHARGE_DC``).  The header row defines the columns::
+
+    elapsed_s, soc_pct, delivered_kw, pack_v, pack_a, batt_temp_c, ambient_c, state,
+    station_max_kw, station_max_a, station_max_v, car_perm_kw, target_a,
+    grid_kw, present_v, present_a
+
+Where ``state`` is ``AC`` or ``DC`` and ``grid_kw`` / ``present_v`` / ``present_a`` are
+grid input power and DC station telemetry respectively (zero when not applicable).
+
+Metrics
+=======
+
+Standard OVMS metrics populated by the e-TNGA module (in addition to the obvious SOC, speed,
+odometer, temperature, and VIN):
+
+* ``v.e.cooling`` — A/C cooling active (true when ``0x106E`` HVAC power > 0)
+* ``v.e.heating`` — HV heater active (true when ``0x1086`` heater power > 0)
+* ``v.e.cabinfan`` — Blower level as a percentage (from ``0x2801``, levels 1–7)
+* ``v.b.consumption`` — Trip-average energy consumption (Wh/km), computed each tick while
+  DRIVING from net trip energy / trip distance
+* ``v.b.coulomb.used`` / ``v.b.coulomb.recd`` — Per-trip charge/discharge coulombs (Ah),
+  reset at trip start; ``v.b.coulomb.used.total`` / ``v.b.coulomb.recd.total`` are
+  persistent lifetime accumulators
+* ``v.b.energy.used`` / ``v.b.energy.recd`` — Per-trip energy (kWh); ``.total`` variants
+  are persistent
+* ``v.c.power`` (``ms_v_charge_power``) — Battery-delivered charge power (DID ``0x10D4``),
+  valid for both AC and DC charging
+* ``v.c.kwh.grid`` / ``v.c.kwh.grid.total`` — AC grid energy delivered this session /
+  lifetime, integrated from ``0x161D`` (AC only; reads 0 during DC)
+
+Key custom metrics (``xte.*`` namespace, 18 total ``xte.v.c.*`` plus supporting metrics):
+
+* ``xte.v.c.gridpower`` — Grid input power (kW) from DID ``0x161D``; AC charging only
+  (the grid-side companion to ``v.c.power``)
+* ``xte.v.e.hvac.power`` — HVAC / cabin power draw (kW); sourced from the OBC (``0x745``,
+  DID ``0x106E``) while charging and from the hybrid control ECU (``0x7D2``) while driving
+* ``xte.v.e.hvac.kwh`` — My-Room cabin energy (kWh); direct time-integral of
+  ``xte.v.e.hvac.power`` over the My-Room-active interval, reset at charge start; valid for
+  both AC and DC
+* ``xte.v.e.hvac.kwh.drive`` — Per-trip driving cabin/HVAC energy (kWh); time-integral of
+  HVAC power while in the DRIVING state, reset at trip start
 
 .. toctree::
    :maxdepth: 1

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -28,8 +28,9 @@ Two parallel states
      - PID ``0x10D1`` on the Plug-In Control ECU
      - ``CS_NONE=0``, ``CS_DRIVING=1``, ``CS_CHARGING=3``
 
-``PollState`` selects which PIDs are polled — see the ``{S, A, D, C}``
-columns in the ``obdii_polls[]`` table in ``vehicle_toyota_etnga.cpp``.
+``PollState`` selects which PIDs are polled — see the seven-column
+``obdii_polls[]`` table in ``vehicle_toyota_etnga.cpp`` (documented in
+:doc:`index` under "PID Polling Logic").
 ``ControlState`` is the vehicle's own self-report and is the primary trigger
 for the ``AWAKE → DRIVING`` edge.
 
@@ -48,14 +49,16 @@ window.
 Tick loop
 =========
 
-``Ticker1()`` runs once per second and does two things:
+``Ticker1()`` runs once per second and does three things:
 
 1. ``ResetStaleMetrics()`` manually clears ``controlstate``,
    ``ms_v_env_awake``, ``ms_v_door_chargeport``, ``ms_v_charge_pilot``,
    and ``ms_v_bat_power`` if they have gone stale but still hold a
    non-default value.  This is the only way ``ms_v_env_awake`` ever drops
    back to ``false``.
-2. Dispatches to the appropriate handler —
+2. While in the ``DRIVING`` state, computes ``v.b.consumption``
+   (trip-average Wh/km) from net trip energy divided by trip distance.
+3. Dispatches to the appropriate handler —
    ``HandleSleepState()``, ``HandleAwakeState()``,
    ``HandleDrivingState()``, ``HandleChargeHandshakeState()``,
    ``HandleChargeWaitState()``, ``HandleChargeAcState()``, or
@@ -81,7 +84,7 @@ Transition diagram
               │     ▲                              │       │
    CAN traffic│     │ env_awake stale (~120 s)      │       │
    OR 12V >   │     │ OR 5-min / 15-min watchdog    │       │
-   ref+0.2 V  │     │ (arms 10 s cooldown)          │       │
+   ref+0.2 V  │     │ (arms escalating cooldown)    │       │
               ▼     │                              │       │
           ┌─────────────────┐                      │       │
           │      AWAKE      │◄──────────────────┐  │       │
@@ -204,7 +207,7 @@ All edges live in ``etnga_poll_states.cpp``.
    * - ``AWAKE → SLEEP`` (forced, door watch)
      - ``monotonic - m_v_env_awaketime > 300`` AND charge door never opened
      - 5-minute watchdog when awake with no ``CS_DRIVING`` and charge
-       door not opened.  Arms the 10-second cooldown latch.
+       door not opened.  Arms the escalating cooldown latch.
    * - ``AWAKE → SLEEP`` (forced, cable watch)
      - ``monotonic - m_cable_watch_start > 900`` (armed but no cable plug-in)
      - 15-minute watchdog: charge door was seen open (``m_armed_for_charge``
@@ -244,7 +247,7 @@ All edges live in ``etnga_poll_states.cpp``.
    * - ``CHARGE_WAIT → SLEEP``
      - ``ms_v_env_awake == false``
      - Bus went dead during scheduled wait (OBC slept or gateway isolated
-       OBD).  Arms the 10-second cooldown latch.
+       OBD).  Arms the escalating cooldown latch.
    * - ``CHARGE_AC → CHARGE_WAIT``
      - ``ac_op == 0x00`` (Stop) OR PISW ``== 0x00``
      - Phase ended cleanly or cable pulled.  Sets
@@ -253,6 +256,12 @@ All edges live in ``etnga_poll_states.cpp``.
      - ``hlc == 0xFF`` (Unconnected) OR PISW ``== 0x00``
      - DC phase ended or cable pulled.  Sets
        ``ms_v_charge_state = "stopped"``.
+
+Web UI pages
+============
+
+The e-TNGA module registers five vehicle-menu web pages at startup; see the
+:doc:`index` "Web UI" section for the full URL list and descriptions.
 
 Charge state strings (``ms_v_charge_state``)
 ============================================
@@ -293,7 +302,10 @@ Charge session (in-RAM)
 =======================
 
 A ``ChargeSessionState`` struct (member ``m_charge_session``) tracks the
-current plug-in event entirely in RAM — there is no flash persistence:
+current plug-in event.  The session **state** lives only in RAM and is not
+flash-persisted; however, a per-sample CSV is streamed to disk throughout
+the session and a summary HTML report is written at session close, so data
+is durable even if the in-RAM state is lost to a hard reset.
 
 .. list-table::
    :header-rows: 1
@@ -306,7 +318,44 @@ current plug-in event entirely in RAM — there is no flash persistence:
    * - ``start_monotonic``
      - ``ms_m_monotonic`` value at session open (seconds since boot)
    * - ``start_soc``
-     - ``ms_v_bat_soc`` integer value at session open
+     - ``ms_v_bat_soc`` integer value at session open (−1 if unknown)
+   * - ``start_utc``
+     - UTC wall-clock at session open (0 if clock not synced)
+   * - ``is_dc``
+     - ``true`` if the session included a DC fast-charge phase
+   * - ``peak_power``
+     - Highest ``ms_v_charge_power`` seen during the session (kW)
+   * - ``temp_seen`` / ``temp_min`` / ``temp_max``
+     - Battery temperature range (°C) observed during charging
+   * - ``has_loc`` / ``start_lat`` / ``start_lon``
+     - GPS coordinates at session open (from ``ms_v_pos_latitude/longitude``,
+       captured only if GPS lock was active)
+   * - ``amb_seen`` / ``amb_min`` / ``amb_max``
+     - Ambient temperature range (°C) observed during charging
+   * - ``delivered_ah``
+     - Charge-side coulomb count (Ah) integrated from ``ms_v_bat_current``
+       during active charging phases; used for the implied-capacity estimate
+   * - ``last_sample_monotonic``
+     - Monotonic timestamp of the last per-tick aggregation (used for Ah dt
+       and CSV streaming)
+   * - ``events``
+     - Event log: vector of (monotonic seconds, label string) pairs
+       appended via ``LogChargeEvent()`` at each state transition
+   * - ``svg``
+     - Downsampled chart buffer: vector of ``Sample{t_s, kw, soc}`` at
+       the current ``svg_interval_s`` cadence (≤300 points; interval
+       doubles and buffer is decimated when the cap is exceeded)
+   * - ``svg_interval_s``
+     - Current SVG sampling interval (seconds); starts at 20 s, doubles
+       on decimation
+   * - ``last_svg_monotonic``
+     - Monotonic timestamp of the last SVG sample
+   * - ``base``
+     - File basename ``<dir>/<timestamp>`` (no extension); ``.html`` and
+       ``.csv`` are appended for the two output files
+   * - ``csv_started``
+     - ``true`` after the CSV header has been written; subsequent calls
+       append rather than truncate
 
 **Session open:** ``TransitionToChargeHandshakeState()`` opens the
 session (sets ``in_session = true``) on first entry.  If the driver
@@ -333,12 +382,11 @@ would silently break the wake-reconcile path.
 Charge curve & station metrics
 ==============================
 
-Tasks 1–4 of the ``v3-charge-statemachine`` feature added eleven custom
-``xte.v.c.*`` metrics and began populating two standard OVMS metrics
-during charging.  They are decoded by ``IncomingPlugInControlSystem()``
-in ``etnga_poll_processor.cpp`` (with scale/decode math in
-``etnga_metrics.cpp``) as the poller runs in the ``CHARGE_AC`` and
-``CHARGE_DC`` states.
+The module maintains 18 custom ``xte.v.c.*`` metrics and populates
+several standard OVMS metrics during charging.  They are decoded by
+``IncomingPlugInControlSystem()`` in ``etnga_poll_processor.cpp`` (with
+scale/decode math in ``etnga_metrics.cpp``) as the poller runs in the
+``CHARGE_AC`` and ``CHARGE_DC`` states.
 
 DC / universal custom metrics
 ------------------------------
@@ -452,7 +500,9 @@ is distinct from ``xte.v.c.acop`` (``0x1684``), which drives the
 Charge-report supporting channels
 ----------------------------------
 
-These four metrics feed the in-module charge report (work item D).
+These four metrics feed the in-module charge report (see :doc:`index`
+"Charge session report").  ``GenerateChargeReport()`` is implemented and
+is called at session end from ``TransitionToAwakeState()``.
 ``xte.v.c.myroom`` is polled only in the ``CHARGE_AC`` and ``CHARGE_DC``
 states; ``xte.v.e.hvac.power`` is polled in those charge states (from the
 OBC, ``0x745``) **and** in ``DRIVING`` (from the hybrid control ECU,
@@ -508,8 +558,9 @@ OBC, ``0x745``) **and** in ``DRIVING`` (from the hybrid control ECU,
 
 .. note::
 
-   **Limiting-side attribution (work item D, not yet implemented).**
-   When the report attributes who capped the charge rate, compare the
+   **Limiting-side attribution (pending).**  The charge report is
+   implemented; the remaining open item is correctly attributing which
+   side (car vs. station) capped the charge rate.  When doing so, compare the
    car's permission ``0x16A1`` against the station's **declared max**
    ``0x166A`` and take the lower as the binding cap.  Do **not** fold the
    station's instantaneous V×I output (``0x166B`` × ``0x166C``) in as a
@@ -524,29 +575,45 @@ Cooldown latch
 ==============
 
 To prevent flapping after the forced-sleep watchdogs,
-``HandleAwakeState`` sets ``m_allow_wake = false`` and records
-``m_sleep_entry_time`` before transitioning to ``SLEEP``.  While the
-latch is held:
+``TransitionToSleepState`` sets ``m_allow_wake = false`` and records
+``m_sleep_entry_time`` before calling ``SetPollState(SLEEP)``.  While
+the latch is held:
 
 * ``IncomingFrameCan2`` does **not** call ``SetAwake(true)``, so trailing
   post-shutdown CAN traffic cannot bounce the driver straight back to
   ``AWAKE``.
-* After 10 seconds, ``HandleSleepState`` clears the latch and CAN frames
-  can wake the driver again.
+* After the current cooldown window elapses, ``HandleSleepState`` clears
+  the latch and CAN frames can wake the driver again.
+
+The cooldown window is **not** a fixed 10 seconds — it uses an escalating
+backoff schedule defined in ``SLEEP_COOLDOWN_SECS[]``::
+
+    {10, 30, 60, 120, 300}   // seconds
+
+Each consecutive no-activity sleep (watchdog-triggered, not a real
+drive/charge event) advances to the next entry and stays there.  A real
+activity event — drive start, charge start, charge-door open, or 12 V
+bump — calls ``ResetSleepBackoff()`` which returns the index to 0 so the
+next sleep uses the shortest (10 s) window again.
 
 The 12 V-based wake path is **not** gated by ``m_allow_wake`` — high aux
-voltage will pull the driver out of ``SLEEP`` even mid-cooldown.
+voltage will pull the driver out of ``SLEEP`` even mid-cooldown, and also
+resets the backoff index.
 
-``CHARGE_WAIT → SLEEP`` also arms the cooldown latch (same 10-second
-window) to prevent immediate re-wake from bus noise after the OBC sleeps.
+``CHARGE_WAIT → SLEEP`` also arms the cooldown latch (using the current
+backoff window) to prevent immediate re-wake from bus noise after the OBC
+sleeps.
 
 Boot
 ====
 
-The constructor calls ``TransitionToSleepState()`` and
-``PollSetThrottling(0)``.  The driver always starts in ``SLEEP`` and
-waits for CAN activity or a 12 V bump before doing anything else.
-``TransitionToSleepState()`` also clears ``m_armed_for_charge``.
+The constructor calls ``SetPollState(PollState::SLEEP)`` **directly**
+(not via ``TransitionToSleepState()``) and ``PollSetThrottling(0)``.
+This is intentional: ``TransitionToSleepState()`` would arm the cooldown
+latch and advance the backoff index, neither of which is wanted at boot.
+``m_armed_for_charge`` is set to ``false`` directly for the same reason.
+The driver always starts in ``SLEEP`` and waits for CAN activity or a
+12 V bump before doing anything else.
 
 Notes and quirks
 ================
@@ -581,10 +648,12 @@ Notes and quirks
   states clean up via ``SetChargingStatus(false)`` and ``SetChargeState``
   only.  Charge metrics added in the future may need explicit clearing on
   exit.
-* **No flash persistence for charge sessions.** ``m_charge_session`` lives
-  only in RAM.  A hard reset or power cycle mid-session will lose the
-  session-open state; the wake-reconcile will not fire because
-  ``in_session`` will be ``false`` after boot.
+* **No flash persistence for charge session state.** ``m_charge_session``
+  lives only in RAM.  A hard reset or power cycle mid-session will lose
+  the in-RAM session state; the wake-reconcile will not fire because
+  ``in_session`` will be ``false`` after boot.  However, the per-sample
+  CSV is streamed to disk continuously, so partial session data (up to
+  the reset point) is preserved even if no HTML report is generated.
 
 TPMS
 ====


### PR DESCRIPTION
Brings the vehicle docs in line with the code after this cycle of work (web UI, BMS wiring, TPMS, charge report v1/v2 + CSV, new metrics, dynamic titles, sleep-cooldown backoff, 7-state poll machine).

**e-TNGA index.rst:** rewrote the obsolete 4-state `PID Polling Logic` section as a 7-state list-table transcribed from `obdii_polls[]` (removes the non-existent `PID_CHARGING`); clarified the BMS v+t row; added Web UI, Charge session report, and Metrics sections; noted `v.c.power` is now battery-delivered (0x10D4).
**state_machine.rst:** fixed the cooldown (escalating {10,30,60,120,300}s, not 10s), the boot description (`SetPollState(SLEEP)` direct), "work item D" → charge report implemented, expanded the ChargeSessionState field table, corrected metric count, added Ticker1 consumption + web UI mention.
**Solterra:** added xte config namespace + web UI note.
**bZ4X:** fixed config namespace (`xbz`→`xte`) and log tag (`v-toyotabz4x`→`v-toyota-bz4x`); added web UI note.

Docs-only — firmware build skipped; docs workflow validates the RST. From a deep doc-vs-code review.