### PR TITLE
ci: run firmware build on self-hosted ovms3 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    # Self-hosted (SH K3s, the `ovms3` ARC scale set) so the firmware build can
+    # push its output to the in-cluster MinIO artifact store (10.20.5.228) — a
+    # private IP that GitHub-hosted runners can't reach. The runner image
+    # (ovms-ci-runner) runs as root with apt/sudo/python3/ccache/git present, so
+    # this legacy ESP-IDF 3.3 build (which fetches its own toolchain + esp-idf)
+    # runs unchanged. docs.yml (Pages) and web-assets-check.yml stay GitHub-hosted.
+    runs-on: ovms3
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v6


### PR DESCRIPTION
Moves the Firmware build job to the self-hosted `ovms3` ARC runner (SH K3s) so it can reach the in-cluster MinIO artifact store (`10.20.5.228`, a private IP GitHub-hosted runners can't reach).

- The reused `ovms-ci-runner` image runs as root and has apt/sudo/python3/ccache/git, so the legacy ESP-IDF 3.3 build (which fetches its own toolchain + esp-idf fork) runs unchanged.
- **This PR is the validation step** — proving the legacy build is green on self-hosted. The firmware artifact still uploads to GitHub artifacts here; a follow-up moves it to MinIO (`s3://ci-artifacts/<run_id>/ovms3/`) and flips ovms-modern's network-flash `vintage` path to match.
- `docs.yml` (Pages) and `web-assets-check.yml` stay on GitHub-hosted runners.