### PR TITLE
etnga: keep chargeport 'open' during charge states

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -80,8 +80,13 @@ void OvmsVehicleToyotaETNGA::ResetStaleMetrics() // Reset stale variables
         SetAwake(false);
     }
 
-    // Check to make sure the 'charging door' signal has been updated recently
-    if (StandardMetrics.ms_v_door_chargeport->IsStale() && StandardMetrics.ms_v_door_chargeport->AsBool()) {
+    // Check to make sure the 'charging door' signal has been updated recently.
+    // The lid (0x1625) is only polled in AWAKE+DRIVING, so in the charge states it
+    // reads stale even though the cable is physically holding the door open — don't
+    // force it off there, or the UI/server shows the port closed mid-charge. The arm
+    // logic in HandleAwakeState has already latched by then, so holding "open" is safe.
+    if (StandardMetrics.ms_v_door_chargeport->IsStale() && StandardMetrics.ms_v_door_chargeport->AsBool() &&
+            static_cast<PollState>(m_poll_state) < PollState::CHARGE_HANDSHAKE) {
         ESP_LOGD(TAG, "Charging Door is stale. Manually setting to off");
         SetChargingDoorStatus(false);
     }


### PR DESCRIPTION
## What

`ms_v_door_chargeport` is only polled in AWAKE+DRIVING (PID 0x1625, 10s cadence — see poll list in `vehicle_toyota_etnga.cpp`). On entering a charge state the metric goes stale within ~10s, and `ResetStaleMetrics` then forced it to **off** mid-session. The UI/server/app showed the charge port *closed* while the cable was plugged in and the car was actively charging.

Observed on 2026-06-09 during a DC fast-charge session:
```
13:31:19  Charging Door Status changed: Open (1)
13:31:27  Transitioning from the AWAKE to the CHARGE_HANDSHAKE state
13:31:30  Charging Door is stale. Manually setting to off   <-- this
13:31:40  Transitioning from CHARGE_HANDSHAKE to CHARGE_DC   (charge ran fine to 64%)
```

## Change

Gate the stale→off reset on poll state `< CHARGE_HANDSHAKE`, so the lid is only forced off in SLEEP/AWAKE/DRIVING. In the charge states the cable physically holds the door open and the lid is deliberately not polled, so holding "open" is correct.

## Why it's safe (display-only)

- Charge **entry** is PISW-driven, not door-driven — the door doesn't gate any charge transition.
- The charge-arm logic in `HandleAwakeState` has already latched `m_armed_for_charge` before this reset would fire, so it can't affect arming either.
- The door is re-polled within 10s on return to AWAKE, so the metric self-corrects after the session.

No `changes.txt` entry: plain display-accuracy fix, nothing for the user to act on.

## Validation

Builds via CI. Behavior (port reads "open" across a full session; nothing downstream keys off the door flipping closed) can only be fully confirmed on-vehicle during a real charge — **not yet on-vehicle validated.**