### PR TITLE
etnga: initialize v.c.charging and v.c.mode at boot

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -48,6 +48,15 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     SetAwake(false);
     SetReadyStatus(false);
     SetChargingDoorStatus(false);
+    // v.c.charging is a persistent metric (restored from RTC across soft reboots) and is
+    // read by ABRP as the charging indicator. Boot is forced into the SLEEP poll state, so
+    // initialize it false to match — otherwise a reboot mid-charge leaves it stale-true (and
+    // a fresh power-up leaves it undefined) until the poller re-derives the real state.
+    SetChargingStatus(false);
+    // v.c.mode pairs with the above: the poller only sets it ("standard" AC / "performance"
+    // DC, the ABRP is_dcfc indicator) while charging and clears it to "" on session end, so
+    // the not-charging boot value is empty.
+    StandardMetrics.ms_v_charge_mode->SetValue("");
 
     // Set poll state transition variables to shorter autostale than default
     // in case their ECUs go to sleep before the 'false' poll


### PR DESCRIPTION
## Problem
`InitializeMetrics()` sets the other boot-state flags (awake, ready, charging-door) but never populated the charge metrics. At startup:
- `v.c.charging` (`ms_v_charge_inprogress`, a **persistent** metric restored from RTC across soft reboots) was **undefined on a cold boot**, and could be **restored stale-`true`** after a mid-charge soft reboot — leaving ABRP showing "charging" while parked/driving until the poller re-derived state.
- `v.c.mode` was undefined at boot.

ABRP keys on both (`v.c.mode == performance` → `is_dcfc`).

## Fix
Initialize `v.c.charging = false` and `v.c.mode = ""` in `InitializeMetrics()`, alongside the existing flags and consistent with the forced-`SLEEP` boot poll state. The poller still sets the real values on entering a charge state, so an active charge is picked up within one poll cycle.

## Verification
- Builds via GitHub CI.
- On-vehicle behavior validation pending (observe `v.c.charging`/`v.c.mode` immediately after a reboot while parked and while charging).