### PR TITLE
etnga: fix charge-session energy/report loss and 12V sleep-wake oscillation

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_can_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_can_processor.cpp
@@ -22,7 +22,9 @@ void OvmsVehicleToyotaETNGA::IncomingFrameCan2(CAN_frame_t* p_frame)
              p_frame->MsgID, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
 
     if (!m_allow_wake) {
-        ESP_LOGI(TAG, "OBD message ignored during cooldown");
+        // Verbose: this fires for EVERY frame received during a cooldown window — at
+        // parked-bus broadcast rates an INFO message here flooded the log.
+        ESP_LOGV(TAG, "OBD message ignored during cooldown");
     } else {
         SetAwake(true);
     }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -236,9 +236,14 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
 
     int now = StandardMetrics.ms_m_monotonic->AsInt();
     int elapsed = now - m_charge_session.start_monotonic;
+    // Ambient is undefined until the first in-charge 0x1F46 reply (~30 s in): write an
+    // empty field rather than 0.0, which is indistinguishable from a real 0 C reading.
+    char amb[16] = "";
+    if (StandardMetrics.ms_v_env_temp->IsDefined())
+        snprintf(amb, sizeof(amb), "%.1f", StandardMetrics.ms_v_env_temp->AsFloat());
     char row[256];
     snprintf(row, sizeof(row),
-        "%d,%.0f,%.3f,%.1f,%.1f,%.1f,%.1f,%s,"
+        "%d,%.0f,%.3f,%.1f,%.1f,%.1f,%s,%s,"
         "%.2f,%.0f,%.0f,%.2f,%.0f,%.3f,%.0f,%.0f\n",
         elapsed,
         StandardMetrics.ms_v_bat_soc->AsFloat(),
@@ -246,7 +251,7 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
         StandardMetrics.ms_v_bat_voltage->AsFloat(),
         StandardMetrics.ms_v_bat_current->AsFloat(),
         StandardMetrics.ms_v_bat_temp->AsFloat(),
-        StandardMetrics.ms_v_env_temp->AsFloat(),
+        amb,
         (m_charge_session.is_dc ? "DC" : "AC"),
         m_v_charge_sta_max_p->AsFloat(), m_v_charge_sta_max_i->AsFloat(), m_v_charge_sta_max_v->AsFloat(),
         m_v_charge_perm->AsFloat(), m_v_charge_tgti->AsFloat(),
@@ -270,8 +275,30 @@ void OvmsVehicleToyotaETNGA::FlushChargeCsv()
     std::ofstream f(m_charge_session.base + ".csv", m_charge_session.csv_file_created
         ? (std::ios::out | std::ios::app)
         : (std::ios::out | std::ios::trunc));
-    if (!f) return;
+    if (!f) {
+        // Can't open (SD removed/unmounted mid-charge?): keep the rows for retry, but
+        // bound the pending buffer — at ~100 B/row this otherwise grows without limit
+        // for the rest of the session (heap safety).
+        if (m_charge_session.csv_buf.size() > 16384) {
+            ESP_LOGE(TAG, "Charge CSV unwritable, buffer over limit — discarding buffered rows: %s.csv",
+                m_charge_session.base.c_str());
+            m_charge_session.csv_buf.clear();
+        }
+        return;
+    }
     f << m_charge_session.csv_buf;
+    f.flush();
+    if (f.fail()) {
+        // Keep the rows for the next attempt (disk full / SD hiccup) — clearing here
+        // silently lost them. last_csv_flush stays old, so retry on the next row.
+        ESP_LOGE(TAG, "Charge CSV write failed (disk full?): %s.csv", m_charge_session.base.c_str());
+        if (m_charge_session.csv_buf.size() > 16384) {
+            // Filesystem persistently unwritable: bound the pending buffer (heap safety).
+            ESP_LOGE(TAG, "Charge CSV buffer over limit — discarding buffered rows");
+            m_charge_session.csv_buf.clear();
+        }
+        return;
+    }
     m_charge_session.csv_buf.clear();
     m_charge_session.csv_file_created = true;
     m_charge_session.last_csv_flush = StandardMetrics.ms_m_monotonic->AsInt();
@@ -320,11 +347,15 @@ static void PruneChargeReports(const char* tag, const std::string& dir)
 //   - traces: delivered power, station-offered max (DC only) and car-permitted limit (the
 //     0x16A1 taper curve), plus the SOC overlay. All powers plot as magnitudes (0x16A1 is
 //     signed: negative = charging), so the three power traces share one positive axis.
-std::string OvmsVehicleToyotaETNGA::RenderPowerSvg()
+// Streams directly to the (already open) report file: a 300-sample DC session built a
+// ~25-30 KB contiguous std::string here, a needless heap spike on the ESP32.
+void OvmsVehicleToyotaETNGA::RenderPowerSvg(std::ostream& out)
 {
     const std::vector<ChargeSessionState::Sample>& s = m_charge_session.svg;
-    if (s.size() < 2)
-        return "<p>(not enough samples for a chart)</p>";
+    if (s.size() < 2) {
+        out << "<p>(not enough samples for a chart)</p>";
+        return;
+    }
 
     const bool  dc    = m_charge_session.is_dc;
     const float pmax  = dc ? 150.0f : 11.0f;   // fixed power-axis full scale (kW)
@@ -334,78 +365,76 @@ std::string OvmsVehicleToyotaETNGA::RenderPowerSvg()
     const int PW = W - PADL - PADR, PH = H - PADT - PADB;
     int tmax = s.back().t_s > 0 ? s.back().t_s : 1;
 
-    std::string out;
     char b[256];
     snprintf(b, sizeof(b), "<svg viewBox=\"0 0 %d %d\" style=\"width:100%%;max-width:%dpx;height:auto\" xmlns=\"http://www.w3.org/2000/svg\">\n", W, H, W);
-    out += b;
-    out += "<rect width=\"100%\" height=\"100%\" fill=\"#fff\"/>\n";
+    out << b;
+    out << "<rect width=\"100%\" height=\"100%\" fill=\"#fff\"/>\n";
 
     // Horizontal gridlines + left power-axis (kW) labels.
     for (float kw = 0.0f; kw <= pmax + 0.01f; kw += pstep) {
         float y = PADT + (float)PH * (1.0f - kw / pmax);
-        snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%.1f\" x2=\"%d\" y2=\"%.1f\" stroke=\"#eee\"/>\n", PADL, y, W-PADR, y); out += b;
-        snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%.1f\" font-size=\"10\" fill=\"#06c\" text-anchor=\"end\">%g</text>\n", PADL-3, y+3, kw); out += b;
+        snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%.1f\" x2=\"%d\" y2=\"%.1f\" stroke=\"#eee\"/>\n", PADL, y, W-PADR, y); out << b;
+        snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%.1f\" font-size=\"10\" fill=\"#06c\" text-anchor=\"end\">%g</text>\n", PADL-3, y+3, kw); out << b;
     }
     // Right SOC-axis (%) labels, fixed 0-100.
     for (int soc = 0; soc <= 100; soc += 25) {
         float y = PADT + (float)PH * (1.0f - soc / 100.0f);
-        snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%.1f\" font-size=\"10\" fill=\"#39c\">%d</text>\n", W-PADR+3, y+3, soc); out += b;
+        snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%.1f\" font-size=\"10\" fill=\"#39c\">%d</text>\n", W-PADR+3, y+3, soc); out << b;
     }
     // Axis lines (left power, right SOC, bottom time).
-    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, PADT, PADL, H-PADB); out += b;
-    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", W-PADR, PADT, W-PADR, H-PADB); out += b;
-    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, H-PADB, W-PADR, H-PADB); out += b;
+    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, PADT, PADL, H-PADB); out << b;
+    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", W-PADR, PADT, W-PADR, H-PADB); out << b;
+    snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, H-PADB, W-PADR, H-PADB); out << b;
 
     // SOC overlay (right axis, 0-100).
-    out += "<polyline fill=\"none\" stroke=\"#39c\" stroke-width=\"1\" stroke-dasharray=\"1 3\" points=\"";
+    out << "<polyline fill=\"none\" stroke=\"#39c\" stroke-width=\"1\" stroke-dasharray=\"1 3\" points=\"";
     for (size_t i = 0; i < s.size(); i++) {
         float x = PADL + (float)PW * s[i].t_s / tmax;
         float soc = s[i].soc < 0 ? 0.0f : (s[i].soc > 100 ? 100.0f : (float)s[i].soc);
         float y = PADT + (float)PH * (1.0f - soc / 100.0f);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
+        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
     }
-    out += "\"/>\n";
+    out << "\"/>\n";
 
     // Station-offered max (DC only — 0x166A is not polled on AC).
     if (dc) {
-        out += "<polyline fill=\"none\" stroke=\"#e80\" stroke-width=\"1\" stroke-dasharray=\"5 3\" points=\"";
+        out << "<polyline fill=\"none\" stroke=\"#e80\" stroke-width=\"1\" stroke-dasharray=\"5 3\" points=\"";
         for (size_t i = 0; i < s.size(); i++) {
             float x = PADL + (float)PW * s[i].t_s / tmax;
             float v = s[i].sta_max; if (v < 0) v = 0; if (v > pmax) v = pmax;
             float y = PADT + (float)PH * (1.0f - v / pmax);
-            snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
+            snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
         }
-        out += "\"/>\n";
+        out << "\"/>\n";
     }
 
     // Car-permitted limit (the BMS taper curve).
-    out += "<polyline fill=\"none\" stroke=\"#0a0\" stroke-width=\"1\" stroke-dasharray=\"5 3\" points=\"";
+    out << "<polyline fill=\"none\" stroke=\"#0a0\" stroke-width=\"1\" stroke-dasharray=\"5 3\" points=\"";
     for (size_t i = 0; i < s.size(); i++) {
         float x = PADL + (float)PW * s[i].t_s / tmax;
         float v = s[i].car_perm; if (v < 0) v = 0; if (v > pmax) v = pmax;
         float y = PADT + (float)PH * (1.0f - v / pmax);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
+        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
     }
-    out += "\"/>\n";
+    out << "\"/>\n";
 
     // Delivered power (primary trace).
-    out += "<polyline fill=\"none\" stroke=\"#06c\" stroke-width=\"2\" points=\"";
+    out << "<polyline fill=\"none\" stroke=\"#06c\" stroke-width=\"2\" points=\"";
     for (size_t i = 0; i < s.size(); i++) {
         float x = PADL + (float)PW * s[i].t_s / tmax;
         float v = s[i].kw; if (v < 0) v = 0; if (v > pmax) v = pmax;
         float y = PADT + (float)PH * (1.0f - v / pmax);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out += b;
+        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
     }
-    out += "\"/>\n";
+    out << "\"/>\n";
 
     // Legend (bottom).
     int ly = H - 6;
-    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#06c\">delivered kW</text>\n", PADL+6, ly); out += b;
-    if (dc) { snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#e80\">station max</text>\n", PADL+96, ly); out += b; }
-    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#0a0\">car permitted</text>\n", PADL+186, ly); out += b;
-    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#39c\">SOC %%</text>\n", PADL+282, ly); out += b;
-    out += "</svg>\n";
-    return out;
+    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#06c\">delivered kW</text>\n", PADL+6, ly); out << b;
+    if (dc) { snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#e80\">station max</text>\n", PADL+96, ly); out << b; }
+    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#0a0\">car permitted</text>\n", PADL+186, ly); out << b;
+    snprintf(b, sizeof(b), "<text x=\"%d\" y=\"%d\" font-size=\"10\" fill=\"#39c\">SOC %%</text>\n", PADL+282, ly); out << b;
+    out << "</svg>\n";
 }
 
 void OvmsVehicleToyotaETNGA::GenerateChargeReport()
@@ -493,7 +522,8 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     }
     f << "</dl>\n";
 
-    f << "<h2>Charging power</h2>\n" << RenderPowerSvg();
+    f << "<h2>Charging power</h2>\n";
+    RenderPowerSvg(f);
 
     f << "<h2>Session events</h2>\n<table><tr><th>Time</th><th>Event</th></tr>\n";
     for (size_t i = 0; i < m_charge_session.events.size(); i++) {
@@ -518,14 +548,23 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     {
         std::string csv = m_charge_session.base + ".csv";
         std::string name = csv.substr(csv.find_last_of('/') + 1);
-        f << "<p><a href=\"/xte/report?file=" << name << "\">Download per-sample CSV</a></p>\n";
+        // Include the storage location (the write side knows it) so WebChargeReport
+        // serves the right file without a fallback scan over every location.
+        const char* loc = (m_charge_session.base.compare(0, 4, "/sd/") == 0) ? "sd" : "store";
+        f << "<p><a href=\"/xte/report?file=" << name << "&amp;loc=" << loc
+          << "\">Download per-sample CSV</a></p>\n";
     }
 
     f << "<p class=\"note\">Generated on-module by OVMS (Toyota e-TNGA). Single-phase; avg power is over the "
          "whole plug-in interval. Estimates are provisional.</p>\n</body></html>\n";
     f.close();
-
-    ESP_LOGI(TAG, "Charge report written: %s.html (%.2f kWh, %d%%->%d%%)",
-        m_charge_session.base.c_str(), energy_kwh, start_soc, end_soc);
+    if (f.fail()) {
+        // The stream writes above are individually unchecked; surface a disk-full /
+        // truncated report here rather than logging success.
+        ESP_LOGE(TAG, "Charge report write failed (disk full?): %s.html", m_charge_session.base.c_str());
+    } else {
+        ESP_LOGI(TAG, "Charge report written: %s.html (%.2f kWh, %d%%->%d%%)",
+            m_charge_session.base.c_str(), energy_kwh, start_soc, end_soc);
+    }
     PruneChargeReports(TAG, ChargeReportDir());
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -204,7 +204,7 @@ bool OvmsVehicleToyotaETNGA::CalculateChargingDoorStatus(const std::string& data
     return GetRxBBit(data, 1, 1);
 }
 
-int OvmsVehicleToyotaETNGA::CalculateAcOpStatus(const std::string& data) { return GetRxBInt8(data, 0); }
+int OvmsVehicleToyotaETNGA::CalculateAcOpStatus(const std::string& data) { return GetRxBByte(data, 0); }
 void OvmsVehicleToyotaETNGA::SetAcOpStatus(int v)
 {
     if (m_v_charge_ac_op->SetValue(v))
@@ -232,7 +232,9 @@ void OvmsVehicleToyotaETNGA::SetHlcState(int v)
             LogChargeEvent(lbl);
     }
 }
-int OvmsVehicleToyotaETNGA::CalculatePISWRaw(const std::string& data) { return GetRxBInt8(data, 0); }
+// Unsigned byte: a signed read made codes >= 0x80 negative, silently failing the
+// state machine's `pisw >= 0x02` cable-present checks on any extended/error code.
+int OvmsVehicleToyotaETNGA::CalculatePISWRaw(const std::string& data) { return GetRxBByte(data, 0); }
 void OvmsVehicleToyotaETNGA::SetPISWRaw(int v)
 {
     if (m_v_charge_pisw_raw->SetValue(v))
@@ -509,7 +511,9 @@ int OvmsVehicleToyotaETNGA::CalculateChargeType(const std::string& data)
 
 float OvmsVehicleToyotaETNGA::CalculateHVACSetpoint(const std::string& data)
 {
-    int rawValue = GetRxBInt8(data, 0);
+    // Unsigned byte: the raw value is an enumerated code (0..255); a signed read sent
+    // codes >= 0x80 into the wrong piecewise branch as negatives.
+    int rawValue = GetRxBByte(data, 0);
     
     // Calculate the HVAC setpoint based on the piecewise function
     if (rawValue == 0) {
@@ -536,7 +540,7 @@ bool OvmsVehicleToyotaETNGA::CalculatePISWStatus(const std::string& data)
 {
     // 0x00 = None
     // 0x03 = Charging connector connected
-    return GetRxBInt8(data, 0);
+    return GetRxBByte(data, 0) != 0;
 }
 
 bool OvmsVehicleToyotaETNGA::CalculateReadyStatus(const std::string& data)
@@ -731,7 +735,7 @@ void OvmsVehicleToyotaETNGA::SetBatteryCellVoltageStatistics(const std::vector<f
     float averageVoltage = sum / voltages.size();
     float variance = 0.0f;
     for (float v : voltages) {
-        variance += pow(v - averageVoltage, 2);
+        variance += (v - averageVoltage) * (v - averageVoltage);
     }
     float standardDeviation = sqrt(variance / voltages.size());
 
@@ -771,7 +775,7 @@ void OvmsVehicleToyotaETNGA::SetBatteryTemperatureStatistics(const std::vector<f
         float maxTemperature = *std::max_element(temperatures.begin(), temperatures.end());
         float variance = 0.0f;
         for (float temperature : temperatures) {
-            variance += pow(temperature - averageTemperature, 2);
+            variance += (temperature - averageTemperature) * (temperature - averageTemperature);
         }
         float standardDeviation = sqrt(variance / temperatures.size());
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -65,6 +65,24 @@ void OvmsVehicleToyotaETNGA::IncomingPollReply(const OvmsPoller::poll_job_t &job
     }
 }
 
+void OvmsVehicleToyotaETNGA::IncomingPollError(const OvmsPoller::poll_job_t &job, int32_t code)
+{
+    // UDS negative responses and poll TX failures previously vanished silently.  Logged
+    // for diagnosis only (OBC lock-isolation NRCs, gateway refusals, and TX failures
+    // while the bus is wedged) — deliberately NO state/session action here; see the
+    // lock-isolation notes in HandleChargeAcState/HandleChargeDcState.
+    // A repeating identical error (e.g. one TX failure per poll on a wedged bus) logs
+    // at WARN once, then at debug level until the error signature changes.
+    // Non-overlapping fold: module low byte (bits 24-31), pid (8-23), code (0-7).
+    uint32_t sig = ((job.moduleid_rec & 0xFF) << 24) ^ ((job.pid & 0xFFFF) << 8) ^ (code & 0xFF);
+    if (sig != m_last_poll_error) {
+        m_last_poll_error = sig;
+        ESP_LOGW(TAG, "Poll error: module %03" PRIx32 " PID %04X code %d", job.moduleid_rec, job.pid, (int)code);
+    } else {
+        ESP_LOGD(TAG, "Poll error (repeat): module %03" PRIx32 " PID %04X code %d", job.moduleid_rec, job.pid, (int)code);
+    }
+}
+
 void OvmsVehicleToyotaETNGA::IncomingAirConditionerSystem(uint16_t pid)
 {
     switch (pid) {
@@ -252,6 +270,9 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
         }
 
         case PID_BATTERY_CHARGING_POWER: {
+            // Biased u16: a zero-filled short reply decodes as -327.68 kW and would be
+            // integrated into ms_v_charge_kwh — guard before the gate.
+            if (m_rxbuf.size() < 2) { ESP_LOGW(TAG, "Short reply for PID %04X (%d bytes)", pid, (int)m_rxbuf.size()); break; }
             // Only valid during AC or DC charging
             if (StandardMetrics.ms_v_charge_inprogress->AsBool()) {
                 float batteryChargingPower = CalculateBatteryChargingPower(m_rxbuf);
@@ -261,6 +282,8 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
         }
 
         case PID_CHARGER_INPUT_POWER: {
+            // Accumulates into the LIFETIME grid-energy total — guard against short replies.
+            if (m_rxbuf.size() < 2) { ESP_LOGW(TAG, "Short reply for PID %04X (%d bytes)", pid, (int)m_rxbuf.size()); break; }
             // Only valid during AC charging
             if (m_poll_state == PollState::CHARGE_AC) {
                 float chargerInputPower = CalculateChargerInputPower(m_rxbuf);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -49,19 +49,38 @@ void OvmsVehicleToyotaETNGA::HandleSleepState()
     if (StandardMetrics.ms_v_env_awake->AsBool()) {
         // There is life.
         TransitionToAwakeState();
-    } else if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > (StandardMetrics.ms_v_bat_12v_voltage_ref->AsFloat()+0.2f)) {
-        // Voltage is high. Maybe awake as well...
-        ESP_LOGI(TAG, "Aux 12V has exceeded the threshold");
-        // Real power-up — resume responsive cooldowns.
-        ResetSleepBackoff();
-        // Send a CAN reset.
-        esp_err_t result = m_can2->Reset();
-        if (result == ESP_OK) {
-            ESP_LOGI(TAG, "CAN bus reset successfully");
-        } else {
-            ESP_LOGE(TAG, "CAN bus reset failed, error code: %d", result);
+    } else {
+        // 12V wake is RISING-EDGE only. Level-triggering here oscillated: the post-drive/
+        // post-charge surface charge keeps 12V above ref+0.2 for a long time with a dead
+        // bus, so every SLEEP tick reset the backoff, reset the CAN controller and bounced
+        // to AWAKE — a ~2s SLEEP/AWAKE loop (one CAN reset per cycle) whose sleep re-entry
+        // also restarted the cooldown, so frame-wake never re-enabled until 12V decayed.
+        float v12 = StandardMetrics.ms_v_bat_12v_voltage->AsFloat();
+        float ref = StandardMetrics.ms_v_bat_12v_voltage_ref->AsFloat();
+        bool high = v12 > ref + 0.2f;
+        if (high && !m_12v_was_high) {
+            // Voltage just jumped: real power-up (DC-DC came on) — wake even during cooldown.
+            ESP_LOGI(TAG, "Aux 12V has exceeded the threshold");
+            ResetSleepBackoff();
+            // Send a CAN reset.
+            esp_err_t result = m_can2->Reset();
+            if (result == ESP_OK) {
+                ESP_LOGI(TAG, "CAN bus reset successfully");
+            } else {
+                ESP_LOGE(TAG, "CAN bus reset failed, error code: %d", result);
+            }
+            // Lift the cooldown gate so incoming CAN frames can hold us awake; without this
+            // a 12V wake during cooldown bounced straight back to sleep even with the
+            // vehicle genuinely on (IncomingFrameCan2 was still discarding frames).
+            m_allow_wake = true;
+            TransitionToAwakeState();
         }
-        TransitionToAwakeState();
+        // Hysteresis on the latch: set above ref+0.2, clear only below ref+0.1 — a level
+        // hovering at the threshold (ADC noise) must not produce repeated edges/CAN resets.
+        if (high)
+            m_12v_was_high = true;
+        else if (v12 < ref + 0.1f)
+            m_12v_was_high = false;
     }
 }
 
@@ -83,8 +102,13 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
         !m_v_charge_pisw_raw->IsStale() &&
         m_v_charge_pisw_raw->AsInt() == 0x00) {
         // Session ended while we slept (cable removed during the sleep gap).
+        // Close the session the same way TransitionToAwakeState does: flush + report.
+        // Resetting without the report silently discarded the whole session (and the
+        // streamed CSV was then deleted as an orphan by PruneChargeReports).
         ESP_LOGI(TAG, "Charge session ended during sleep — finalizing");
         StandardMetrics.ms_v_charge_state->SetValue("done");
+        LogChargeEvent("Unplugged (during sleep)");
+        GenerateChargeReport();   // flushes the CSV; no-op + stub-CSV cleanup if no energy delivered
         m_charge_session = ChargeSessionState{};
         // fall through to normal AWAKE handling
     }
@@ -105,8 +129,9 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
     int pisw = m_v_charge_pisw_raw->AsInt();
     bool lid_open = StandardMetrics.ms_v_door_chargeport->AsBool();
 
-    // pisw is fresh here mainly after a HANDSHAKE->AWAKE bounce (pisw not polled in
-    // plain AWAKE); cold cable-detect relies on the lid-open arm logic below.
+    // pisw is polled @5s in AWAKE (obdii_polls[]; also required by the wake-reconcile
+    // above), so a seated cable is detected here directly. The lid-open arm logic below
+    // only bounds how long we stay awake waiting for a plug-in.
     if (pisw >= 0x02) {
         // Cable is seated — enter charge handshake immediately
         TransitionToChargeHandshakeState();
@@ -259,6 +284,10 @@ void OvmsVehicleToyotaETNGA::TransitionToSleepState()
     m_sleep_entry_time = monotonic;
     m_sleep_cooldown_secs = SLEEP_COOLDOWN_SECS[m_sleep_backoff_idx];
     m_allow_wake = false;
+    // Seed the 12V edge latch from the current reading: entering sleep with 12V still
+    // elevated (post-drive/post-charge surface charge) must not count as a rising edge.
+    m_12v_was_high = StandardMetrics.ms_v_bat_12v_voltage->AsFloat()
+                     > (StandardMetrics.ms_v_bat_12v_voltage_ref->AsFloat() + 0.2f);
     if (m_sleep_backoff_idx < SLEEP_COOLDOWN_STEPS - 1)
         m_sleep_backoff_idx++;
     SetPollState(PollState::SLEEP);
@@ -320,6 +349,19 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
         m_charge_session.start_monotonic = StandardMetrics.ms_m_monotonic->AsInt();
         m_charge_session.start_utc = StandardMetrics.ms_m_timeutc->AsInt();
         m_charge_session.start_soc = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+        // Session energy counters reset HERE (session open), NOT in NotifyChargeStart:
+        // the framework fires that hook on every ms_v_charge_state change to "charging",
+        // including a CHARGE_WAIT pause/resume mid-session, which wiped the energy
+        // accumulated in earlier phases (and made the report's kWh phase-local).
+        StandardMetrics.ms_v_bat_energy_used->SetValue(0);
+        StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
+        lastBatteryEnergyLogTime = 0;
+        StandardMetrics.ms_v_charge_kwh->SetValue(0);
+        lastChargerEnergyLogTime = 0;
+        StandardMetrics.ms_v_charge_kwh_grid->SetValue(0);
+        lastGridEnergyLogTime = 0;
+        m_v_env_hvac_kwh->SetValue(0);
+        lastHvacEnergyLogTime = 0;
         if (StandardMetrics.ms_v_pos_gpslock->AsBool()) {
             m_charge_session.has_loc = true;
             m_charge_session.start_lat = StandardMetrics.ms_v_pos_latitude->AsFloat();
@@ -339,9 +381,9 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
         // basename = "<dir>/<UTC timestamp>" (no extension); files are <base>.html / <base>.csv
         {
             char ts[40];
-            int utc = m_charge_session.start_utc;
+            time_t utc = m_charge_session.start_utc;
             if (utc > 1000000000) {
-                time_t st = (time_t) utc; struct tm tmv; gmtime_r(&st, &tmv);
+                time_t st = utc; struct tm tmv; gmtime_r(&st, &tmv);
                 strftime(ts, sizeof(ts), "%Y%m%dT%H%M%SZ", &tmv);
             } else {
                 snprintf(ts, sizeof(ts), "charge-%d", m_charge_session.start_monotonic);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <dirent.h>
 #include <sys/stat.h>
 #include <string>
@@ -44,6 +45,28 @@ static std::vector<etnga_report_loc> etnga_report_locs()
         locs.push_back({ "sd", "/sd/charge-reports" });
     locs.push_back({ "store", "/store/charge-reports" });
     return locs;
+}
+
+// Percent-encode a string for use as a URL query-parameter value (RFC 3986 unreserved
+// characters pass through). encode_html() is the wrong codec for hrefs: current report
+// filenames are plain timestamps, but any future filename scheme with reserved
+// characters would silently produce broken links.
+static std::string etnga_url_encode(const std::string& s)
+{
+    static const char hex[] = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(s.size());
+    for (size_t i = 0; i < s.size(); i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            out += (char)c;
+        else {
+            out += '%';
+            out += hex[c >> 4];
+            out += hex[c & 0x0F];
+        }
+    }
+    return out;
 }
 
 // Map a location label back to its directory, or "" if the label is unknown.
@@ -470,13 +493,15 @@ void OvmsVehicleToyotaETNGA::WebChargeReports(PageEntry_t& p, PageContext_t& c)
         c.print("<ul class=\"list-unstyled\">");
         for (size_t i = 0; i < files.size(); i++) {
             const char* loc = files[i].second;
-            std::string html = c.encode_html(files[i].first);
             std::string stem = files[i].first.substr(0, files[i].first.size() - 5);   // strip ".html"
-            std::string csv  = c.encode_html(stem + ".csv");
+            // hrefs take URL-encoding; the visible link text takes HTML-encoding.
+            std::string html_url = etnga_url_encode(files[i].first);
+            std::string csv_url  = etnga_url_encode(stem + ".csv");
+            std::string html_txt = c.encode_html(files[i].first);
             c.printf("<li><a href=\"/xte/report?file=%s&amp;loc=%s\" target=\"_blank\">%s</a> "
                      "&nbsp;<a href=\"/xte/report?file=%s&amp;loc=%s\">csv</a> "
                      "<span class=\"text-muted\">[%s]</span></li>",
-                     html.c_str(), loc, html.c_str(), csv.c_str(), loc, loc);
+                     html_url.c_str(), loc, html_txt.c_str(), csv_url.c_str(), loc, loc);
         }
         c.print("</ul>");
     }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -158,27 +158,10 @@ void OvmsVehicleToyotaETNGA::NotifyVehicleOn()
     lastHvacDriveEnergyLogTime = 0;
 }
 
-void OvmsVehicleToyotaETNGA::NotifyChargeStart()
-{
-    ESP_LOGV(TAG, "Notification of charge start - Reset energy metrics for trip reporting");
-    // Vehicle started. Reset the trip statistics
-    StandardMetrics.ms_v_bat_energy_used->SetValue(0);
-    StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
-    lastBatteryEnergyLogTime = 0;
-    
-    StandardMetrics.ms_v_charge_kwh->SetValue(0);
-    lastChargerEnergyLogTime = 0;
-
-    StandardMetrics.ms_v_charge_kwh_grid->SetValue(0);
-    lastGridEnergyLogTime = 0;
-
-    m_v_env_hvac_kwh->SetValue(0);
-    lastHvacEnergyLogTime = 0;
-
-    // Standard framework behavior last: the base sends the "charge started" push
-    // notification, which should reflect the freshly reset session counters.
-    OvmsVehicle::NotifyChargeStart();
-}
+// NotifyChargeStart is deliberately NOT overridden: the framework fires it on every
+// ms_v_charge_state change to "charging" — including a CHARGE_WAIT pause/resume mid-
+// session — so resetting the session energy counters there wiped earlier phases.
+// The counters reset at session open in TransitionToChargeHandshakeState instead.
 
 void OvmsVehicleToyotaETNGA::Ticker1(uint32_t ticker)
 {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <iosfwd>
+#include <time.h>
 #include "vehicle.h"
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
@@ -47,6 +49,7 @@ public:
     void Ticker1(uint32_t ticker) override;
 
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
+    void IncomingPollError(const OvmsPoller::poll_job_t &job, int32_t code) override;
 
     void IncomingFrameCan2(CAN_frame_t* p_frame) override;
 
@@ -71,6 +74,8 @@ protected:
     int m_sleep_entry_time = 0;  // Used to track the time that cooldown timer started
     int m_sleep_cooldown_secs = 10;  // Cooldown window (s) for the current sleep; default must equal SLEEP_COOLDOWN_SECS[0]
     int m_sleep_backoff_idx = 0;     // Index into SLEEP_COOLDOWN_SECS; escalates on consecutive no-activity sleeps
+    bool m_12v_was_high = false;     // 12V-above-threshold latch: the SLEEP 12V wake fires on the rising edge only
+                                     // (level-triggering oscillated; seeded on each sleep entry in TransitionToSleepState)
 
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
     int  m_cable_watch_start = 0;      // monotonic s when armed (15-min cable watch)
@@ -80,7 +85,7 @@ protected:
         bool  in_session = false;
         int   start_monotonic = 0;
         int   start_soc = -1;
-        int   start_utc = 0;
+        time_t start_utc = 0;
         bool  is_dc = false;
         float peak_power = 0.0f;
         bool  temp_seen = false;
@@ -152,7 +157,8 @@ protected:
     OvmsMetricInt* m_v_e_awd;   // 0x1087 b2 AWD / X-MODE status (custom; no standard OVMS metric)
     
     void NotifyVehicleOn() override;
-    void NotifyChargeStart() override;
+    // NotifyChargeStart deliberately not overridden — see vehicle_toyota_etnga.cpp;
+    // session counters reset at session open in TransitionToChargeHandshakeState.
 
 private:
     static constexpr const char* TAG = "v-toyota-etnga";
@@ -166,12 +172,17 @@ private:
     uint32_t lastHvacEnergyLogTime = 0;
     uint32_t lastHvacDriveEnergyLogTime = 0;
 
+    // XOR-folded signature of the last poll error logged at WARN (module/pid/code — see
+    // IncomingPollError): repeats of the same error (e.g. one TX failure per poll while
+    // the bus is wedged) drop to debug level until the signature changes.
+    uint32_t m_last_poll_error = 0;
+
     void InitializeMetrics();  // Initializes the metrics specific to this vehicle module
     void ResetStaleMetrics();  // Checks if state transition metrics are stale (and resets them)
 
     // Charge session report (etnga_charge_report.cpp)
     void UpdateChargeSessionStats();   // live aggregation while charging (peak power, temp range, type)
-    std::string RenderPowerSvg();      // inline SVG power(+SOC)-vs-time chart from m_charge_session.svg
+    void RenderPowerSvg(std::ostream& out);  // stream the inline SVG power(+SOC)-vs-time chart from m_charge_session.svg
     void GenerateChargeReport();       // write the session-end HTML report to /store/charge-reports/
     void LogChargeEvent(const char* label);            // append a timestamped event
     void AppendChargeCsvRow();                          // buffer one CSV row (header on first call)


### PR DESCRIPTION
Second full-module review pass (follow-up to #104). All findings verified against framework behavior (`vehicle.cpp` NotifyChargeState dispatch, poller IncomingError paths) before fixing.

## Bug fixes

- **Charge kWh wiped on pause/resume**: the framework fires `NotifyChargeStart()` on every `ms_v_charge_state` change to "charging" (vehicle.cpp:2495) — including a CHARGE_WAIT pause/resume mid-session — so the override's counter resets discarded earlier-phase energy and made the report kWh phase-local. Resets moved to session open in `TransitionToChargeHandshakeState` (gated on `!in_session`); override removed.
- **Session ended during sleep lost its report**: the `HandleAwakeState` wake-reconcile reset `m_charge_session` without generating the report, and the streamed CSV was then deleted as an orphan by `PruneChargeReports`. The typical case is an overnight AC charge unplugged in the morning. Now closes via the same flush+report path as `TransitionToAwakeState`.
- **12V wake oscillation**: the SLEEP-state 12V wake was level-triggered and ignored the cooldown — while post-drive/post-charge 12V stayed above ref+0.2V with a dead bus, the module looped SLEEP→AWAKE every ~2s with a CAN controller reset per cycle, and the cooldown never re-armed frame-wake. Now rising-edge triggered (latch seeded on sleep entry, 0.1V hysteresis band) and a real edge lifts the cooldown gate so CAN frames can hold the module awake. *Possibly relevant to the recurring CAN2 RX wedge — the old loop issued a `m_can2->Reset()` every 2 seconds while parked.*
- **Short-reply guards** for `PID_BATTERY_CHARGING_POWER` / `PID_CHARGER_INPUT_POWER`: a zero-filled short reply decoded as −327.68 kW straight into `ms_v_charge_kwh` (and the lifetime grid total). Completes the guard pass from #104.
- **CSV/report write failures**: buffered CSV rows are no longer discarded when a flush fails (disk full / SD removed); pending buffer bounded at 16 KB on both the open-fail and write-fail paths. Truncated HTML report writes now log an error instead of success.
- **Unsigned decodes** for PISW raw / AC-Op / HVAC setpoint / PISW status: `GetRxBInt8` made codes ≥0x80 negative, silently failing the `pisw >= 0x02` cable-present checks. Note the intended semantic change: an unknown high PISW code now reads as cable-present (conservative — session teardown stays explicit on 0x00).

## Diagnostics & cleanups

- New `IncomingPollError` override: UDS NRCs and poll TX failures were silently swallowed; now WARN once per distinct (module, pid, code) signature, debug for repeats. TX failures fire when the bus is wedged, so this leaves a trace for the CAN2 wedge investigation.
- `RenderPowerSvg` streams to the report file instead of building a ~25 KB heap string; `pow(x,2)` → `x*x` in the 96-cell variance loops; per-frame cooldown log demoted to verbose (it flooded at bus broadcast rates); CSV ambient column blank while undefined instead of 0.0; report CSV link carries `&loc=`; report-index hrefs URL-encoded; `start_utc` int → `time_t`; stale PISW-polling comment corrected.

No `changes.txt` entry (bug fixes, no user action required).

## Validation

- Findings + fixes traced against `components/vehicle/vehicle.cpp` and `components/poller/` sources; independent reviewer pass on the diff (its one Important finding — the open-fail buffer cap — is included).
- Compile gate: GitHub CI on this PR.
- On-vehicle validation pending (module is currently on the bench): priority cases are a pause/resume AC session (kWh survives resume) and post-drive park (no SLEEP/AWAKE oscillation; later genuine wake still works).