### PR TITLE
ci: upload firmware to MinIO instead of GitHub artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,12 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_MAXSIZE: 500M
   CCACHE_COMPILERCHECK: content
+  # Firmware output goes to the self-hosted MinIO artifact store (reachable from
+  # the ovms3 runner) instead of GitHub Actions artifacts (account-wide 500MB
+  # Free-tier quota). Objects keyed by github.run_id; ovms-modern's network-flash
+  # vintage path downloads ovms3.bin from there by run_id. 30-day bucket lifecycle.
+  MINIO_ENDPOINT: http://10.20.5.228:9000
+  MC_VERSION: RELEASE.2025-08-13T08-35-41Z
 
 jobs:
   build:
@@ -187,23 +193,26 @@ jobs:
 
           ccache --show-stats
 
-      - name: Upload firmware artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ovms3-firmware
-          # ovms3.bin is the app image (flash via `ota flash vfs`, as
-          # scripts/ovms-deploy.sh does). The other three .bin are also needed for
-          # a fresh serial flash (`make flash`). ovms3.elf + ovms3.map carry the
-          # debug symbols / link map needed to decode a crash backtrace
-          # (`boot status` on the module) back to functions and source lines.
-          # if-no-files-found: error so a silently-missing binary fails the job
-          # instead of producing an empty zip.
-          path: |
-            vehicle/OVMS.V3/build/ovms3.bin
-            vehicle/OVMS.V3/build/ovms3.elf
-            vehicle/OVMS.V3/build/ovms3.map
-            vehicle/OVMS.V3/build/bootloader/bootloader.bin
-            vehicle/OVMS.V3/build/partitions.bin
-            vehicle/OVMS.V3/build/ota_data_initial.bin
-          if-no-files-found: error
-          retention-days: 30
+      - name: Upload firmware to MinIO
+        # ovms3.bin is the app image (flash via `ota flash vfs`, as
+        # scripts/ovms-deploy.sh does). The other three .bin are also needed for a
+        # fresh serial flash (`make flash`). ovms3.elf + ovms3.map carry the debug
+        # symbols / link map needed to decode a crash backtrace (`boot status`)
+        # back to functions and source lines. All keyed by run_id under ovms3/.
+        env:
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://dl.min.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION}" -o "$RUNNER_TEMP/mc"
+          chmod +x "$RUNNER_TEMP/mc"
+          "$RUNNER_TEMP/mc" alias set sh "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+          "$RUNNER_TEMP/mc" cp \
+            vehicle/OVMS.V3/build/ovms3.bin \
+            vehicle/OVMS.V3/build/ovms3.elf \
+            vehicle/OVMS.V3/build/ovms3.map \
+            vehicle/OVMS.V3/build/bootloader/bootloader.bin \
+            vehicle/OVMS.V3/build/partitions.bin \
+            vehicle/OVMS.V3/build/ota_data_initial.bin \
+            "sh/ci-artifacts/${RUN_ID}/ovms3/"


### PR DESCRIPTION
Final step taking OVMS-3 firmware off GitHub artifact storage. Now that the Firmware build runs on the self-hosted `ovms3` runner (#113, merged), it can reach the in-cluster MinIO store.

- Replaces the `ovms3-firmware` `upload-artifact` with `mc cp` to `s3://ci-artifacts/<run_id>/ovms3/` (all six build outputs; pinned mc; 30-day bucket lifecycle).
- ovms-modern's `network-flash` vintage path downloads `ovms3.bin` from the same run_id key (companion PR ovms-modern#TBD).

## ⚠️ Required before merge: add repo secrets
Same as ovms-modern (my token can't set Actions secrets):
| Secret | Value |
|---|---|
| `MINIO_ACCESS_KEY` | `ci-ovms-modern` |
| `MINIO_SECRET_KEY` | *(from `sops -d slate-hill/configs/k3s/apps/minio/secret.yaml`)* |

## Merge order
Merge **this** first and let one master build run (populates MinIO) **before** merging the ovms-modern vintage PR, so a `green-master` vintage flash finds the object.