### PR TITLE
etnga charge report: location name, ambient fix, AC/DC chart, HLC events

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -6,6 +6,15 @@ Open Vehicle Monitor System v3 - Change log
     efficiency/implied-capacity estimates) plus a fine-grained per-sample CSV (delivered/offered/
     allowed power, pack + battery-temp over time) to /sd/charge-reports/ (fallback /store). Also
     fixes peak charging power on DC (was sourced from the AC-only grid-input poll).
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): charge report refinements — the power chart now
+    uses a fixed, standardized scale per charge type (AC 0-11 kW, DC 0-150 kW) with a fixed 0-100%
+    SOC axis, and overlays the station-offered max (DC) and car-permitted (BMS taper) traces
+    alongside delivered power. The report shows the matching named OVMS location (geofence) when
+    one is defined, decodes the DC HLC handshake states (0x1666) into the session event log, and
+    no longer reports a bogus "0 -> 0 C" ambient range. Ambient temperature is now polled during
+    charging (HCS 0x1F46 — the A/C ambient sensor's ECU sleeps while charging), and "kWh from grid"
+    / charging-efficiency are shown for AC sessions only (not meaningful on DC). The "Charging
+    metrics" vehicle-menu page is renamed "Charging monitor".
 - hw3.1: Fix random crash (abort in esp_sha_read_digest_state) during TLS handshakes by disabling
     mbedTLS hardware SHA acceleration (CONFIG_MBEDTLS_HARDWARE_SHA). The shared ESP32 SHA engine
     could return an all-zero digest state when mbedtls_sha256_clone() snapshotted it mid-handshake,

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -27,8 +27,12 @@
 #include <vector>
 #include <algorithm>
 
+#include <sdkconfig.h>
 #include "ovms_log.h"
 #include "metrics_standard.h"
+#ifdef CONFIG_OVMS_COMP_LOCATION
+#include "ovms_location.h"
+#endif
 #include "vehicle_toyota_etnga.h"
 
 #define CHARGE_REPORT_DIR  "/store/charge-reports"
@@ -80,6 +84,53 @@ const char* OvmsVehicleToyotaETNGA::ChargeOutcomeLabel(int code)
     }
 }
 
+// Map a 0x1666 "DC HLC state" enum code (ISO 15118 high-level-communication state machine)
+// to a human-readable label. Codes sourced from solterra-can (2026-05 DC-charge captures;
+// 6 empirically confirmed, the rest inferred from the CCS state sequence).
+// Returns "" for unknown codes so the caller skips logging them.
+const char* OvmsVehicleToyotaETNGA::HlcStateLabel(int code)
+{
+    switch (code & 0xFF) {
+        case 0x00: return "HLC: SLAC";
+        case 0x01: return "HLC: SDP";
+        case 0x02: return "HLC: App-protocol negotiation";
+        case 0x03: return "HLC: Session setup";
+        case 0x04: return "HLC: Service discovery";
+        case 0x05: return "HLC: Service detail";
+        case 0x06: return "HLC: Payment service selection";
+        case 0x07: return "HLC: Certificate installation";
+        case 0x08: return "HLC: Certificate update";
+        case 0x09: return "HLC: Payment details";
+        case 0x0A: return "HLC: Authorization";
+        case 0x0B: return "HLC: Charge-parameter discovery";
+        case 0x0C: return "HLC: Cable check";
+        case 0x0D: return "HLC: Precharge";
+        case 0x0E: return "HLC: Power delivery (start)";
+        case 0x0F: return "HLC: Current demand";
+        case 0x10: return "HLC: Power delivery (stop)";
+        case 0x11: return "HLC: Welding detection";
+        case 0x12: return "HLC: Session stop";
+        case 0xFF: return "HLC: Unconnected";
+        default:   return "";
+    }
+}
+
+// Return the name of the first defined OVMS location (geofence) that contains (lat,lon),
+// or "" if none match. Used to show a friendly place name in the report alongside coords.
+std::string OvmsVehicleToyotaETNGA::LookupLocationName(float lat, float lon)
+{
+#ifdef CONFIG_OVMS_COMP_LOCATION
+    for (LocationMap::iterator it = MyLocations.m_locations.begin();
+         it != MyLocations.m_locations.end(); ++it) {
+        if (it->second && it->second->IsInLocation(lat, lon))
+            return it->first;
+    }
+#else
+    (void)lat; (void)lon;
+#endif
+    return "";
+}
+
 // Append a monotonic-timestamped event to the session event log.
 // No-op outside a session (guard matches the in_session flag set in TransitionToChargeHandshakeState).
 void OvmsVehicleToyotaETNGA::LogChargeEvent(const char* label)
@@ -111,12 +162,16 @@ void OvmsVehicleToyotaETNGA::UpdateChargeSessionStats()
     } else if (t < m_charge_session.temp_min) m_charge_session.temp_min = t;
     else if (t > m_charge_session.temp_max) m_charge_session.temp_max = t;
 
-    float amb = StandardMetrics.ms_v_env_temp->AsFloat();
-    if (!m_charge_session.amb_seen) {
-        m_charge_session.amb_min = m_charge_session.amb_max = amb;
-        m_charge_session.amb_seen = true;
-    } else if (amb < m_charge_session.amb_min) m_charge_session.amb_min = amb;
-    else if (amb > m_charge_session.amb_max) m_charge_session.amb_max = amb;
+    // Only fold in ambient when a fresh reading exists (env temp is undefined when parked
+    // until the in-charge 0x1F46 poll answers) — prevents a bogus 0 C dragging the range.
+    if (StandardMetrics.ms_v_env_temp->IsDefined()) {
+        float amb = StandardMetrics.ms_v_env_temp->AsFloat();
+        if (!m_charge_session.amb_seen) {
+            m_charge_session.amb_min = m_charge_session.amb_max = amb;
+            m_charge_session.amb_seen = true;
+        } else if (amb < m_charge_session.amb_min) m_charge_session.amb_min = amb;
+        else if (amb > m_charge_session.amb_max) m_charge_session.amb_max = amb;
+    }
 
     m_charge_session.is_dc = (static_cast<PollState>(m_poll_state) == PollState::CHARGE_DC);
 
@@ -139,6 +194,8 @@ void OvmsVehicleToyotaETNGA::UpdateChargeSessionStats()
         s.t_s = now - m_charge_session.start_monotonic;
         s.kw  = p;
         s.soc = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+        s.sta_max  = m_v_charge_sta_max_p->AsFloat();        // station-offered max kW (0x166A, DC only; 0 on AC)
+        s.car_perm = fabsf(m_v_charge_perm->AsFloat());      // car-permitted kW (0x16A1 is signed: |.| is the charge limit)
         m_charge_session.svg.push_back(s);
         m_charge_session.last_svg_monotonic = now;
         // Cap ~300 points: when exceeded, double the interval and decimate (keep every other).
@@ -225,49 +282,96 @@ static void PruneChargeReports(const char* tag, const std::string& dir)
     }
 }
 
-// Render a self-contained inline SVG line chart of delivered power (+ light SOC overlay) vs time.
+// Render a self-contained inline SVG chart vs time, with standardized axes:
+//   - left axis: delivered power (kW), fixed full-scale per charge type (AC 0-11, DC 0-150)
+//   - right axis: SOC, fixed 0-100 %
+//   - traces: delivered power, station-offered max (DC only) and car-permitted limit (the
+//     0x16A1 taper curve), plus the SOC overlay. All powers plot as magnitudes (0x16A1 is
+//     signed: negative = charging), so the three power traces share one positive axis.
 std::string OvmsVehicleToyotaETNGA::RenderPowerSvg()
 {
     const std::vector<ChargeSessionState::Sample>& s = m_charge_session.svg;
     if (s.size() < 2)
         return "<p>(not enough samples for a chart)</p>";
 
-    const int W = 640, H = 240, PADL = 44, PADB = 24, PADT = 10, PADR = 10;
+    const bool  dc    = m_charge_session.is_dc;
+    const float pmax  = dc ? 150.0f : 11.0f;   // fixed power-axis full scale (kW)
+    const float pstep = dc ? 25.0f  : 2.0f;    // power gridline / tick spacing (kW)
+
+    const int W = 640, H = 260, PADL = 44, PADB = 28, PADT = 12, PADR = 44;
     const int PW = W - PADL - PADR, PH = H - PADT - PADB;
     int tmax = s.back().t_s > 0 ? s.back().t_s : 1;
-    float kwmax = 1.0f;
-    for (size_t i = 0; i < s.size(); i++)
-        if (s[i].kw > kwmax) kwmax = s[i].kw;
 
     std::string out;
-    char b[160];
+    char b[256];
     snprintf(b, sizeof(b), "<svg viewBox=\"0 0 %d %d\" style=\"width:100%%;max-width:%dpx;height:auto\" xmlns=\"http://www.w3.org/2000/svg\">\n", W, H, W);
     out += b;
     out += "<rect width=\"100%\" height=\"100%\" fill=\"#fff\"/>\n";
-    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, PADT, PADL, H-PADB); out += b;
-    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, H-PADB, W-PADR, H-PADB); out += b;
-    snprintf(b, sizeof(b), "<text x=\"4\" y=\"%d\" font-size=\"10\" fill=\"#666\">%.0f kW</text>\n", PADT+8, kwmax); out += b;
 
-    // SOC overlay (light)
-    out += "<polyline fill=\"none\" stroke=\"#9cf\" stroke-width=\"1\" points=\"";
+    // Horizontal gridlines + left power-axis (kW) labels.
+    for (float kw = 0.0f; kw <= pmax + 0.01f; kw += pstep) {
+        float y = PADT + (float)PH * (1.0f - kw / pmax);
+        snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%.1f\" x2=\"%d\" y2=\"%.1f\" stroke=\"#eee\"/>\n", PADL, y, W-PADR, y); out += b;
+        snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%.1f\" font-size=\"10\" fill=\"#06c\" text-anchor=\"end\">%g</text>\n", PADL-3, y+3, kw); out += b;
+    }
+    // Right SOC-axis (%) labels, fixed 0-100.
+    for (int soc = 0; soc <= 100; soc += 25) {
+        float y = PADT + (float)PH * (1.0f - soc / 100.0f);
+        snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%.1f\" font-size=\"10\" fill=\"#39c\">%d</text>\n", W-PADR+3, y+3, soc); out += b;
+    }
+    // Axis lines (left power, right SOC, bottom time).
+    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, PADT, PADL, H-PADB); out += b;
+    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", W-PADR, PADT, W-PADR, H-PADB); out += b;
+    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, H-PADB, W-PADR, H-PADB); out += b;
+
+    // SOC overlay (right axis, 0-100).
+    out += "<polyline fill=\"none\" stroke=\"#39c\" stroke-width=\"1\" stroke-dasharray=\"1 3\" points=\"";
     for (size_t i = 0; i < s.size(); i++) {
         float x = PADL + (float)PW * s[i].t_s / tmax;
-        float y = PADT + (float)PH * (1.0f - s[i].soc / 100.0f);
+        float soc = s[i].soc < 0 ? 0.0f : (s[i].soc > 100 ? 100.0f : (float)s[i].soc);
+        float y = PADT + (float)PH * (1.0f - soc / 100.0f);
         snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
     }
     out += "\"/>\n";
 
-    // delivered power
+    // Station-offered max (DC only — 0x166A is not polled on AC).
+    if (dc) {
+        out += "<polyline fill=\"none\" stroke=\"#e80\" stroke-width=\"1\" stroke-dasharray=\"5 3\" points=\"";
+        for (size_t i = 0; i < s.size(); i++) {
+            float x = PADL + (float)PW * s[i].t_s / tmax;
+            float v = s[i].sta_max; if (v < 0) v = 0; if (v > pmax) v = pmax;
+            float y = PADT + (float)PH * (1.0f - v / pmax);
+            snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
+        }
+        out += "\"/>\n";
+    }
+
+    // Car-permitted limit (the BMS taper curve).
+    out += "<polyline fill=\"none\" stroke=\"#0a0\" stroke-width=\"1\" stroke-dasharray=\"5 3\" points=\"";
+    for (size_t i = 0; i < s.size(); i++) {
+        float x = PADL + (float)PW * s[i].t_s / tmax;
+        float v = s[i].car_perm; if (v < 0) v = 0; if (v > pmax) v = pmax;
+        float y = PADT + (float)PH * (1.0f - v / pmax);
+        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
+    }
+    out += "\"/>\n";
+
+    // Delivered power (primary trace).
     out += "<polyline fill=\"none\" stroke=\"#06c\" stroke-width=\"2\" points=\"";
     for (size_t i = 0; i < s.size(); i++) {
         float x = PADL + (float)PW * s[i].t_s / tmax;
-        float y = PADT + (float)PH * (1.0f - s[i].kw / kwmax);
+        float v = s[i].kw; if (v < 0) v = 0; if (v > pmax) v = pmax;
+        float y = PADT + (float)PH * (1.0f - v / pmax);
         snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
     }
     out += "\"/>\n";
 
-    snprintf(b, sizeof(b), "<text x=\"50\" y=\"%d\" font-size=\"10\" fill=\"#06c\">power (kW)</text><text x=\"140\" y=\"%d\" font-size=\"10\" fill=\"#9cf\">SOC %%</text>\n", H-6, H-6);
-    out += b;
+    // Legend (bottom).
+    int ly = H - 6;
+    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#06c\">delivered kW</text>\n", PADL+6, ly); out += b;
+    if (dc) { snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#e80\">station max</text>\n", PADL+96, ly); out += b; }
+    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#0a0\">car permitted</text>\n", PADL+186, ly); out += b;
+    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#39c\">SOC %%</text>\n", PADL+282, ly); out += b;
     out += "</svg>\n";
     return out;
 }
@@ -320,8 +424,11 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     snprintf(b, sizeof(b), "%dh %02dm %02ds", dh, dm, ds);
     f << "<dt>Duration</dt><dd>" << b << "</dd>\n";
     if (m_charge_session.has_loc) {
+        std::string locname = LookupLocationName(m_charge_session.start_lat, m_charge_session.start_lon);
         snprintf(b, sizeof(b), "%.5f, %.5f", m_charge_session.start_lat, m_charge_session.start_lon);
-        f << "<dt>Location</dt><dd>" << b
+        f << "<dt>Location</dt><dd>";
+        if (!locname.empty()) f << locname << " &mdash; ";
+        f << b
           << " (<a target=\"_blank\" href=\"https://www.openstreetmap.org/?mlat="
           << m_charge_session.start_lat << "&mlon=" << m_charge_session.start_lon
           << "#map=17/" << m_charge_session.start_lat << "/" << m_charge_session.start_lon << "\">map</a>)</dd>\n";
@@ -333,7 +440,12 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     f << "<dt>Type</dt><dd>" << (m_charge_session.is_dc ? "DC fast" : "AC") << "</dd>\n";
     snprintf(b, sizeof(b), "%d%% &rarr; %d%% (+%d%%)", start_soc, end_soc, start_soc>=0?end_soc-start_soc:0);
     f << "<dt>SOC</dt><dd>" << b << "</dd>\n";
-    snprintf(b, sizeof(b), "%.2f kWh delivered, %.2f kWh from grid", energy_kwh, grid_kwh);
+    // "From grid" is an AC-charge concept (the 0x161D grid-input poll only answers on AC);
+    // on DC the energy meter is the station's, so show delivered only.
+    if (m_charge_session.is_dc)
+        snprintf(b, sizeof(b), "%.2f kWh delivered", energy_kwh);
+    else
+        snprintf(b, sizeof(b), "%.2f kWh delivered, %.2f kWh from grid", energy_kwh, grid_kwh);
     f << "<dt>Energy</dt><dd>" << b << "</dd>\n";
     snprintf(b, sizeof(b), "%.1f kW peak / %.2f kW avg", m_charge_session.peak_power, avg_kw);
     f << "<dt>Power</dt><dd>" << b << "</dd>\n";
@@ -359,7 +471,7 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     f << "</table>\n";
 
     f << "<h2 class=\"est\">Estimates</h2>\n<dl class=\"est\">\n";
-    if (grid_kwh > 0.01f) {
+    if (!m_charge_session.is_dc && grid_kwh > 0.01f) {   // efficiency needs grid energy (AC only)
         snprintf(b, sizeof(b), "%.0f%% (%.2f kWh loss)", energy_kwh/grid_kwh*100.0f, grid_kwh-energy_kwh);
         f << "<dt>Charging efficiency</dt><dd>" << b << "</dd>\n";
     }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -201,7 +201,18 @@ bool OvmsVehicleToyotaETNGA::CalculateChargingDoorStatus(const std::string& data
 int OvmsVehicleToyotaETNGA::CalculateAcOpStatus(const std::string& data) { return GetRxBInt8(data, 0); }
 void OvmsVehicleToyotaETNGA::SetAcOpStatus(int v) { m_v_charge_ac_op->SetValue(v); }
 int OvmsVehicleToyotaETNGA::CalculateHlcState(const std::string& data) { return GetRxBByte(data, 0); }
-void OvmsVehicleToyotaETNGA::SetHlcState(int v) { m_v_charge_hlc->SetValue(v); }
+void OvmsVehicleToyotaETNGA::SetHlcState(int v)
+{
+    m_v_charge_hlc->SetValue(v);
+    // Log each new 0x1666 HLC (DC handshake) state as a session event. Unknown codes
+    // return "" and are skipped (avoids logging a non-static formatted string).
+    if (m_charge_session.in_session && v != m_charge_session.last_hlc) {
+        m_charge_session.last_hlc = v;
+        const char* lbl = HlcStateLabel(v);
+        if (lbl && lbl[0])
+            LogChargeEvent(lbl);
+    }
+}
 int OvmsVehicleToyotaETNGA::CalculatePISWRaw(const std::string& data) { return GetRxBInt8(data, 0); }
 void OvmsVehicleToyotaETNGA::SetPISWRaw(int v) { m_v_charge_pisw_raw->SetValue(v); }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -332,9 +332,14 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
             m_charge_session.start_lat = StandardMetrics.ms_v_pos_latitude->AsFloat();
             m_charge_session.start_lon = StandardMetrics.ms_v_pos_longitude->AsFloat();
         }
-        float amb = StandardMetrics.ms_v_env_temp->AsFloat();
-        m_charge_session.amb_seen = true;
-        m_charge_session.amb_min = m_charge_session.amb_max = amb;
+        // Seed the ambient range only from a fresh reading. env temp is Clear()ed when the
+        // car parks, so seeding unconditionally produced a bogus "0 -> 0 C". The in-charge
+        // 0x1F46 poll (enabled in the poll list) fills the range as readings arrive.
+        if (StandardMetrics.ms_v_env_temp->IsDefined()) {
+            float amb = StandardMetrics.ms_v_env_temp->AsFloat();
+            m_charge_session.amb_seen = true;
+            m_charge_session.amb_min = m_charge_session.amb_max = amb;
+        }
         m_charge_session.svg_interval_s = 20;
         m_charge_session.last_sample_monotonic = 0;
         m_charge_session.last_svg_monotonic = 0;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -67,7 +67,7 @@ static std::string etnga_vehicle_name()
 void OvmsVehicleToyotaETNGA::WebInit()
 {
     MyWebServer.RegisterPage("/bms/cellmon", "BMS cell monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
-    MyWebServer.RegisterPage("/xte/charge", "Charging metrics", WebDispChgMetrics, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/xte/charge", "Charging monitor", WebDispChgMetrics, PageMenu_Vehicle, PageAuth_Cookie);
     MyWebServer.RegisterPage("/xte/reports", "Charge reports", WebChargeReports, PageMenu_Vehicle, PageAuth_Cookie);
     MyWebServer.RegisterPage("/xte/report", "Charge report", WebChargeReport, PageMenu_None, PageAuth_Cookie);
     MyWebServer.RegisterPage("/xte/config", "Configuration", WebCfgFeatures, PageMenu_Vehicle, PageAuth_Cookie);
@@ -170,7 +170,7 @@ void OvmsVehicleToyotaETNGA::WebDispChgMetrics(PageEntry_t& p, PageContext_t& c)
         "</style>\n"
         "<div class=\"panel panel-primary\">"
           "<div class=\"panel-heading\">");
-    c.print(etnga_vehicle_name() + " charging metrics");
+    c.print(etnga_vehicle_name() + " charging monitor");
     c.print(
           "</div>"
           "<div class=\"panel-body\">"

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -53,7 +53,7 @@ static const OvmsPoller::poll_pid_t obdii_polls[] = {
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_BLOWER_LEVEL,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x2801 blower level 1-7: DRIVING only (=> v.e.cabinfan %)
 
     // Charging polls — state-machine DIDs
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,   { 0,  0, 0,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F46: not polled by sim in any charge state; 0 until confirmed useful
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,   { 0,  0, 0, 30, 30, 30, 30}, 0, ISOTP_STD }, // 0x1F46 ambient via HCS (awake during charge): HS/WAIT/AC/DC @30s — the A/C 0x1002 ambient is DRIVING-only (HVAC ECU sleeps while charging), so the charge report had no ambient source
   { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_PISW_STATUS,              { 0,  5, 0,  1, 30, 10, 10}, 0, ISOTP_STD }, // 0x1669 PISW: AWAKE=5 (Task 5); HS=1,WAIT=30,AC=10,DC=10 (sim)
   { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_VOLTAGE_TYPE,    { 0,  0, 0,  5,  0,  0,  0}, 0, ISOTP_STD }, // 0x161C VTYPE: HS=5s only (sim: HANDSHAKE=5, absent elsewhere)
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -94,8 +94,9 @@ protected:
         int   last_sample_monotonic = 0;   // dt for delivered_ah + CSV row cadence
         // v2: event log (monotonic seconds, static label string)
         std::vector<std::pair<int,const char*>> events;
-        // v2: downsampled chart buffer
-        struct Sample { int t_s; float kw; int soc; };
+        int   last_hlc = -1;               // last 0x1666 HLC state logged as an event (change detection)
+        // v2: downsampled chart buffer (per sample: delivered kW, SOC, station-offered + car-permitted kW)
+        struct Sample { int t_s; float kw; int soc; float sta_max; float car_perm; };
         std::vector<Sample> svg;
         int   svg_interval_s = 20;
         int   last_svg_monotonic = 0;
@@ -164,6 +165,8 @@ private:
     void AppendChargeCsvRow();                          // stream one CSV row (opens+header on first call)
     std::string ChargeReportDir();                      // "/sd/charge-reports" if SD mounted else "/store/..."
     static const char* ChargeOutcomeLabel(int code);    // 0x1688 enum -> human text
+    static const char* HlcStateLabel(int code);         // 0x1666 DC HLC state enum -> human text ("" if unknown)
+    std::string LookupLocationName(float lat, float lon); // matching OVMS named-location (geofence), or ""
 
     // Incoming message handling functions
     void IncomingAirConditionerSystem(uint16_t pid);


### PR DESCRIPTION
Refinements to the e-TNGA charge session report (follow-up to #90):

1. **Menu rename** — `Charging metrics` → `Charging monitor`.
2. **Named location** — report shows the matching OVMS geofence name (if defined) next to the GPS coords.
3. **Ambient "0 → 0 °C" fix** — the A/C ambient PID (0x1002) is DRIVING-only (HVAC ECU sleeps while charging) and env temp is `Clear()`ed when parked. Now polls the HCS ambient PID (0x1F46, awake during charge) at 30 s in charge states, and only folds ambient into the range when `IsDefined()` (else omits the row).
4. **Grid energy / efficiency AC-only** — `kWh from grid` and charging efficiency are shown only for AC (the 0x161D grid-input poll answers on AC only).
5. **Standardized chart axes** — power axis fixed per type (AC 0–11 kW, DC 0–150 kW) with gridline ticks; SOC axis fixed 0–100% on the right.
6. **Station-max + car-permitted traces** — added beside delivered power. 0x16A1 is signed (negative = charging) so all powers plot as magnitudes on one axis.
7. **HLC events** — decode the 0x1666 DC HLC handshake states and log each transition to the session event log.

⚠️ **Needs on-vehicle validation:** the in-charge ambient source (0x1F46) and the 0x1666 HLC state labels are from reverse-engineering and a real charge is needed to confirm 0x1F46 returns a sane ambient and the HLC sequence reads correctly.

Read-side + poll-list change; no CAN-write behavior changes.