### PR TITLE
etnga web: DC charge monitor — Permitted shown positive + My Room energy

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -283,7 +283,10 @@ void OvmsVehicleToyotaETNGA::WebChgRenderDc(PageContext_t& c, OvmsVehicleToyotaE
         "<div class=\"clearfix\">"
           "<h6 class=\"metric-head\">Car</h6>"
           "<div class=\"metric number\" data-metric=\"v.c.power\" data-prec=\"3\"><span class=\"label\">Delivered</span><span class=\"value\">?</span><span class=\"unit\">kW</span></div>"
-          "<div class=\"metric number\" data-metric=\"xte.v.c.perm\" data-prec=\"2\"><span class=\"label\">Permitted</span><span class=\"value\">?</span><span class=\"unit\">kW</span></div>"
+          // Permitted is the |0x16A1| charge limit; the metric is stored signed (negative while
+          // charging), so it's updated from JS as an absolute value (id=permkw) like the chart does,
+          // rather than bound raw via data-metric — keeps the on-screen number positive.
+          "<div class=\"metric number\"><span class=\"label\">Permitted</span><span class=\"value\" id=\"permkw\">?</span><span class=\"unit\">kW</span></div>"
           "<div class=\"metric number\" data-metric=\"xte.v.c.tgti\" data-prec=\"0\"><span class=\"label\">Target</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
         "</div>"
 
@@ -298,6 +301,8 @@ void OvmsVehicleToyotaETNGA::WebChgRenderDc(PageContext_t& c, OvmsVehicleToyotaE
         "<div class=\"clearfix\">"
           "<h6 class=\"metric-head\">Session energy</h6>"
           "<div class=\"metric number\" data-metric=\"v.c.kwh\" data-prec=\"2\"><span class=\"label\">Charged</span><span class=\"value\">?</span><span class=\"unit\">kWh</span></div>"
+          // My-Room cabin energy integrates over both AC and DC sessions, so show it here too.
+          "<div class=\"metric number\" data-metric=\"xte.v.e.hvac.kwh\" data-prec=\"3\"><span class=\"label\">Cabin (My Room)</span><span class=\"value\">?</span><span class=\"unit\">kWh</span></div>"
         "</div>");
 }
 
@@ -349,17 +354,20 @@ void OvmsVehicleToyotaETNGA::WebChgChartJs(PageContext_t& c, OvmsVehicleToyotaET
         "      plotOptions:{series:{marker:{enabled:false}}},\n"
         "      series:series});\n"
         "  }\n"
+        "  var pm=null;\n"
+        "  function showPerm(){if(DC&&pm!=null)$('#permkw').text(Math.abs(pm).toFixed(2));}\n"
         "  function onUpd(){\n"
+        "    pm=mv('xte.v.c.perm'); showPerm();\n"   // update the Permitted panel field even before the chart builds
         "    if(!chart) return;\n"
         "    var t=baseT/60+(Date.now()/1000-loadT)/60;\n"
-        "    var d=mv('v.c.power'),sc=mv('v.b.soc'),pm=mv('xte.v.c.perm'),sm=mv('xte.v.c.stamaxp');\n"
+        "    var d=mv('v.c.power'),sc=mv('v.b.soc'),sm=mv('xte.v.c.stamaxp');\n"
         "    var cap=600, sidx=DC?3:2;\n"
         "    if(d!=null) chart.series[0].addPoint([t,d],false,chart.series[0].data.length>cap);\n"
         "    chart.series[1].addPoint([t,pm==null?0:Math.abs(pm)],false,chart.series[1].data.length>cap);\n"
         "    if(DC) chart.series[2].addPoint([t,sm==null?0:sm],false,chart.series[2].data.length>cap);\n"
         "    chart.series[sidx].addPoint([t,sc],true,chart.series[sidx].data.length>cap);\n"
         "  }\n"
-        "  function init(){build(); $('#chgmon').on('msg:metrics',onUpd);}\n"
+        "  function init(){build(); pm=mv('xte.v.c.perm'); showPerm(); $('#chgmon').on('msg:metrics',onUpd);}\n"
         "  if(window.Highcharts) init();\n"
         "  else $.ajax({url:window.assets.charts_js,dataType:'script',cache:true,success:init});\n"
         "})();\n"


### PR DESCRIPTION
## What

Two display fixes to the e-TNGA DC fast-charge monitor (`/xte/charge`):

1. **Permitted power read negative while charging.** The DC "Car" panel bound `xte.v.c.perm` raw via `data-metric`. That metric is the `|0x16A1|` charge limit stored **signed** (negative during charge, per the protocol's charge-direction convention) — only the live chart (`Math.abs(pm)`) and the report (`fabsf`) abs'd it, so this one panel field showed a confusing negative number.

2. **My Room accumulator missing on the DC screen.** The AC "Session energy" panel already shows `Cabin (My Room)` (`xte.v.e.hvac.kwh`), but the DC panel didn't — even though the integral is valid for both AC and DC.

## Change

- Convert the Permitted field to a JS-updated span (`id=permkw`) showing `Math.abs(pm)`, seeded in `init()` and refreshed on each `msg:metrics` (before the chart-ready guard). Mirrors the chart's existing handling.
- Add the `Cabin (My Room)` row to the DC Session energy panel.

## Why it's safe (display-only)

The stored metric, the per-second CSV log (`etnga_charge_report.cpp:256`), and the charge report all keep the **raw signed** value — host tooling that reads the CSV `perm` column is unaffected. Nothing in the state machine or data path changes; this only changes what the DC monitor renders.

Inline page JS (emitted from C++), so **no web-asset regeneration** is required. No `changes.txt` entry — minor UI tweaks, no user action needed.

## Validation

Builds via CI. Behavior (Permitted reads positive throughout a session; My Room row populates on DC) can only be fully confirmed on-vehicle during a real DC charge — **not yet on-vehicle validated.**