### PR TITLE
etnga: charge-report/state clean fixes (park-at-boot, charge-state re-assert, report temp units)

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -530,7 +530,12 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
           << "#map=17/" << m_charge_session.start_lat << "/" << m_charge_session.start_lon << "\">map</a>)</dd>\n";
     }
     if (m_charge_session.amb_seen) {
-        snprintf(b, sizeof(b), "%.0f&deg;C &rarr; %.0f&deg;C", m_charge_session.amb_min, m_charge_session.amb_max);
+        // Follow the user's configured temperature unit (°C or °F).
+        metric_unit_t tu = OvmsMetricGetUserUnit(GrpTemp, Celcius);
+        const char* tlabel = OvmsMetricUnitLabel(tu);
+        float amb_lo = UnitConvert(Celcius, tu, m_charge_session.amb_min);
+        float amb_hi = UnitConvert(Celcius, tu, m_charge_session.amb_max);
+        snprintf(b, sizeof(b), "%.0f%s &rarr; %.0f%s", amb_lo, tlabel, amb_hi, tlabel);
         f << "<dt>Ambient</dt><dd>" << b << "</dd>\n";
     }
     f << "<dt>Type</dt><dd>" << (m_charge_session.is_dc ? "DC fast" : "AC") << "</dd>\n";
@@ -558,7 +563,12 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
         f << acc;
     }
     if (m_charge_session.temp_seen) {
-        snprintf(b, sizeof(b), "%.0f&deg;C &rarr; %.0f&deg;C", m_charge_session.temp_min, m_charge_session.temp_max);
+        // Follow the user's configured temperature unit (°C or °F).
+        metric_unit_t tu = OvmsMetricGetUserUnit(GrpTemp, Celcius);
+        const char* tlabel = OvmsMetricUnitLabel(tu);
+        float bat_lo = UnitConvert(Celcius, tu, m_charge_session.temp_min);
+        float bat_hi = UnitConvert(Celcius, tu, m_charge_session.temp_max);
+        snprintf(b, sizeof(b), "%.0f%s &rarr; %.0f%s", bat_lo, tlabel, bat_hi, tlabel);
         f << "<dt>Battery temp</dt><dd>" << b << "</dd>\n";
     }
     {
@@ -581,7 +591,9 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
 
     f << "<h2 class=\"est\">Estimates</h2>\n<dl class=\"est\">\n";
     if (!m_charge_session.is_dc && grid_kwh > 0.01f) {   // efficiency needs grid energy (AC only)
-        snprintf(b, sizeof(b), "%.0f%% (%.2f kWh loss)", energy_kwh/grid_kwh*100.0f, grid_kwh-energy_kwh);
+        float loss = grid_kwh - energy_kwh;   // negative would imply delivered > grid (measurement skew)
+        snprintf(b, sizeof(b), "%.0f%% (%.2f kWh %s)", energy_kwh/grid_kwh*100.0f, fabsf(loss),
+            loss >= 0.0f ? "loss" : "gain?");
         f << "<dt>Charging efficiency</dt><dd>" << b << "</dd>\n";
     }
     if (start_soc >= 0 && end_soc > start_soc && m_charge_session.delivered_ah > 0.5f) {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -48,6 +48,13 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     SetAwake(false);
     SetReadyStatus(false);
     SetChargingDoorStatus(false);
+    // Default gear to Park (0) at boot. v.e.gear is otherwise only set by the 0x1061 poll
+    // (DRIVING-only) or on the DRIVING->AWAKE transition, so a module that boots straight into
+    // charging (e.g. after a crash) would never set it — leaving the is_parked override
+    // (gear === 0) with no value, so is_parked goes absent during charging. Park is the safe
+    // boot default; if we actually boot mid-drive, the DRIVING-state 0x1061 poll corrects it
+    // within ~1s.
+    SetShiftPosition(0);
     // v.c.charging is a persistent metric (restored from RTC across soft reboots) and is
     // read by ABRP as the charging indicator. Boot is forced into the SLEEP poll state, so
     // initialize it false to match — otherwise a reboot mid-charge leaves it stale-true (and

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -278,6 +278,13 @@ void OvmsVehicleToyotaETNGA::HandleChargeAcState()
     // handlers resume normally.  Do not add timeout-based session teardown here.
     UpdateChargeSessionStats();   // aggregate peak power / temp range / type for the session report
 
+    // Keep charge-state metrics fresh (they're otherwise set only on transition → go stale
+    // at 120s, and a mid-charge reboot leaves the Status page showing "Not charging").
+    if (StandardMetrics.ms_v_charge_inprogress->Age() > 60) {
+        StandardMetrics.ms_v_charge_inprogress->SetValue(true);
+        StandardMetrics.ms_v_charge_state->SetValue("charging");
+    }
+
     int pisw = m_v_charge_pisw_raw->AsInt();
     int ac_op = m_v_charge_ac_op->AsInt();
 
@@ -300,6 +307,13 @@ void OvmsVehicleToyotaETNGA::HandleChargeDcState()
     // (0x00) read or hlc==0xFF (HLC Unconnected) terminates the DC phase.  On unlock the
     // OBC answers again and polling resumes.  Do not add timeout-based session teardown here.
     UpdateChargeSessionStats();   // aggregate peak power / temp range / type for the session report
+
+    // Keep charge-state metrics fresh (they're otherwise set only on transition → go stale
+    // at 120s, and a mid-charge reboot leaves the Status page showing "Not charging").
+    if (StandardMetrics.ms_v_charge_inprogress->Age() > 60) {
+        StandardMetrics.ms_v_charge_inprogress->SetValue(true);
+        StandardMetrics.ms_v_charge_state->SetValue("charging");
+    }
 
     int pisw = m_v_charge_pisw_raw->AsInt();
     int hlc = m_v_charge_hlc->AsInt();


### PR DESCRIPTION
Three low-risk e-TNGA charge fixes, **extracted fresh onto current master** from the stale
`feature/etnga-charge-monitor-fixes` branch (which was 68 behind master / pre-v2-charge-rewrite).
These three apply cleanly with no conflicts; the async SD-I/O worker from that branch is a
separate, larger follow-on (needs re-integration against master's v2 csv_buf model + charge-session validation).

- **Park at boot** (`etnga_metrics.cpp`): default `v.e.gear` to Park in `InitializeMetrics` so
  `is_parked` holds when the module boots straight into charging (e.g. after a crash). A real
  mid-drive boot is corrected by the DRIVING-only 0x1061 poll within ~1s.
- **Charge-state re-assert** (`etnga_poll_states.cpp`): re-assert `v.c.charging`/`v.c.state` in the
  AC and DC handlers when older than 60s — they're otherwise set only on transition, so they age
  out at 120s during a long charge and a mid-charge reboot shows "Not charging" on the Status page.
- **Report temperature units + efficiency guard** (`etnga_charge_report.cpp`): ambient and
  battery-temp ranges follow the user's °C/°F preference (via `UnitConvert`/`GrpTemp`) instead of
  hardcoded °C; the charging-efficiency line shows `|loss|` with a "gain?" label when delivered >
  grid (measurement skew) instead of a negative-kWh "loss".

No `changes.txt` entry: bug/correctness fixes, no user action or new config.

Validation: build-verified by this PR's CI. Behavioral confirmation (park-at-boot during a
mid-charge boot; report temp/efficiency rendering) is best observed on a real charge session —
none of it can be functionally validated off-vehicle.