### PR TITLE
etnga: drive-input + Brake/EPB metrics, charge-debug logging, WAIT poll cadence

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -50,6 +50,17 @@ Open Vehicle Monitor System v3 - Change log
     (SOC delta, energy delivered + from grid, peak/avg power, battery-temp range, AC/DC, outcome).
     The newest 50 reports are kept. This first version covers single-phase, live-telemetry
     sessions; multi-phase, sleep-survival and limiting-side attribution are planned follow-ups.
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): new driver-input metrics while driving —
+    accelerator position, drive mode (Eco/Normal/Power), foot-brake pedal, and the electric
+    parking brake. Adds the Brake/EPB ECU (0x7B0) as a new poll target. AWD/X-MODE status is
+    exposed as a custom metric.
+  Populated standard metrics:
+    v.e.throttle                          -- Accelerator pedal position [%]
+    v.e.drivemode                         -- Drive mode select (0=Normal,1=Power,6=Eco)
+    v.e.footbrake                         -- Brake pedal position [%] (mapped from pedal stroke)
+    v.e.handbrake                         -- Electric parking brake applied
+  New metric:
+    xte.v.e.awd                           -- AWD / X-MODE status (0=Normal,2=Snow/Dirt,3=Deep Snow/Mud)
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -45,6 +45,7 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     m_v_bat_temp_heater = MyMetrics.InitFloat("xte.v.b.temp.heater", SM_STALE_MID, 0.0f, Celcius);  // This variable stores the temperature of the battery coolant
     m_v_pos_trip_start = MyMetrics.InitFloat("xte.v.p.trip.start", SM_STALE_NONE, 0.0f, Kilometers, false);  // This variable stores the odometer reading at the beginning of a trip
     m_v_env_awaketime = MyMetrics.InitInt("xte.v.e.awaketime", SM_STALE_NONE);  // Time awake state was entered for awake timeout (monotonic seconds)
+    m_v_e_awd = MyMetrics.InitInt("xte.v.e.awd", SM_STALE_MID);  // 0x1087 b2 AWD / X-MODE status (custom)
 
     // Set initial values for metrics
     SetAwake(false);
@@ -201,7 +202,8 @@ bool OvmsVehicleToyotaETNGA::CalculateChargingDoorStatus(const std::string& data
 int OvmsVehicleToyotaETNGA::CalculateAcOpStatus(const std::string& data) { return GetRxBInt8(data, 0); }
 void OvmsVehicleToyotaETNGA::SetAcOpStatus(int v)
 {
-    m_v_charge_ac_op->SetValue(v);
+    if (m_v_charge_ac_op->SetValue(v))
+        ESP_LOGD(TAG, "AC Op Status changed: 0x%02X (%d)", v, v);
     // Log each new 0x1684 AC-Op state as a session event (mirrors SetHlcState for DC).
     // Stop/unknown return "" from AcOpStatusLabel and are skipped.
     if (m_charge_session.in_session && v != m_charge_session.last_acop) {
@@ -214,7 +216,8 @@ void OvmsVehicleToyotaETNGA::SetAcOpStatus(int v)
 int OvmsVehicleToyotaETNGA::CalculateHlcState(const std::string& data) { return GetRxBByte(data, 0); }
 void OvmsVehicleToyotaETNGA::SetHlcState(int v)
 {
-    m_v_charge_hlc->SetValue(v);
+    if (m_v_charge_hlc->SetValue(v))
+        ESP_LOGD(TAG, "HLC State changed: 0x%02X (%d)", v, v);
     // Log each new 0x1666 HLC (DC handshake) state as a session event. Unknown codes
     // return "" and are skipped (avoids logging a non-static formatted string).
     if (m_charge_session.in_session && v != m_charge_session.last_hlc) {
@@ -225,50 +228,82 @@ void OvmsVehicleToyotaETNGA::SetHlcState(int v)
     }
 }
 int OvmsVehicleToyotaETNGA::CalculatePISWRaw(const std::string& data) { return GetRxBInt8(data, 0); }
-void OvmsVehicleToyotaETNGA::SetPISWRaw(int v) { m_v_charge_pisw_raw->SetValue(v); }
+void OvmsVehicleToyotaETNGA::SetPISWRaw(int v)
+{
+    if (m_v_charge_pisw_raw->SetValue(v))
+        ESP_LOGD(TAG, "PISW Raw changed: 0x%02X (%d)", v, v);
+}
 
 float OvmsVehicleToyotaETNGA::CalculatePermissionPower(const std::string& data)
 {
     // 0x16A1: two's-complement s16, x0.01 kW. Sentinel 0x8000 handled by caller (skip).
     return static_cast<float>(GetRxBInt16(data, 0)) / 100.0f;
 }
-void OvmsVehicleToyotaETNGA::SetPermissionPower(float kw) { m_v_charge_perm->SetValue(kw); }
+void OvmsVehicleToyotaETNGA::SetPermissionPower(float kw)
+{
+    LogMetricChange(m_v_charge_perm, kw, "Min Permission Power", "kW");
+    m_v_charge_perm->SetValue(kw);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateTargetCurrent(const std::string& data)
 {
     return static_cast<float>(GetRxBUint16(data, 0));  // x1 A
 }
-void OvmsVehicleToyotaETNGA::SetTargetCurrent(float amps) { m_v_charge_tgti->SetValue(amps); }
+void OvmsVehicleToyotaETNGA::SetTargetCurrent(float amps)
+{
+    LogMetricChange(m_v_charge_tgti, amps, "Target Charging Current", "A");
+    m_v_charge_tgti->SetValue(amps);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateStationVoltage(const std::string& data)
 {
     return static_cast<float>(GetRxBUint16(data, 0));  // 0x166B x1 V/LSB; idle=0, no sentinel
 }
-void OvmsVehicleToyotaETNGA::SetStationVoltage(float volts) { StandardMetrics.ms_v_charge_voltage->SetValue(volts); }
+void OvmsVehicleToyotaETNGA::SetStationVoltage(float volts)
+{
+    LogMetricChange(StandardMetrics.ms_v_charge_voltage, volts, "Station Voltage", "V");
+    StandardMetrics.ms_v_charge_voltage->SetValue(volts);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateStationCurrent(const std::string& data)
 {
     return static_cast<float>(GetRxBUint16(data, 0));  // 0x166C x1 A/LSB; idle=0, no sentinel
 }
-void OvmsVehicleToyotaETNGA::SetStationCurrent(float amps)  { StandardMetrics.ms_v_charge_current->SetValue(amps); }
+void OvmsVehicleToyotaETNGA::SetStationCurrent(float amps)
+{
+    LogMetricChange(StandardMetrics.ms_v_charge_current, amps, "Station Current", "A");
+    StandardMetrics.ms_v_charge_current->SetValue(amps);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateStationMaxPower(const std::string& data)
 {
     return static_cast<float>(GetRxBUint16(data, 0)) / 100.0f;  // 0x166A x0.01 kW/LSB; idle=0 when no station
 }
-void OvmsVehicleToyotaETNGA::SetStationMaxPower(float kw) { m_v_charge_sta_max_p->SetValue(kw); }
+void OvmsVehicleToyotaETNGA::SetStationMaxPower(float kw)
+{
+    LogMetricChange(m_v_charge_sta_max_p, kw, "Station Max Power", "kW");
+    m_v_charge_sta_max_p->SetValue(kw);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateStationMaxCurrent(const std::string& data)
 {
     return static_cast<float>(GetRxBUint16(data, 0));  // 0x1679 x1 A/LSB; idle=0 when no station
 }
-void OvmsVehicleToyotaETNGA::SetStationMaxCurrent(float amps) { m_v_charge_sta_max_i->SetValue(amps); }
+void OvmsVehicleToyotaETNGA::SetStationMaxCurrent(float amps)
+{
+    LogMetricChange(m_v_charge_sta_max_i, amps, "Station Max Current", "A");
+    m_v_charge_sta_max_i->SetValue(amps);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateStationMaxVoltage(const std::string& data)
 {
     return static_cast<float>(GetRxBUint16(data, 0));  // 0x1681 x1 V/LSB; idle=0 when no station
 }
-void OvmsVehicleToyotaETNGA::SetStationMaxVoltage(float volts) { m_v_charge_sta_max_v->SetValue(volts); }
+void OvmsVehicleToyotaETNGA::SetStationMaxVoltage(float volts)
+{
+    LogMetricChange(m_v_charge_sta_max_v, volts, "Station Max Voltage", "V");
+    m_v_charge_sta_max_v->SetValue(volts);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateAcTargetPower(const std::string& data)
 {
@@ -281,18 +316,46 @@ int OvmsVehicleToyotaETNGA::CalculateChargerOutputRaw(const std::string& data)  
 int OvmsVehicleToyotaETNGA::CalculateChargerOutputTargetRaw(const std::string& data){ return GetRxBUint16(data, 2); }  // 0x161E b3-4 raw, scale TBD
 int OvmsVehicleToyotaETNGA::CalculateAcUsableRaw(const std::string& data)           { return GetRxBByte(data, 0); }    // 0x1665 raw, scale TBD
 
-void OvmsVehicleToyotaETNGA::SetAcTargetPower(float kw)        { m_v_charge_ac_tgt_p->SetValue(kw); }
-void OvmsVehicleToyotaETNGA::SetChargerOpStatus(int v)        { m_v_charge_chgr_op->SetValue(v); }
-void OvmsVehicleToyotaETNGA::SetAcCurrentLimitRaw(int v)      { m_v_charge_ac_ilim->SetValue(v); }
-void OvmsVehicleToyotaETNGA::SetChargerOutputRaw(int v)       { m_v_charge_out->SetValue(v); }
-void OvmsVehicleToyotaETNGA::SetChargerOutputTargetRaw(int v) { m_v_charge_out_tgt->SetValue(v); }
-void OvmsVehicleToyotaETNGA::SetAcUsableRaw(int v)            { m_v_charge_ac_usable->SetValue(v); }
+void OvmsVehicleToyotaETNGA::SetAcTargetPower(float kw)
+{
+    LogMetricChange(m_v_charge_ac_tgt_p, kw, "AC Target Power", "kW");
+    m_v_charge_ac_tgt_p->SetValue(kw);
+}
+void OvmsVehicleToyotaETNGA::SetChargerOpStatus(int v)
+{
+    if (m_v_charge_chgr_op->SetValue(v))
+        ESP_LOGD(TAG, "Charger Op Status changed: 0x%02X (%d)", v, v);
+}
+void OvmsVehicleToyotaETNGA::SetAcCurrentLimitRaw(int v)
+{
+    if (m_v_charge_ac_ilim->SetValue(v))
+        ESP_LOGD(TAG, "AC Current Limit (raw) changed: 0x%04X (%d)", v, v);
+}
+void OvmsVehicleToyotaETNGA::SetChargerOutputRaw(int v)
+{
+    if (m_v_charge_out->SetValue(v))
+        ESP_LOGD(TAG, "Charger Output (raw) changed: 0x%04X (%d)", v, v);
+}
+void OvmsVehicleToyotaETNGA::SetChargerOutputTargetRaw(int v)
+{
+    if (m_v_charge_out_tgt->SetValue(v))
+        ESP_LOGD(TAG, "Charger Output Target (raw) changed: 0x%04X (%d)", v, v);
+}
+void OvmsVehicleToyotaETNGA::SetAcUsableRaw(int v)
+{
+    if (m_v_charge_ac_usable->SetValue(v))
+        ESP_LOGD(TAG, "AC Usable Power (raw) changed: 0x%02X (%d)", v, v);
+}
 
 bool OvmsVehicleToyotaETNGA::CalculateMyRoom(const std::string& data)
 {
     return GetRxBBit(data, 1, 0);   // 0x1692 byte 2 (idx 1), bit 0 = My Room active
 }
-void OvmsVehicleToyotaETNGA::SetMyRoom(bool active) { m_v_charge_myroom->SetValue(active); }
+void OvmsVehicleToyotaETNGA::SetMyRoom(bool active)
+{
+    LogMetricChange(m_v_charge_myroom, active, "My Room", active ? "Active" : "Inactive");
+    m_v_charge_myroom->SetValue(active);
+}
 
 float OvmsVehicleToyotaETNGA::CalculateAcConsumption(const std::string& data)
 {
@@ -338,10 +401,103 @@ void OvmsVehicleToyotaETNGA::SetHvacPower(float kw)
 }
 
 int OvmsVehicleToyotaETNGA::CalculateChargeOutcome(const std::string& data)  { return GetRxBByte(data, 0); }  // 0x1688 26-state enum; RETAINED between sessions (does not reset on plug-in) — report must scope it per-session
-void OvmsVehicleToyotaETNGA::SetChargeOutcome(int v) { m_v_charge_outcome->SetValue(v); }
+void OvmsVehicleToyotaETNGA::SetChargeOutcome(int v)
+{
+    if (m_v_charge_outcome->SetValue(v))
+        ESP_LOGD(TAG, "Charge Outcome changed: 0x%02X (%d)", v, v);
+}
 
 int OvmsVehicleToyotaETNGA::CalculateChargeStopReq(const std::string& data)  { return GetRxBByte(data, 0); }  // 0x1667 enum (partial)
-void OvmsVehicleToyotaETNGA::SetChargeStopReq(int v) { m_v_charge_stopreq->SetValue(v); }
+void OvmsVehicleToyotaETNGA::SetChargeStopReq(int v)
+{
+    if (m_v_charge_stopreq->SetValue(v))
+        ESP_LOGD(TAG, "Charge Stop Request changed: 0x%02X (%d)", v, v);
+}
+
+// --- 2026-06-06 pins: EV ECU driver inputs + Brake/EPB ---
+
+float OvmsVehicleToyotaETNGA::CalculateThrottle(const std::string& data)
+{
+    // 0x1060 b1: accelerator position, u8 x0.5 %/LSB (0x00-0xC8 -> 0-100%)
+    return static_cast<float>(GetRxBByte(data, 0)) * 0.5f;
+}
+void OvmsVehicleToyotaETNGA::SetThrottle(float pct)
+{
+    LogMetricChange(StandardMetrics.ms_v_env_throttle, pct, "Throttle", "%");
+    StandardMetrics.ms_v_env_throttle->SetValue(pct);
+}
+
+int OvmsVehicleToyotaETNGA::CalculateDriveMode(const std::string& data)
+{
+    return GetRxBByte(data, 0);   // 0x1004 b1: Drive Mode Select Status enum
+}
+void OvmsVehicleToyotaETNGA::SetDriveMode(int mode)
+{
+    // Platform enum (this BEV trim emits only 0/1/6 — Normal/Power/Eco):
+    std::string label;
+    switch (mode)
+    {
+        case 0:  label = "Normal";    break;
+        case 1:  label = "Power";     break;
+        case 2:  label = "Sport";     break;
+        case 3:  label = "Sport S";   break;
+        case 4:  label = "Sport S+";  break;
+        case 5:  label = "Comfort";   break;
+        case 6:  label = "Eco";       break;
+        case 9:  label = "Range";     break;
+        case 11: label = "Chauffeur"; break;
+        default: label = "unknown";   break;
+    }
+    LogMetricChange(StandardMetrics.ms_v_env_drivemode, mode, "Drive Mode", label);
+    StandardMetrics.ms_v_env_drivemode->SetValue(mode);
+}
+
+int OvmsVehicleToyotaETNGA::CalculateAwdMode(const std::string& data)
+{
+    return GetRxBByte(data, 1);   // 0x1087 b2: AWD / X-MODE status enum
+}
+void OvmsVehicleToyotaETNGA::SetAwdMode(int mode)
+{
+    std::string label;
+    switch (mode)
+    {
+        case 0:  label = "Normal";                      break;
+        case 2:  label = "Snow/Dirt";                   break;
+        case 3:  label = "Deep Snow/Mud";               break;
+        case 4:  label = "Snow/Dirt (Temp Cancel)";     break;
+        case 5:  label = "Deep Snow/Mud (Temp Cancel)"; break;
+        default: label = "unknown";                     break;
+    }
+    LogMetricChange(m_v_e_awd, mode, "AWD Mode", label);
+    m_v_e_awd->SetValue(mode);
+}
+
+float OvmsVehicleToyotaETNGA::CalculateFootBrake(const std::string& data)
+{
+    // 0x104C b1: brake pedal stroke, u8 ~1 mm/LSB. Captured range 0 (rest) .. 67 (full press).
+    // Map to 0-100% of observed full-press stroke for ms_v_env_footbrake (% semantics).
+    const float kFootBrakeFullStrokeMm = 67.0f;
+    float pct = static_cast<float>(GetRxBByte(data, 0)) * 100.0f / kFootBrakeFullStrokeMm;
+    if (pct > 100.0f) pct = 100.0f;
+    return pct;
+}
+void OvmsVehicleToyotaETNGA::SetFootBrake(float pct)
+{
+    LogMetricChange(StandardMetrics.ms_v_env_footbrake, pct, "Foot Brake", "%");
+    StandardMetrics.ms_v_env_footbrake->SetValue(pct);
+}
+
+bool OvmsVehicleToyotaETNGA::CalculateParkBrake(const std::string& data)
+{
+    // 0x1045 b1 (RH actuator): 0x00=Park Applied, 0x02=Released, 0x03=Applying, 0x04=Releasing, 0x05=Completely Released.
+    // OVMS handbrake bool: applied only when Park Applied (0x00). (0x01 Hold Applied is the separate brake-hold feature.)
+    return GetRxBByte(data, 0) == 0x00;
+}
+void OvmsVehicleToyotaETNGA::SetParkBrake(bool applied)
+{
+    LogMetricChange(StandardMetrics.ms_v_env_handbrake, applied, "Park Brake", applied ? "Applied" : "Released");
+    StandardMetrics.ms_v_env_handbrake->SetValue(applied);
+}
 
 int OvmsVehicleToyotaETNGA::CalculateControlMode(const std::string& data)
 {
@@ -555,12 +711,16 @@ void OvmsVehicleToyotaETNGA::SetBatteryCellVoltages(const std::vector<float>& vo
 
 void OvmsVehicleToyotaETNGA::SetBatteryCapacityFull(const std::vector<float>& caps)
 {
-    m_v_bat_cap_full->SetValue(caps);
+    // SetValue() returns true only when an element actually changed → change-gated log
+    // (no vector overload of LogMetricChange exists). Slow poll (60-120s); data collection.
+    if (m_v_bat_cap_full->SetValue(caps))
+        ESP_LOGD(TAG, "Battery Capacity Full (Ah): %s", m_v_bat_cap_full->AsString().c_str());
 }
 
 void OvmsVehicleToyotaETNGA::SetBatteryCapacityAlt(const std::vector<float>& caps)
 {
-    m_v_bat_cap_alt->SetValue(caps);
+    if (m_v_bat_cap_alt->SetValue(caps))
+        ESP_LOGD(TAG, "Battery Capacity Alt (Ah): %s", m_v_bat_cap_alt->AsString().c_str());
 }
 
 void OvmsVehicleToyotaETNGA::SetBatteryCellVoltageStatistics(const std::vector<float>& voltages)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -55,6 +55,10 @@ void OvmsVehicleToyotaETNGA::IncomingPollReply(const OvmsPoller::poll_job_t &job
             IncomingTPMS(job.pid);
             break;
 
+        case BRAKE_EPB_RX:
+            IncomingBrakeEpb(job.pid);
+            break;
+
         default:
             ESP_LOGW(TAG, "Unknown module: %03" PRIx32, job.moduleid_rec);
             return;
@@ -160,10 +164,44 @@ void OvmsVehicleToyotaETNGA::IncomingHybridControlSystem(uint16_t pid)
             break;
         }
 
+        case PID_THROTTLE: {
+            SetThrottle(CalculateThrottle(m_rxbuf));
+            break;
+        }
+
+        case PID_DRIVE_MODE_SELECT: {
+            SetDriveMode(CalculateDriveMode(m_rxbuf));
+            break;
+        }
+
+        case PID_AWD_MODE: {
+            SetAwdMode(CalculateAwdMode(m_rxbuf));
+            break;
+        }
+
         // Add more cases for other PIDs if needed
 
         default:
             // Handle unsupported PID
+            ESP_LOGW(TAG, "Unsupported PID: %04X", pid);
+            break;
+    }
+}
+
+void OvmsVehicleToyotaETNGA::IncomingBrakeEpb(uint16_t pid)
+{
+    switch (pid) {
+        case PID_BRAKE_PEDAL_STROKE: {
+            SetFootBrake(CalculateFootBrake(m_rxbuf));
+            break;
+        }
+
+        case PID_EPB_STATUS: {
+            SetParkBrake(CalculateParkBrake(m_rxbuf));
+            break;
+        }
+
+        default:
             ESP_LOGW(TAG, "Unsupported PID: %04X", pid);
             break;
     }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -46,11 +46,19 @@ static const OvmsPoller::poll_pid_t obdii_polls[] = {
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_SHIFT_POSITION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1061 gear: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_ODOMETER,                  { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1FA6 odometer: DRIVING only
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @1s (matches battery V/I for the cabin-energy integrator)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_THROTTLE,                  { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1060 b1 accelerator position: DRIVING@1s (v.e.throttle)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_DRIVE_MODE_SELECT,         { 0,  0, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1004 b1 drive mode (Eco/Normal/Power): DRIVING@5s (v.e.drivemode)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AWD_MODE,                  { 0,  0, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1087 b2 AWD/X-MODE status: DRIVING@5s (xte.v.e.awd)
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE,       { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1002 ambient temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_CABIN_TEMPERATURE,         { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1001 cabin temp: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HVAC_SETPOINT,             { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1036 HVAC setpoint: DRIVING only
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HEATER_POWER,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1086 HV heater power: DRIVING only (>0 => v.e.heating)
   { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_BLOWER_LEVEL,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x2801 blower level 1-7: DRIVING only (=> v.e.cabinfan %)
+
+    // Chassis / driver inputs — Brake/EPB ECU (0x7B0), direct-poll standard ISO-TP (new target 2026-06-06)
+    // EPB stays alive in the parked body tail, so park-brake is polled in AWAKE too; foot-brake is DRIVING-only.
+  { BRAKE_EPB_TX,              BRAKE_EPB_RX,              VEHICLE_POLL_TYPE_READDATA, PID_BRAKE_PEDAL_STROKE,        { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x104C b1 brake pedal stroke: DRIVING@1s (v.e.footbrake)
+  { BRAKE_EPB_TX,              BRAKE_EPB_RX,              VEHICLE_POLL_TYPE_READDATA, PID_EPB_STATUS,                { 0,  5, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1045 b1 EPB actuator status: AWAKE+DRIVING@5s (v.e.handbrake)
 
     // Charging polls — state-machine DIDs
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,   { 0,  0, 0, 30, 30, 30, 30}, 0, ISOTP_STD }, // 0x1F46 ambient via HCS (awake during charge): HS/WAIT/AC/DC @30s — the A/C 0x1002 ambient is DRIVING-only (HVAC ECU sleeps while charging), so the charge report had no ambient source
@@ -59,8 +67,8 @@ static const OvmsPoller::poll_pid_t obdii_polls[] = {
 
 //  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_CONTROL_INFORMATION, { 0, 0, 0, 1, 1, 1, 1}, 0, ISOTP_STD }, // 0x1689 deferred
 
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_CHARGING_OP_STATUS,    { 0,  0, 0,  1, 30,  1,  1}, 0, ISOTP_STD }, // 0x1684 AC op: HS=1,WAIT=30,AC=1,DC=1 (sim)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_HLC_STATE,                { 0,  0, 0,  1, 30,  0,  1}, 0, ISOTP_STD }, // 0x1666 HLC: HS=1,WAIT=30,AC=0 (not needed),DC=1 (sim)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_CHARGING_OP_STATUS,    { 0,  0, 0,  1,  1,  1,  1}, 0, ISOTP_STD }, // 0x1684 AC op: HS=1,WAIT=1 (catch AC engage promptly),AC=1,DC=1
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_HLC_STATE,                { 0,  0, 0,  1,  1,  0,  1}, 0, ISOTP_STD }, // 0x1666 HLC: HS=1,WAIT=1 (catch DC engage promptly),AC=0 (not needed),DC=1
   { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_MIN_PERMISSION_POWER,     { 0,  0, 0,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x16A1 perm power (curve): AC+DC=1s (sim DID_PERM_PWR)
   { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_TARGET_CHARGING_CURRENT,  { 0,  0, 0,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x166D target current: AC+DC=1s (sim DID_TGT_CUR)
   { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CHARGING_POWER,   { 0,  0, 0,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x10D4 batt power: AC+DC=1s (sim); handler gated on charge-in-progress

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -146,6 +146,7 @@ protected:
     OvmsMetricFloat* m_v_bat_temp_heater;
     OvmsMetricInt* m_v_env_awaketime;
     OvmsMetricFloat* m_v_pos_trip_start;
+    OvmsMetricInt* m_v_e_awd;   // 0x1087 b2 AWD / X-MODE status (custom; no standard OVMS metric)
     
     void NotifyVehicleOn();
     void NotifyChargeStart();
@@ -180,6 +181,7 @@ private:
     void IncomingHybridBatterySystem(uint16_t pid);
     void IncomingHybridControlSystem(uint16_t pid);
     void IncomingPlugInControlSystem(uint16_t pid);
+    void IncomingBrakeEpb(uint16_t pid);
     void IncomingTPMS(uint16_t pid);
     void UpdateTPMSAlert();
     bool TPMSCornerMapValid();
@@ -227,6 +229,11 @@ private:
     bool CalculateReadyStatus(const std::string& data);
     int CalculateShiftPosition(const std::string& data);
     float CalculateVehicleSpeed(const std::string& data);
+    float CalculateThrottle(const std::string& data);
+    int   CalculateDriveMode(const std::string& data);
+    int   CalculateAwdMode(const std::string& data);
+    float CalculateFootBrake(const std::string& data);
+    bool  CalculateParkBrake(const std::string& data);
 
     // Metric setter functions
     void SetAcOpStatus(int v);
@@ -278,6 +285,11 @@ private:
     void SetHvacPower(float kw);
     void SetChargeOutcome(int v);
     void SetChargeStopReq(int v);
+    void SetThrottle(float pct);
+    void SetDriveMode(int mode);
+    void SetAwdMode(int mode);
+    void SetFootBrake(float pct);
+    void SetParkBrake(bool applied);
 
     void LogMetricChange(OvmsMetricBool* metric, bool newValue, const std::string& label, const std::string& valueLabel);
     void LogMetricChange(OvmsMetricFloat* metric, float newValue, const std::string& label,const std::string& units);
@@ -321,6 +333,8 @@ enum CANAddress
     PLUG_IN_CONTROL_SYSTEM_TX = 0x745,
     PLUG_IN_CONTROL_SYSTEM_RX = 0x74D,
     HPCM_HYBRIDPTCTR_RX = 0x7EA,
+    BRAKE_EPB_TX = 0x7B0,    // Brake/EPB ECU (ABS/VSC/TRC + Electric Parking Brake) — direct-poll, standard ISO-TP
+    BRAKE_EPB_RX = 0x7B8,
     TPMS_GW_TX = 0x7502A,    // (0x750 << 8) | 0x2A  -> MsgID 0x750, sub 0x2A (ISOTP_EXTADR mixed addressing)
     TPMS_GW_RX = 0x7582A,    // (0x758 << 8) | 0x2A  -> MsgID 0x758, sub 0x2A
 };
@@ -385,6 +399,16 @@ enum CANPID
     PID_TPMS_PRESSURES = 0x1005,  // gateway 0x2A: 5x u16 [status][raw]; psi = raw*0.25 - 7.35
     PID_TPMS_TEMPS = 0x1004,      // gateway 0x2A: 5x u8;  C = raw - 40
     PID_TPMS_CORNERS = 0x2021,    // gateway 0x2A: 5x u8 corner enum (0 none/1 FL/2 FR/3 RL/4 RR)
+
+    // 2026-06-06 pins — EV ECU (0x7D2) driver-input signals
+    PID_THROTTLE = 0x1060,          // b1: accelerator position, u8 x0.5 %/LSB (0x00-0xC8 -> 0-100%)
+    PID_DRIVE_MODE_SELECT = 0x1004, // b1: Eco/Normal/Power enum. NOTE: same numeric value as PID_TPMS_TEMPS,
+                                    //     but dispatched on a different ECU (0x7DA vs TPMS gateway) so no conflict.
+    PID_AWD_MODE = 0x1087,          // b2: X-MODE/AWD status enum
+
+    // 2026-06-06 pins — Brake/EPB ECU (0x7B0) direct-poll
+    PID_BRAKE_PEDAL_STROKE = 0x104C, // b1: brake pedal stroke, u8 ~1 mm/LSB (0 rest .. ~67 full)
+    PID_EPB_STATUS = 0x1045,         // b1 = RH actuator status enum; handbrake applied = 0x00 (Park Applied)
 
 };
 


### PR DESCRIPTION
## Summary
Three related e-TNGA changes from this session:

**1. New driver-input metrics (driving), from solterra-can 2026-06-06 DID pins:**
- `v.e.throttle` ← 0x1060 b1 (EV ECU), u8 ×0.5 %
- `v.e.drivemode` ← 0x1004 b1 (EV ECU), 0=Normal/1=Power/6=Eco
- `xte.v.e.awd` (custom) ← 0x1087 b2 (EV ECU), X-MODE status
- `v.e.footbrake` ← 0x104C b1 (**Brake/EPB 0x7B0 — new poll target**), % mapped against captured 67 mm full-scale
- `v.e.handbrake` ← 0x1045 b1 (Brake/EPB), applied = 0x00

**2. Charge debug logging:** change-gated logging added to ~21 previously-silent metric setters (state-machine inputs acop/hlc/pisw-raw, charge enums, DC station/curve telemetry, RE raw values, capacity arrays).

**3. Charge state machine:** poll HLC (0x1666) and AC-op (0x1684) at 1s instead of 30s in CHARGE_WAIT so a delayed AC/DC start isn't caught up to 30s late.

## Verification
- Compile-only via GitHub CI (build.yml compiles SUBARU_SOLTERRA + TOYOTA_BZ4X, both e-TNGA variants).
- Not yet on-vehicle validated. Foot-brake 67 mm full-scale is one captured hard-press, may need retuning on-vehicle.