### PR TITLE
etnga: split poll states into offset blocks (revert VEHICLE_POLL_NSTATES 7→4)

### DIFF
--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -38,11 +38,8 @@
 
 #define VEHICLE_POLL_TYPE_NONE          0x00
 
-// Number of polling states supported.
-// Bumped 4->7 for vehicle_toyota_etnga's charge sub-machine (CHARGE_HANDSHAKE/
-// WAIT/AC/DC = states 3-6). Other vehicles' shorter polltime[] initialisers
-// zero-fill the extra slots (no polling in states 4-6) — backward-safe.
-#define VEHICLE_POLL_NSTATES            7
+// Number of polling states supported
+#define VEHICLE_POLL_NSTATES            4
 
 // A note on "PID" and their sizes here:
 //  By "PID" for the service types we mean the part of the request parameters

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -28,9 +28,13 @@ Two parallel states
      - PID ``0x10D1`` on the Plug-In Control ECU
      - ``CS_NONE=0``, ``CS_DRIVING=1``, ``CS_CHARGING=3``
 
-``PollState`` selects which PIDs are polled — see the seven-column
-``obdii_polls[]`` table in ``vehicle_toyota_etnga.cpp`` (documented in
-:doc:`index` under "PID Polling Logic").
+``PollState`` selects which PIDs are polled.  Because a poll list supports only
+``VEHICLE_POLL_NSTATES`` (4) states, the seven states are split across two poll
+series in ``vehicle_toyota_etnga.cpp``: ``obdii_polls_base`` (offset 0, the
+non-charge states ``SLEEP``/``AWAKE``/``DRIVING``) and ``obdii_polls_charge``
+(offset 3, the four charge states ``CHARGE_HANDSHAKE``..``CHARGE_DC``).  PIDs
+polled in both a non-charge and a charge state appear in both tables.  See
+:doc:`index` under "PID Polling Logic".
 ``ControlState`` is the vehicle's own self-report and is the primary trigger
 for the ``AWAKE → DRIVING`` edge.
 
@@ -151,7 +155,7 @@ Practical consequences:
   next poll reply after the forced ``TransitionToSleepState`` would
   immediately bounce the driver back to ``AWAKE``.
 * Any future change that reduces poll throttling, adds more PIDs to the
-  ``A`` column of ``obdii_polls[]``, or shortens the watchdog needs to
+  ``AWAKE`` column of ``obdii_polls_base[]``, or shortens the watchdog needs to
   consider whether it could keep a quiescent vehicle awake long enough
   to drain the 12 V battery.
 
@@ -376,7 +380,7 @@ metric is fresh (non-stale) *and* PISW reports ``0x00`` (unconnected),
 the cable was removed during the sleep gap — the driver finalises the
 session immediately (sets ``ms_v_charge_state = "done"`` and resets
 ``m_charge_session``).  The AWAKE-column PISW poll (DID ``0x1669``) in
-``obdii_polls[]`` is required for this reconcile to fire — removing it
+``obdii_polls_base[]`` is required for this reconcile to fire — removing it
 would silently break the wake-reconcile path.
 
 Charge curve & station metrics

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -93,7 +93,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
     // Guard: only act on a non-stale PISW value to avoid the ~30s OBC post-wake transient
     // where PISW may briefly report 0x00 before the OBC fully wakes.
     // REGRESSION DEPENDENCY: this requires PID_PISW_STATUS to be polled in the AWAKE
-    // column (obdii_polls[] in vehicle_toyota_etnga.cpp, AWAKE=5s). Without an AWAKE poll
+    // column (obdii_polls_base[] in vehicle_toyota_etnga.cpp, AWAKE=5s). Without an AWAKE poll
     // the cached PISW value is stale (gap >120s) or the pre-sleep connected value
     // (gap <120s), so a fresh 0x00 never arrives and this reconcile can NEVER fire —
     // leaking in_session and blocking the next session's open-guard. Do not remove the
@@ -129,7 +129,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
     int pisw = m_v_charge_pisw_raw->AsInt();
     bool lid_open = StandardMetrics.ms_v_door_chargeport->AsBool();
 
-    // pisw is polled @5s in AWAKE (obdii_polls[]; also required by the wake-reconcile
+    // pisw is polled @5s in AWAKE (obdii_polls_base[]; also required by the wake-reconcile
     // above), so a seated cable is detected here directly. The lid-open arm logic below
     // only bounds how long we stay awake waiting for a plug-in.
     if (pisw >= 0x02) {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -20,89 +20,119 @@
 //    CHARGE_WAIT (4)       : Plugged in, not (yet/any longer) charging — sparse poll
 //    CHARGE_AC (5)         : AC charging in progress
 //    CHARGE_DC (6)         : DC fast charging in progress
+//
+// A poll list supports only VEHICLE_POLL_NSTATES (4) states, so the 7 states are
+// split across two poll series ("blocks"), each polled by the framework according
+// to its state offset (see OvmsPoller::StandardPollSeries::NextPollEntry):
+//
+//    obdii_polls_base   : offset 0  -> columns map to states 0..3 (SLEEP/AWAKE/DRIVING/-)
+//    obdii_polls_charge : offset 3  -> columns map to states 3..6 (HANDSHAKE/WAIT/AC/DC)
+//
+// This mirrors the Hyundai Ioniq5 secondary-series pattern. PIDs that poll in both a
+// non-charge state and a charge state (battery SOC/V-I/temp/voltage, capacity arrays,
+// ctrl-mode, PISW) appear in BOTH tables, each carrying only its side's cadences.
 
-static const OvmsPoller::poll_pid_t obdii_polls[] = {
-    // Column layout: { SLEEP, AWAKE, DRIVING, CHARGE_HANDSHAKE, CHARGE_WAIT, CHARGE_AC, CHARGE_DC }
-    // Charge columns (indices 3-6) tuned from sim POLLS dict in bin/ovms-sim.py.
+// --- Block A: non-charge states. Offset 0; columns { SLEEP, AWAKE, DRIVING, (unused) }.
+// Column 3 maps to CHARGE_HANDSHAKE and MUST stay 0 here — block B owns the charge
+// states, and a nonzero here would double-poll during handshake.
+static const OvmsPoller::poll_pid_t obdii_polls_base[] = {
+    // Column layout: { SLEEP, AWAKE, DRIVING, - }
 
     // State variables polls
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CONTROL_SYSTEM_MODE,       { 0,  1, 1,  1,  1,  1,  1}, 0, ISOTP_STD }, // 0x10D1 ctrl-mode: all active states @1s (sim: all states)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_LID,              { 0, 10, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1625 charge lid: AWAKE+DRIVING only (sim: not in charge states)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CONTROL_SYSTEM_MODE,        { 0,  1,  1, 0}, 0, ISOTP_STD }, // 0x10D1 ctrl-mode: AWAKE+DRIVING @1s (also block B)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_LID,               { 0, 10, 10, 0}, 0, ISOTP_STD }, // 0x1625 charge lid: AWAKE+DRIVING only
 
-    // Combined polls
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_SOC,               { 0,  0, 1,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x1738 SOC: DRIVING+AC+DC @1s (sim: absent in HS/WAIT)
-  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_SOC_BMS,           { 0,  0, 1,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x1F5B BMS SOC: mirrors PID_BATTERY_SOC pattern (not in sim but module-local)
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_READY_SIGNAL,              { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1076 ready signal: DRIVING only (sim: not in charge states)
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_VOLTAGE_AND_CURRENT,{ 0, 0, 1,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x1F9A pack I: DRIVING+AC+DC @1s (sim: DID_PACK_I AC=1,DC=1)
-  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_TEMPERATURES,      { 0,  0, 10, 0,  0,  0, 20}, 0, ISOTP_STD }, // 0x1814 cell-temp array: DRIVING@10s, DC@20s (sim: DC=20 only)
-  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CELL_VOLTAGES,     { 0,  0, 5,  0,  0,  0, 30}, 0, ISOTP_STD }, // 0x182E cell voltages: DRIVING@5s, DC@30s (sim: DC=30 only)
+    // Combined (battery) polls — also polled in charge (block B)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_SOC,                { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1738 SOC: DRIVING @1s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_SOC_BMS,            { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1F5B BMS SOC: DRIVING @1s
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_READY_SIGNAL,               { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1076 ready signal: DRIVING only
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_VOLTAGE_AND_CURRENT,{ 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1F9A pack I: DRIVING @1s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_TEMPERATURES,       { 0,  0, 10, 0}, 0, ISOTP_STD }, // 0x1814 cell-temp array: DRIVING @10s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CELL_VOLTAGES,      { 0,  0,  5, 0}, 0, ISOTP_STD }, // 0x182E cell voltages: DRIVING @5s
 
-    // Capacity arrays (data-collection only) — near-static, recalibrate over charge cycles; sampled at rest, driving, and both charge phases to watch drift
-  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY,          { 0, 60, 120, 0,  0, 60, 60}, 0, ISOTP_STD }, // 0x1D3E 8x per-module full-charge capacity (Ah)
-  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY_ALT,      { 0, 60, 120, 0,  0, 60, 60}, 0, ISOTP_STD }, // 0x1D3F 8x parallel capacity array, function unconfirmed
+    // Capacity arrays (data-collection only) — also polled in charge (block B)
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY,           { 0, 60,120, 0}, 0, ISOTP_STD }, // 0x1D3E 8x per-module full-charge capacity (Ah)
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY_ALT,       { 0, 60,120, 0}, 0, ISOTP_STD }, // 0x1D3F 8x parallel capacity array, function unconfirmed
 
     // Driving polls
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_VEHICLE_SPEED,             { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1F0D speed: DRIVING only
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_SHIFT_POSITION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1061 gear: DRIVING only
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_ODOMETER,                  { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1FA6 odometer: DRIVING only
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,            { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @1s (matches battery V/I for the cabin-energy integrator)
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_THROTTLE,                  { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1060 b1 accelerator position: DRIVING@1s (v.e.throttle)
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_DRIVE_MODE_SELECT,         { 0,  0, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1004 b1 drive mode (Eco/Normal/Power): DRIVING@5s (v.e.drivemode)
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AWD_MODE,                  { 0,  0, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1087 b2 AWD/X-MODE status: DRIVING@5s (xte.v.e.awd)
-  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE,       { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1002 ambient temp: DRIVING only
-  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_CABIN_TEMPERATURE,         { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1001 cabin temp: DRIVING only
-  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HVAC_SETPOINT,             { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1036 HVAC setpoint: DRIVING only
-  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HEATER_POWER,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1086 HV heater power: DRIVING only (>0 => v.e.heating)
-  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_BLOWER_LEVEL,              { 0,  0, 10, 0,  0,  0,  0}, 0, ISOTP_STD }, // 0x2801 blower level 1-7: DRIVING only (=> v.e.cabinfan %)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_VEHICLE_SPEED,              { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1F0D speed: DRIVING only
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_SHIFT_POSITION,             { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1061 gear: DRIVING only
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_ODOMETER,                   { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1FA6 odometer: DRIVING only
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,             { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x106E HVAC power (hybrid control): DRIVING @1s (cabin-energy integrator)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_THROTTLE,                   { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1060 b1 accelerator position: DRIVING @1s (v.e.throttle)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_DRIVE_MODE_SELECT,          { 0,  0,  5, 0}, 0, ISOTP_STD }, // 0x1004 b1 drive mode (Eco/Normal/Power): DRIVING @5s (v.e.drivemode)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AWD_MODE,                   { 0,  0,  5, 0}, 0, ISOTP_STD }, // 0x1087 b2 AWD/X-MODE status: DRIVING @5s (xte.v.e.awd)
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE,        { 0,  0, 10, 0}, 0, ISOTP_STD }, // 0x1002 ambient temp: DRIVING only
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_CABIN_TEMPERATURE,          { 0,  0, 10, 0}, 0, ISOTP_STD }, // 0x1001 cabin temp: DRIVING only
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HVAC_SETPOINT,              { 0,  0, 10, 0}, 0, ISOTP_STD }, // 0x1036 HVAC setpoint: DRIVING only
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_HEATER_POWER,               { 0,  0, 10, 0}, 0, ISOTP_STD }, // 0x1086 HV heater power: DRIVING only (>0 => v.e.heating)
+  { AIR_CONDITIONER_TX,        AIR_CONDITIONER_RX,        VEHICLE_POLL_TYPE_READDATA, PID_BLOWER_LEVEL,               { 0,  0, 10, 0}, 0, ISOTP_STD }, // 0x2801 blower level 1-7: DRIVING only (=> v.e.cabinfan %)
 
-    // Chassis / driver inputs — Brake/EPB ECU (0x7B0), direct-poll standard ISO-TP (new target 2026-06-06)
+    // Chassis / driver inputs — Brake/EPB ECU (0x7B0), direct-poll standard ISO-TP.
     // EPB stays alive in the parked body tail, so park-brake is polled in AWAKE too; foot-brake is DRIVING-only.
-  { BRAKE_EPB_TX,              BRAKE_EPB_RX,              VEHICLE_POLL_TYPE_READDATA, PID_BRAKE_PEDAL_STROKE,        { 0,  0, 1,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x104C b1 brake pedal stroke: DRIVING@1s (v.e.footbrake)
-  { BRAKE_EPB_TX,              BRAKE_EPB_RX,              VEHICLE_POLL_TYPE_READDATA, PID_EPB_STATUS,                { 0,  5, 5,  0,  0,  0,  0}, 0, ISOTP_STD }, // 0x1045 b1 EPB actuator status: AWAKE+DRIVING@5s (v.e.handbrake)
+  { BRAKE_EPB_TX,              BRAKE_EPB_RX,              VEHICLE_POLL_TYPE_READDATA, PID_BRAKE_PEDAL_STROKE,         { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x104C b1 brake pedal stroke: DRIVING @1s (v.e.footbrake)
+  { BRAKE_EPB_TX,              BRAKE_EPB_RX,              VEHICLE_POLL_TYPE_READDATA, PID_EPB_STATUS,                 { 0,  5,  5, 0}, 0, ISOTP_STD }, // 0x1045 b1 EPB actuator status: AWAKE+DRIVING @5s (v.e.handbrake)
+
+    // PISW — AWAKE keep-alive side only (charge cadences live in block B).
+    // AWAKE @5s is required by the wake-reconcile (see etnga_poll_states.cpp).
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_PISW_STATUS,                { 0,  5,  0, 0}, 0, ISOTP_STD }, // 0x1669 PISW: AWAKE @5s
+
+    // TPMS — gateway-relayed (0x750 sub-target 0x2A) via ISOTP_EXTADR; DRIVING @60s
+    // (0x2A only answers while driving/My-Room — asleep parked & during charging it just times out)
+  { TPMS_GW_TX, TPMS_GW_RX, VEHICLE_POLL_TYPE_READDATA, PID_TPMS_CORNERS,   { 0,  0, 60, 0}, 0, ISOTP_EXTADR }, // 0x2021 slot->corner map
+  { TPMS_GW_TX, TPMS_GW_RX, VEHICLE_POLL_TYPE_READDATA, PID_TPMS_PRESSURES, { 0,  0, 60, 0}, 0, ISOTP_EXTADR }, // 0x1005 pressures (kPa)
+  { TPMS_GW_TX, TPMS_GW_RX, VEHICLE_POLL_TYPE_READDATA, PID_TPMS_TEMPS,     { 0,  0, 60, 0}, 0, ISOTP_EXTADR }, // 0x1004 temperatures (C)
+
+    POLL_LIST_END
+};
+
+// --- Block B: charge states. Registered with state offset CHARGE_HANDSHAKE (3), so its
+// four columns map to states 3..6. Cadences tuned from sim POLLS dict in bin/ovms-sim.py.
+static const OvmsPoller::poll_pid_t obdii_polls_charge[] = {
+    // Column layout: { CHARGE_HANDSHAKE, CHARGE_WAIT, CHARGE_AC, CHARGE_DC }
+
+    // Battery / combined polls — duplicated from block A with charge-side cadences
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CONTROL_SYSTEM_MODE,        { 1,  1,  1,  1}, 0, ISOTP_STD }, // 0x10D1 ctrl-mode: all charge @1s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_SOC,                { 0,  0,  1,  1}, 0, ISOTP_STD }, // 0x1738 SOC: AC+DC @1s (absent in HS/WAIT)
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_SOC_BMS,            { 0,  0,  1,  1}, 0, ISOTP_STD }, // 0x1F5B BMS SOC: AC+DC @1s
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_VOLTAGE_AND_CURRENT,{ 0,  0,  1,  1}, 0, ISOTP_STD }, // 0x1F9A pack I: AC+DC @1s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_TEMPERATURES,       { 0,  0,  0, 20}, 0, ISOTP_STD }, // 0x1814 cell-temp array: DC @20s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CELL_VOLTAGES,      { 0,  0,  0, 30}, 0, ISOTP_STD }, // 0x182E cell voltages: DC @30s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY,           { 0,  0, 60, 60}, 0, ISOTP_STD }, // 0x1D3E per-module capacity: AC+DC @60s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY_ALT,       { 0,  0, 60, 60}, 0, ISOTP_STD }, // 0x1D3F parallel capacity array: AC+DC @60s
 
     // Charging polls — state-machine DIDs
-  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,   { 0,  0, 0, 30, 30, 30, 30}, 0, ISOTP_STD }, // 0x1F46 ambient via HCS (awake during charge): HS/WAIT/AC/DC @30s — the A/C 0x1002 ambient is DRIVING-only (HVAC ECU sleeps while charging), so the charge report had no ambient source
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_PISW_STATUS,              { 0,  5, 0,  1, 30, 10, 10}, 0, ISOTP_STD }, // 0x1669 PISW: AWAKE=5 (Task 5); HS=1,WAIT=30,AC=10,DC=10 (sim)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_VOLTAGE_TYPE,    { 0,  0, 0,  5,  0,  0,  0}, 0, ISOTP_STD }, // 0x161C VTYPE: HS=5s only (sim: HANDSHAKE=5, absent elsewhere)
+  { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_AMBIENT_TEMPERATURE_EV,     {30, 30, 30, 30}, 0, ISOTP_STD }, // 0x1F46 ambient via HCS: all charge @30s (A/C ambient is DRIVING-only)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_PISW_STATUS,                { 1, 30, 10, 10}, 0, ISOTP_STD }, // 0x1669 PISW: HS=1,WAIT=30,AC=10,DC=10
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_VOLTAGE_TYPE,      { 5,  0,  0,  0}, 0, ISOTP_STD }, // 0x161C VTYPE: HS=5s only
 
-//  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_CONTROL_INFORMATION, { 0, 0, 0, 1, 1, 1, 1}, 0, ISOTP_STD }, // 0x1689 deferred
+//  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGING_CONTROL_INFORMATION, { 1, 1, 1, 1}, 0, ISOTP_STD }, // 0x1689 deferred
 
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_CHARGING_OP_STATUS,    { 0,  0, 0,  1,  1,  1,  1}, 0, ISOTP_STD }, // 0x1684 AC op: HS=1,WAIT=1 (catch AC engage promptly),AC=1,DC=1
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_HLC_STATE,                { 0,  0, 0,  1,  1,  0,  1}, 0, ISOTP_STD }, // 0x1666 HLC: HS=1,WAIT=1 (catch DC engage promptly),AC=0 (not needed),DC=1
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_MIN_PERMISSION_POWER,     { 0,  0, 0,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x16A1 perm power (curve): AC+DC=1s (sim DID_PERM_PWR)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_TARGET_CHARGING_CURRENT,  { 0,  0, 0,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x166D target current: AC+DC=1s (sim DID_TGT_CUR)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CHARGING_POWER,   { 0,  0, 0,  0,  0,  1,  1}, 0, ISOTP_STD }, // 0x10D4 batt power: AC+DC=1s (sim); handler gated on charge-in-progress
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGER_INPUT_POWER,      { 0,  0, 0,  0,  0,  5,  5}, 0, ISOTP_STD }, // 0x161D grid power: AC+DC=5s (sim); handler gated on AC charge
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_CHARGING_OP_STATUS,      { 1,  1,  1,  1}, 0, ISOTP_STD }, // 0x1684 AC op: HS=1,WAIT=1,AC=1,DC=1 (catch AC engage promptly)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_HLC_STATE,                  { 1,  1,  0,  1}, 0, ISOTP_STD }, // 0x1666 HLC: HS=1,WAIT=1 (catch DC engage),AC=0,DC=1
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_MIN_PERMISSION_POWER,       { 0,  0,  1,  1}, 0, ISOTP_STD }, // 0x16A1 perm power (curve): AC+DC @1s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_TARGET_CHARGING_CURRENT,    { 0,  0,  1,  1}, 0, ISOTP_STD }, // 0x166D target current: AC+DC @1s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CHARGING_POWER,     { 0,  0,  1,  1}, 0, ISOTP_STD }, // 0x10D4 batt power: AC+DC @1s (handler gated on charge-in-progress)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGER_INPUT_POWER,        { 0,  0,  5,  5}, 0, ISOTP_STD }, // 0x161D grid power: AC+DC @5s (handler gated on AC charge)
 
   // DC station telemetry — present V/I (DC=1s) drive standard ms_v_charge_voltage/current; max P/I/V (DC=5s) are the station caps
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_PRESENT_CURRENT,{ 0, 0, 0,  0,  0,  0,  1}, 0, ISOTP_STD }, // 0x166C DC station A: DC=1s (sim DID_STA_A)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_PRESENT_VOLTAGE,{ 0, 0, 0,  0,  0,  0,  1}, 0, ISOTP_STD }, // 0x166B DC station V: DC=1s (sim DID_STA_V)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_MAX_POWER,      { 0,  0, 0,  0,  0,  0,  5}, 0, ISOTP_STD }, // 0x166A station max power: DC=5s (sim DID_STA_MAX_P)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_MAX_CURRENT,    { 0,  0, 0,  0,  0,  0,  5}, 0, ISOTP_STD }, // 0x1679 station max current: DC=5s (sim DID_STA_MAX_A)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_MAX_VOLTAGE,    { 0,  0, 0,  0,  0,  0,  5}, 0, ISOTP_STD }, // 0x1681 station max voltage: DC=5s (sim DID_STA_MAX_V)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_PRESENT_CURRENT, { 0,  0,  0,  1}, 0, ISOTP_STD }, // 0x166C DC station A: DC @1s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_PRESENT_VOLTAGE, { 0,  0,  0,  1}, 0, ISOTP_STD }, // 0x166B DC station V: DC @1s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_MAX_POWER,       { 0,  0,  0,  5}, 0, ISOTP_STD }, // 0x166A station max power: DC @5s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_MAX_CURRENT,     { 0,  0,  0,  5}, 0, ISOTP_STD }, // 0x1679 station max current: DC @5s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_DC_CHARGER_MAX_VOLTAGE,     { 0,  0,  0,  5}, 0, ISOTP_STD }, // 0x1681 station max voltage: DC @5s
 
   // AC charger telemetry — AC-only (scaled per Techstream dictionary; 0x161E/0x1665 units inferred, confirm on sustained AC)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGER_STATE_CLUSTER,     { 0,  0, 0,  0,  0,  1,  0}, 0, ISOTP_STD }, // 0x1619 charger state cluster: AC=1s (sim DID_CHG_STATE; AC-only)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGER_OUTPUT_POWER,      { 0,  0, 0,  0,  0,  5,  0}, 0, ISOTP_STD }, // 0x161E charger output cluster: AC=5s (sim DID_CHG_OUT_P; AC-only)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_USABLE_POWER,           { 0,  0, 0,  0,  0,  5,  0}, 0, ISOTP_STD }, // 0x1665 A/C useable power: AC=5s (sim DID_AC_USABLE; AC-only)
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGER_STATE_CLUSTER,      { 0,  0,  1,  0}, 0, ISOTP_STD }, // 0x1619 charger state cluster: AC @1s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGER_OUTPUT_POWER,       { 0,  0,  5,  0}, 0, ISOTP_STD }, // 0x161E charger output cluster: AC @5s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_USABLE_POWER,            { 0,  0,  5,  0}, 0, ISOTP_STD }, // 0x1665 A/C useable power: AC @5s
 
-  // Charge-report supporting channels (increment 2) — My Room, A/C power, outcome, stop-request
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_MYROOM,            { 0,  0, 0,  0,  0,  5,  5}, 0, ISOTP_STD }, // 0x1692 My Room flag: AC+DC=5s (sim DID_MYROOM)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,    { 0,  0, 0,  0,  0,  2,  2}, 0, ISOTP_STD }, // 0x106E A/C consumption power: AC+DC=2s (sim DID_AC_CONS_P)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGE_HISTORY,    { 0,  0, 0,  5, 10,  5,  5}, 0, ISOTP_STD }, // 0x1688 outcome/history: HS=5,WAIT=10,AC=5,DC=5 (sim DID_HISTORY)
-  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGE_STOP_REQ,   { 0,  0, 0,  1, 30,  5,  5}, 0, ISOTP_STD }, // 0x1667 stop-request: HS=1,WAIT=30,AC=5,DC=5 (sim DID_STOP_REQ)
+  // Charge-report supporting channels — My Room, A/C power, outcome, stop-request
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_MYROOM,                     { 0,  0,  5,  5}, 0, ISOTP_STD }, // 0x1692 My Room flag: AC+DC @5s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_AC_CONSUMPTION,             { 0,  0,  2,  2}, 0, ISOTP_STD }, // 0x106E A/C consumption power (PICS): AC+DC @2s
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGE_HISTORY,             { 5, 10,  5,  5}, 0, ISOTP_STD }, // 0x1688 outcome/history: HS=5,WAIT=10,AC=5,DC=5
+  { PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_CHARGE_STOP_REQ,            { 1, 30,  5,  5}, 0, ISOTP_STD }, // 0x1667 stop-request: HS=1,WAIT=30,AC=5,DC=5
 
-  // TPMS — gateway-relayed (0x750 sub-target 0x2A) via ISOTP_EXTADR; DRIVING @ 60s
-  // (0x2A only answers while driving/My-Room — asleep parked & during charging, per the 2026-06-03 gateway census — so AWAKE polls just timed out)
-  { TPMS_GW_TX, TPMS_GW_RX, VEHICLE_POLL_TYPE_READDATA, PID_TPMS_CORNERS,    { 0,  0, 60, 0, 0, 0, 0}, 0, ISOTP_EXTADR }, // 0x2021 slot->corner map
-  { TPMS_GW_TX, TPMS_GW_RX, VEHICLE_POLL_TYPE_READDATA, PID_TPMS_PRESSURES, { 0,  0, 60, 0, 0, 0, 0}, 0, ISOTP_EXTADR }, // 0x1005 pressures (kPa)
-  { TPMS_GW_TX, TPMS_GW_RX, VEHICLE_POLL_TYPE_READDATA, PID_TPMS_TEMPS,     { 0,  0, 60, 0, 0, 0, 0}, 0, ISOTP_EXTADR }, // 0x1004 temperatures (C)
-
-    // Tester Present
-  //{ PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_TESTERPRESENT, 0, { 0, 2, 2, 2}, 0, ISOTP_STD },
-  //{ HYBRID_CONTROL_SYSTEM_TX, HYBRID_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_ACTIVE_DIAGNOSTIC_SESSION, { 0, 2, 2, 2}, 0, ISOTP_STD },
-  //{ HYBRID_BATTERY_SYSTEM_TX, HYBRID_BATTERY_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_ACTIVE_DIAGNOSTIC_SESSION, { 0, 2, 2, 2}, 0, ISOTP_STD },
-  //{ PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX, VEHICLE_POLL_TYPE_READDATA, PID_ACTIVE_DIAGNOSTIC_SESSION, { 0, 2, 2, 2}, 0, ISOTP_STD },
     POLL_LIST_END
 };
 
@@ -123,8 +153,17 @@ OvmsVehicleToyotaETNGA::OvmsVehicleToyotaETNGA()
     SetPollState(PollState::SLEEP);
     SetAwake(false);
 
-    // Set polling PID list
-    PollSetPidList(m_can2, obdii_polls);
+    // Set polling PID lists. Block A (offset 0) is the default series covering the
+    // non-charge states; block B is registered as a second series offset to the first
+    // charge state so its 4 columns map to states CHARGE_HANDSHAKE..CHARGE_DC.
+    PollSetPidList(m_can2, obdii_polls_base);
+
+    auto charge_series = std::shared_ptr<OvmsPoller::StandardVehiclePollSeries>(
+        new OvmsPoller::StandardVehiclePollSeries(
+            nullptr, GetPollerSignal(), static_cast<uint16_t>(PollState::CHARGE_HANDSHAKE)));
+    charge_series->PollSetPidList(2 /* CAN2 bus index */, obdii_polls_charge);
+    PollRequest(m_can2, "!xte.charge", charge_series);
+
     PollSetThrottling(0);
 
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
@@ -165,7 +204,7 @@ void OvmsVehicleToyotaETNGA::NotifyVehicleOn()
 
 void OvmsVehicleToyotaETNGA::Ticker1(uint32_t ticker)
 {
-  
+
     if (StandardMetrics.ms_v_charge_inprogress->AsBool()) {
         ESP_LOGV(CHARGING_TAG, "%.0f, %.2f, %.4f, %.0f, %.2f, %.2f, %.2f, %.2f, %.0f, %.2f, %.4f",
                 StandardMetrics.ms_v_bat_voltage->AsFloat(),


### PR DESCRIPTION
## What

The e-TNGA charge sub-machine needs 7 poll states (SLEEP, AWAKE, DRIVING + CHARGE_HANDSHAKE/WAIT/AC/DC). A poll list only supports `VEHICLE_POLL_NSTATES` (4) states, and an earlier change (`cf26255e`) bumped that framework constant 4→7. Per the OVMS dev-board answer, that's the wrong approach: the poller already supports any number of states via **multiple poll series, each with a state offset** (the Hyundai Ioniq5 secondary-series pattern).

This PR drops the framework bump and instead splits the e-TNGA poll table into two offset blocks:

- `obdii_polls_base` — offset 0 → states 0..3 (SLEEP/AWAKE/DRIVING)
- `obdii_polls_charge` — offset `CHARGE_HANDSHAKE` (3) → states 3..6 (HANDSHAKE/WAIT/AC/DC)

`VEHICLE_POLL_NSTATES` is reverted 7→4. The `PollState` enum and state machine are unchanged (state values stay 0..6); only the poll-table data layout and its registration change. PIDs polled in both a non-charge and a charge state appear in both tables with their respective cadences.

## Why

Keeps the framework constant at upstream's 4 (no tree-wide footprint change; no other vehicle uses >4 columns), and follows the established multi-series pattern instead of widening a global compile-time array dimension.

## Correctness

- **Behavior-preserving:** every per-state cadence was reconstructed (`[base 0..2] + [charge 0..3]`) and verified equal to the original 7-column table for all 48 PIDs; block A's handshake column is zero so state 3 polls only from block B.
- **CI:** firmware build green.
- **On-hardware validation (real module, all 7 states):**
  - Drive trip → base block: correct per-state cadences for DRIVING/AWAKE, SLEEP polls nothing.
  - AC charge session → charge block HANDSHAKE/WAIT/AC: correct cadences incl. AC-only telemetry; kWh survived 3× pause/resume; charge report written.
  - ~100 kW DC fast charge (6%→31%, 12.09 kWh) → charge block DC: DC-only station telemetry (`166C/166B/166A/1679/1681`) correct; AC-only PIDs correctly absent.
  - No PID leakage in either direction; zero `IncomingPollError`; no crashes.

## Notes

Not added to `changes.txt` — behavior-preserving internal refactor, no config/user-facing change.