### PR TITLE
etnga: tidy custom metrics for upstream readiness

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -200,16 +200,16 @@ All edges live in ``etnga_poll_states.cpp``.
        frames) and ``ResetStaleMetrics`` flips it false.
    * - ``AWAKE → DRIVING``
      - ``controlstate == CS_DRIVING``
-     - Marks the trip-start metric stale on entry so it resets on the
-       next odometer reading.  Also calls ``RequestVIN()`` (no-op if VIN
-       already cached).
+     - Invalidates the internal trip-start odometer baseline on entry so it
+       reseeds on the next odometer reading.  Also calls ``RequestVIN()``
+       (no-op if VIN already cached).
    * - ``AWAKE → CHARGE_HANDSHAKE``
      - PISW (DID ``0x1669``) ``≥ 0x02`` (cable seated)
      - **Changed from old model** (was ``controlstate == CS_CHARGING``).
        Opens the in-RAM charge session if not already open.  Calls
        ``RequestVIN()``.  Sets ``ms_v_charge_state = "prepared"``.
    * - ``AWAKE → SLEEP`` (forced, door watch)
-     - ``monotonic - m_v_env_awaketime > 300`` AND charge door never opened
+     - ``monotonic - m_awake_entered > 300`` AND charge door never opened
      - 5-minute watchdog when awake with no ``CS_DRIVING`` and charge
        door not opened.  Arms the escalating cooldown latch.
    * - ``AWAKE → SLEEP`` (forced, cable watch)
@@ -405,26 +405,26 @@ These are populated during DC charging (and where applicable, AC charging).
      - DID
      - Unit
      - Meaning
-   * - ``xte.v.c.perm``
+   * - ``xte.v.c.permpower``
      - ``0x16A1``
      - kW
      - Minimum charging permission power — the taper floor of the DC
        charge curve.  Decoded as ``s16 BE × 0.01 kW/LSB``.  The
        ``0x8000`` sentinel is skipped (metric left unchanged).
-   * - ``xte.v.c.tgti``
+   * - ``xte.v.c.tgtcurrent``
      - ``0x166D``
      - A
      - Target charging current set by the vehicle during DC
        fast-charge.
-   * - ``xte.v.c.stamaxp``
+   * - ``xte.v.c.dc.maxpower``
      - ``0x166A``
      - kW
      - DC station maximum power capability as negotiated via HLC.
-   * - ``xte.v.c.stamaxi``
+   * - ``xte.v.c.dc.maxcurrent``
      - ``0x1679``
      - A
      - DC station maximum current (CCS contract).
-   * - ``xte.v.c.stamaxv``
+   * - ``xte.v.c.dc.maxvoltage``
      - ``0x1681``
      - V
      - DC station maximum voltage (CCS contract).
@@ -456,8 +456,8 @@ AC-only custom metrics
 -----------------------
 
 These metrics are populated only while ``PollState == CHARGE_AC``.  Note
-that ``xte.v.c.chgrop`` (charger operation status, from ``0x1619`` byte 3)
-is distinct from ``xte.v.c.acop`` (``0x1684``), which drives the
+that ``xte.v.c.chargerstate`` (charger operation status, from ``0x1619`` byte 3)
+is distinct from ``xte.v.c.ac.opstatus`` (``0x1684``), which drives the
 ``CHARGE_HANDSHAKE → CHARGE_AC`` transition.
 
 .. list-table::
@@ -468,31 +468,31 @@ is distinct from ``xte.v.c.acop`` (``0x1684``), which drives the
      - DID / bytes
      - Unit
      - Meaning
-   * - ``xte.v.c.actgtp``
+   * - ``xte.v.c.ac.tgtpower``
      - ``0x1619`` b1–2
      - kW
      - AC target charging power.  Decoded as ``u16 BE biased-32768
        × 0.01 kW/LSB``.
-   * - ``xte.v.c.chgrop``
+   * - ``xte.v.c.chargerstate``
      - ``0x1619`` b3
      - enum
      - Charger operation status (see source for enum values).
-   * - ``xte.v.c.acilim``
+   * - ``xte.v.c.ac.ilimit``
      - ``0x1619`` b4–5
      - A
      - AC charging current upper limit.  Decoded as ``u16 BE
        biased-32768 × 0.01 A/LSB``.
-   * - ``xte.v.c.chgout``
+   * - ``xte.v.c.output``
      - ``0x161E`` b1–2
      - kW
      - Charger output power.  Decoded as ``u16 BE × 5/1000 kW/LSB``
        (unit inferred).
-   * - ``xte.v.c.chgotgt``
+   * - ``xte.v.c.outputtarget``
      - ``0x161E`` b3–4
      - kW
      - Target-from-charger power.  Decoded as ``u16 BE × 5/1000
        kW/LSB`` (unit inferred).
-   * - ``xte.v.c.acusbl``
+   * - ``xte.v.c.ac.usable``
      - ``0x1665``
      - kW
      - A/C useable power.  Decoded as ``u8 × 0.01 kW/LSB`` (unit
@@ -500,8 +500,8 @@ is distinct from ``xte.v.c.acop`` (``0x1684``), which drives the
 
 .. note::
 
-   The four AC channels (``xte.v.c.acilim``, ``xte.v.c.chgout``,
-   ``xte.v.c.chgotgt``, ``xte.v.c.acusbl``) are now scaled per the
+   The four AC channels (``xte.v.c.ac.ilimit``, ``xte.v.c.output``,
+   ``xte.v.c.outputtarget``, ``xte.v.c.ac.usable``) are now scaled per the
    Techstream dictionary factors.  The ``0x161E`` and ``0x1665`` kW
    units are inferred (by analogy to ``0x161D`` grid power) and pending
    sustained AC-charge confirmation.
@@ -515,7 +515,7 @@ is called at session end from ``TransitionToAwakeState()``.
 ``xte.v.c.myroom`` is polled only in the ``CHARGE_AC`` and ``CHARGE_DC``
 states; ``xte.v.e.hvac.power`` is polled in those charge states (from the
 OBC, ``0x745``) **and** in ``DRIVING`` (from the hybrid control ECU,
-``0x7D2``); ``xte.v.c.outcome`` and ``xte.v.c.stopreq`` are also polled in
+``0x7D2``); ``xte.v.c.outcome`` and ``xte.v.c.stoprequest`` are also polled in
 ``CHARGE_HANDSHAKE`` and ``CHARGE_WAIT``.
 
 .. list-table::
@@ -558,7 +558,7 @@ OBC, ``0x745``) **and** in ``DRIVING`` (from the hybrid control ECU,
        the vehicle does not reset this on plug-in, so a report must
        scope it per-session (capture value at session open and
        compare at session close).
-   * - ``xte.v.c.stopreq``
+   * - ``xte.v.c.stoprequest``
      - ``0x1667``
      - enum
      - Charge Sequence Stop Request from the CCM — HLC-layer fault

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -15,36 +15,33 @@
 void OvmsVehicleToyotaETNGA::InitializeMetrics()
 {
     m_s_controlstate = MyMetrics.InitInt("xte.s.controlstate", SM_STALE_MIN);  // This variable stores the control state variable
-    m_v_charge_pisw_raw = MyMetrics.InitInt("xte.v.c.pisw", SM_STALE_MID);
-    m_v_charge_ac_op    = MyMetrics.InitInt("xte.v.c.acop", SM_STALE_MID);
-    m_v_charge_hlc      = MyMetrics.InitInt("xte.v.c.hlc",  SM_STALE_MID);
-    m_v_charge_perm = MyMetrics.InitFloat("xte.v.c.perm", SM_STALE_MID, 0.0f, kW);
-    m_v_charge_tgti = MyMetrics.InitFloat("xte.v.c.tgti", SM_STALE_MID, 0.0f, Amps);
-    m_v_charge_sta_max_p = MyMetrics.InitFloat("xte.v.c.stamaxp", SM_STALE_MID, 0.0f, kW);
-    m_v_charge_sta_max_i = MyMetrics.InitFloat("xte.v.c.stamaxi", SM_STALE_MID, 0.0f, Amps);
-    m_v_charge_sta_max_v = MyMetrics.InitFloat("xte.v.c.stamaxv", SM_STALE_MID, 0.0f, Volts);
-    m_v_charge_ac_tgt_p  = MyMetrics.InitFloat("xte.v.c.actgtp", SM_STALE_MID, 0.0f, kW);
-    m_v_charge_chgr_op   = MyMetrics.InitInt("xte.v.c.chgrop", SM_STALE_MID);                     // enum: 0=Stand by,1=Ready,2=Stop,3=RoB Stop
-    m_v_charge_ac_ilim   = MyMetrics.InitFloat("xte.v.c.acilim", SM_STALE_MID, 0.0f, Amps);
-    m_v_charge_out       = MyMetrics.InitFloat("xte.v.c.chgout", SM_STALE_MID, 0.0f, kW);
-    m_v_charge_out_tgt   = MyMetrics.InitFloat("xte.v.c.chgotgt", SM_STALE_MID, 0.0f, kW);
-    m_v_charge_ac_usable = MyMetrics.InitFloat("xte.v.c.acusbl", SM_STALE_MID, 0.0f, kW);
+    m_v_charge_pisw_raw = MyMetrics.InitInt("xte.v.c.piswraw", SM_STALE_MID);
+    m_v_charge_ac_op    = MyMetrics.InitInt("xte.v.c.ac.opstatus", SM_STALE_MID);
+    m_v_charge_hlc      = MyMetrics.InitInt("xte.v.c.hlcstate",  SM_STALE_MID);
+    m_v_charge_perm = MyMetrics.InitFloat("xte.v.c.permpower", SM_STALE_MID, 0.0f, kW);
+    m_v_charge_tgti = MyMetrics.InitFloat("xte.v.c.tgtcurrent", SM_STALE_MID, 0.0f, Amps);
+    m_v_charge_sta_max_p = MyMetrics.InitFloat("xte.v.c.dc.maxpower", SM_STALE_MID, 0.0f, kW);
+    m_v_charge_sta_max_i = MyMetrics.InitFloat("xte.v.c.dc.maxcurrent", SM_STALE_MID, 0.0f, Amps);
+    m_v_charge_sta_max_v = MyMetrics.InitFloat("xte.v.c.dc.maxvoltage", SM_STALE_MID, 0.0f, Volts);
+    m_v_charge_ac_tgt_p  = MyMetrics.InitFloat("xte.v.c.ac.tgtpower", SM_STALE_MID, 0.0f, kW);
+    m_v_charge_chgr_op   = MyMetrics.InitInt("xte.v.c.chargerstate", SM_STALE_MID);                     // enum: 0=Stand by,1=Ready,2=Stop,3=RoB Stop
+    m_v_charge_ac_ilim   = MyMetrics.InitFloat("xte.v.c.ac.ilimit", SM_STALE_MID, 0.0f, Amps);
+    m_v_charge_out       = MyMetrics.InitFloat("xte.v.c.output", SM_STALE_MID, 0.0f, kW);
+    m_v_charge_out_tgt   = MyMetrics.InitFloat("xte.v.c.outputtarget", SM_STALE_MID, 0.0f, kW);
+    m_v_charge_ac_usable = MyMetrics.InitFloat("xte.v.c.ac.usable", SM_STALE_MID, 0.0f, kW);
     m_v_charge_myroom  = MyMetrics.InitBool("xte.v.c.myroom", SM_STALE_MID);
     m_v_charge_grid_power = MyMetrics.InitFloat("xte.v.c.gridpower", SM_STALE_MID, 0.0f, kW);
     m_v_env_hvac_power = MyMetrics.InitFloat("xte.v.e.hvac.power", SM_STALE_MID, 0.0f, kW);
     m_v_env_hvac_kwh   = MyMetrics.InitFloat("xte.v.e.hvac.kwh",   SM_STALE_MID, 0.0f, kWh);
     m_v_env_hvac_kwh_drive = MyMetrics.InitFloat("xte.v.e.hvac.kwh.drive", SM_STALE_MID, 0.0f, kWh);  // Per-trip driving cabin/HVAC energy
     m_v_charge_outcome = MyMetrics.InitInt("xte.v.c.outcome", SM_STALE_MID);
-    m_v_charge_stopreq = MyMetrics.InitInt("xte.v.c.stopreq", SM_STALE_MID);
+    m_v_charge_stopreq = MyMetrics.InitInt("xte.v.c.stoprequest", SM_STALE_MID);
     m_v_bat_cap_full = MyMetrics.InitVector<float>("xte.v.b.cap.full", SM_STALE_HIGH, 0, AmpHours);  // 0x1D3E 8x per-module full-charge capacity (data collection)
     m_v_bat_cap_alt  = MyMetrics.InitVector<float>("xte.v.b.cap.alt",  SM_STALE_HIGH, 0, AmpHours);  // 0x1D3F 8x parallel capacity array, function unconfirmed (data collection)
     m_v_bat_heater_status = MyMetrics.InitBool("xte.v.b.heater", SM_STALE_MID);  // This variable stores the status of the battery coolant heater relay
     m_v_bat_soc_bms = MyMetrics.InitFloat("xte.v.b.soc.bms", SM_STALE_MID, 0.0f, Percentage, true);  // This variable stores the SOC as reported by the BMS
-    m_v_bat_speed_water_pump = MyMetrics.InitFloat("xte.v.b.speed.waterpump", SM_STALE_MID, 0.0f, Other);  // This variable stores the RPM of the battery water pump
     m_v_bat_temp_coolant = MyMetrics.InitFloat("xte.v.b.temp.coolant", SM_STALE_MID, 0.0f, Celcius);  // This variable stores the temperature of the battery coolant
     m_v_bat_temp_heater = MyMetrics.InitFloat("xte.v.b.temp.heater", SM_STALE_MID, 0.0f, Celcius);  // This variable stores the temperature of the battery coolant
-    m_v_pos_trip_start = MyMetrics.InitFloat("xte.v.p.trip.start", SM_STALE_NONE, 0.0f, Kilometers, false);  // This variable stores the odometer reading at the beginning of a trip
-    m_v_env_awaketime = MyMetrics.InitInt("xte.v.e.awaketime", SM_STALE_NONE);  // Time awake state was entered for awake timeout (monotonic seconds)
     m_v_e_awd = MyMetrics.InitInt("xte.v.e.awd", SM_STALE_MID);  // 0x1087 b2 AWD / X-MODE status (custom)
 
     // Set initial values for metrics
@@ -918,15 +915,16 @@ void OvmsVehicleToyotaETNGA::SetOdometer(float odometer)
     LogMetricChange(StandardMetrics.ms_v_pos_odometer, odometer, "Odometer", "km");
     StandardMetrics.ms_v_pos_odometer->SetValue(odometer);  // Set the odometer metric
 
-    if (m_v_pos_trip_start->IsStale())
+    if (!m_trip_start_valid)
     {
-        // Update the trip start metric if it is stale
-        // It becomes stale when first transitioning to the READY state
-        m_v_pos_trip_start->SetValue(odometer);
+        // Seed the trip-start baseline on the first reading of a trip.
+        // It is invalidated on transition to DRIVING (see TransitionToDrivingState).
+        m_trip_start_odo = odometer;
+        m_trip_start_valid = true;
     }
 
     // Update the trip odometer
-    float tripOdometer = odometer - m_v_pos_trip_start->AsFloat();
+    float tripOdometer = odometer - m_trip_start_odo;
     StandardMetrics.ms_v_pos_trip->SetValue(tripOdometer);
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -143,7 +143,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
             m_armed_for_charge = true;
             m_cable_watch_start = monotonic;
             ResetSleepBackoff();   // deliberate user action — resume responsive cooldowns
-        } else if (monotonic - m_v_env_awaketime->AsInt() > 300) {
+        } else if (monotonic - m_awake_entered > 300) {
             // Door watch expired (5 min in AWAKE, charge door never opened) → sleep
             ESP_LOGI(TAG, "Vehicle awake for over 300s with no activity — forcing sleep state");
             TransitionToSleepState();
@@ -310,7 +310,7 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
     // For all other transitions into AWAKE (SLEEP→AWAKE, DRIVING→AWAKE),
     // arm state is reset by TransitionToSleepState / TransitionToDrivingState.
     SetPollState(PollState::AWAKE);
-    m_v_env_awaketime->SetValue(monotonic);
+    m_awake_entered = monotonic;
     // Leaving the charge sub-machine: close the session. ms_v_charge_state is "done" only
     // when energy was being delivered (AC/DC — normally these exit via CHARGE_WAIT; the
     // direct path is a safety net); HANDSHAKE/WAIT exits just clear it.
@@ -332,7 +332,7 @@ void OvmsVehicleToyotaETNGA::TransitionToDrivingState()
     m_armed_for_charge = false;
     ResetSleepBackoff();   // real drive — resume responsive cooldowns
     SetPollState(PollState::DRIVING);
-    m_v_pos_trip_start->SetStale(true);
+    m_trip_start_valid = false;
     RequestVIN();
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -296,9 +296,9 @@ void OvmsVehicleToyotaETNGA::WebChgRenderDc(PageContext_t& c, OvmsVehicleToyotaE
 
         "<div class=\"clearfix\">"
           "<h6 class=\"metric-head\">Station</h6>"
-          "<div class=\"metric number\" data-metric=\"xte.v.c.stamaxp\" data-prec=\"1\"><span class=\"label\">Max power</span><span class=\"value\">?</span><span class=\"unit\">kW</span></div>"
-          "<div class=\"metric number\" data-metric=\"xte.v.c.stamaxv\" data-prec=\"0\"><span class=\"label\">Max V</span><span class=\"value\">?</span><span class=\"unit\">V</span></div>"
-          "<div class=\"metric number\" data-metric=\"xte.v.c.stamaxi\" data-prec=\"0\"><span class=\"label\">Max A</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
+          "<div class=\"metric number\" data-metric=\"xte.v.c.dc.maxpower\" data-prec=\"1\"><span class=\"label\">Max power</span><span class=\"value\">?</span><span class=\"unit\">kW</span></div>"
+          "<div class=\"metric number\" data-metric=\"xte.v.c.dc.maxvoltage\" data-prec=\"0\"><span class=\"label\">Max V</span><span class=\"value\">?</span><span class=\"unit\">V</span></div>"
+          "<div class=\"metric number\" data-metric=\"xte.v.c.dc.maxcurrent\" data-prec=\"0\"><span class=\"label\">Max A</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
           "<div class=\"metric number\" data-metric=\"v.c.voltage\" data-prec=\"1\"><span class=\"label\">Present V</span><span class=\"value\">?</span><span class=\"unit\">V</span></div>"
           "<div class=\"metric number\" data-metric=\"v.c.current\" data-prec=\"1\"><span class=\"label\">Present A</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
         "</div>"
@@ -310,7 +310,7 @@ void OvmsVehicleToyotaETNGA::WebChgRenderDc(PageContext_t& c, OvmsVehicleToyotaE
           // charging), so it's updated from JS as an absolute value (id=permkw) like the chart does,
           // rather than bound raw via data-metric — keeps the on-screen number positive.
           "<div class=\"metric number\"><span class=\"label\">Permitted</span><span class=\"value\" id=\"permkw\">?</span><span class=\"unit\">kW</span></div>"
-          "<div class=\"metric number\" data-metric=\"xte.v.c.tgti\" data-prec=\"0\"><span class=\"label\">Target</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
+          "<div class=\"metric number\" data-metric=\"xte.v.c.tgtcurrent\" data-prec=\"0\"><span class=\"label\">Target</span><span class=\"value\">?</span><span class=\"unit\">A</span></div>"
         "</div>"
 
         "<div class=\"clearfix\">"
@@ -380,17 +380,17 @@ void OvmsVehicleToyotaETNGA::WebChgChartJs(PageContext_t& c, OvmsVehicleToyotaET
         "  var pm=null;\n"
         "  function showPerm(){if(DC&&pm!=null)$('#permkw').text(Math.abs(pm).toFixed(2));}\n"
         "  function onUpd(){\n"
-        "    pm=mv('xte.v.c.perm'); showPerm();\n"   // update the Permitted panel field even before the chart builds
+        "    pm=mv('xte.v.c.permpower'); showPerm();\n"   // update the Permitted panel field even before the chart builds
         "    if(!chart) return;\n"
         "    var t=baseT/60+(Date.now()/1000-loadT)/60;\n"
-        "    var d=mv('v.c.power'),sc=mv('v.b.soc'),sm=mv('xte.v.c.stamaxp');\n"
+        "    var d=mv('v.c.power'),sc=mv('v.b.soc'),sm=mv('xte.v.c.dc.maxpower');\n"
         "    var cap=600, sidx=DC?3:2;\n"
         "    if(d!=null) chart.series[0].addPoint([t,d],false,chart.series[0].data.length>cap);\n"
         "    chart.series[1].addPoint([t,pm==null?0:Math.abs(pm)],false,chart.series[1].data.length>cap);\n"
         "    if(DC) chart.series[2].addPoint([t,sm==null?0:sm],false,chart.series[2].data.length>cap);\n"
         "    chart.series[sidx].addPoint([t,sc],true,chart.series[sidx].data.length>cap);\n"
         "  }\n"
-        "  function init(){build(); pm=mv('xte.v.c.perm'); showPerm(); $('#chgmon').on('msg:metrics',onUpd);}\n"
+        "  function init(){build(); pm=mv('xte.v.c.permpower'); showPerm(); $('#chgmon').on('msg:metrics',onUpd);}\n"
         "  if(window.Highcharts) init();\n"
         "  else $.ajax({url:window.assets.charts_js,dataType:'script',cache:true,success:init});\n"
         "})();\n"
@@ -398,8 +398,8 @@ void OvmsVehicleToyotaETNGA::WebChgChartJs(PageContext_t& c, OvmsVehicleToyotaET
         dc ? 1 : 0, init.c_str(), elapsed);
 }
 // Emit the state-history table, a backfill literal of the in-memory event log, and JS that seeds
-// the table then appends a row whenever the watched state metric changes (xte.v.c.hlc on DC,
-// xte.v.c.acop on AC). On DC it also keeps the #hlcstate header span current. Labels come from
+// the table then appends a row whenever the watched state metric changes (xte.v.c.hlcstate on DC,
+// xte.v.c.ac.opstatus on AC). On DC it also keeps the #hlcstate header span current. Labels come from
 // inline maps so no extra string metric is needed.
 void OvmsVehicleToyotaETNGA::WebChgStateHistoryJs(PageContext_t& c, OvmsVehicleToyotaETNGA* v, bool dc)
 {
@@ -440,7 +440,7 @@ void OvmsVehicleToyotaETNGA::WebChgStateHistoryJs(PageContext_t& c, OvmsVehicleT
         "  for(var i=0;i<EVT.length;i++) row(EVT[i][0],EVT[i][1]);\n"
         "  if(DC){var hn=HLC[lastState]; if(hn) $('#hlcstate').text(hn);}\n"
         "  function onUpd(){\n"
-        "    var m=DC?metrics['xte.v.c.hlc']:metrics['xte.v.c.acop'];\n"
+        "    var m=DC?metrics['xte.v.c.hlcstate']:metrics['xte.v.c.ac.opstatus'];\n"
         "    if(m==null) return; m=parseInt(m);\n"
         "    if(DC){var hn=HLC[m]; if(hn) $('#hlcstate').text(hn);}\n"
         "    if(m===lastState) return; lastState=m;\n"

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -149,11 +149,12 @@ protected:
     OvmsMetricVector<float>* m_v_bat_cap_alt;   // 0x1D3F 8x u16 x0.01 Ah — parallel array, function unconfirmed (data collection)
     OvmsMetricBool* m_v_bat_heater_status;
     OvmsMetricFloat* m_v_bat_soc_bms;
-    OvmsMetricFloat* m_v_bat_speed_water_pump;
     OvmsMetricFloat* m_v_bat_temp_coolant;
     OvmsMetricFloat* m_v_bat_temp_heater;
-    OvmsMetricInt* m_v_env_awaketime;
-    OvmsMetricFloat* m_v_pos_trip_start;
+    // Internal bookkeeping (not exposed as metrics):
+    int   m_awake_entered = 0;        // ms_m_monotonic seconds when AWAKE was entered (awake-timeout watchdog)
+    float m_trip_start_odo = 0.0f;    // odometer baseline at trip start
+    bool  m_trip_start_valid = false; // false until the baseline is seeded; reset on transition to DRIVING
     OvmsMetricInt* m_v_e_awd;   // 0x1087 b2 AWD / X-MODE status (custom; no standard OVMS metric)
     
     void NotifyVehicleOn() override;


### PR DESCRIPTION
Upstream-prep cleanup of the e-TNGA custom (`xte.*`) metrics. Behavior-preserving; no framework changes.

## Changes
- **Remove dead metric** `xte.v.b.speed.waterpump` — registered but never populated (no `SetValue` anywhere), and there's no `Rpm` unit in the framework, so removal is the clean fix.
- **Demote internal bookkeeping** from metrics to plain members (no external consumers):
  - `xte.v.e.awaketime` → `int m_awake_entered` (awake-timeout watchdog timestamp)
  - `xte.v.p.trip.start` → `float m_trip_start_odo` + `bool m_trip_start_valid` (replaces the metric stale-flag-as-sentinel pattern)
- **Rename terse `xte.v.c.*` charge leaf names** for clarity, with `ac.`/`dc.` grouping: `stamaxp→dc.maxpower`, `stamaxi→dc.maxcurrent`, `stamaxv→dc.maxvoltage`, `actgtp→ac.tgtpower`, `acilim→ac.ilimit`, `acusbl→ac.usable`, `acop→ac.opstatus`, `chgout→output`, `chgotgt→outputtarget`, `chgrop→chargerstate`, `stopreq→stoprequest`, `pisw→piswraw`, `hlc→hlcstate`, `perm→permpower`, `tgti→tgtcurrent`. Web UI + docs updated to match. Internal member names unchanged.

## Scope / safety
- Renames are component-contained — no `plugins/`, ABRP, or server references to the old names.
- `xte.v.b.cap.full` / `cap.alt` intentionally left as-is (fork-only data-collection, not upstreamed).
- Verified: no dangling member refs, no old metric strings anywhere in the repo, docs corrected. CI build green (workflow_dispatch).