### PR TITLE
poller: fix use-after-free of vehicle signal on vehicle teardown (#123)

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -464,7 +464,9 @@ void OvmsVehicleToyotaETNGA::RequestVIN()
             HYBRID_CONTROL_SYSTEM_TX, HYBRID_CONTROL_SYSTEM_RX,
             VEHICLE_POLL_TYPE_READDATA, PID_VIN,
             ISOTP_STD, 0, /*retry_fail=*/3));
-    PollRequest(m_can2, "!xte.vin", entry);
+    // "!v." prefix => auto-removed on vehicle shutdown (poller/docs/API.rst). This OnceOffPoll
+    // binds 'this', so leaving it registered past teardown is a use-after-free.
+    PollRequest(m_can2, "!v.xte.vin", entry);
 }
 
 void OvmsVehicleToyotaETNGA::IncomingVINSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, CAN_frame_format_t format, const std::string &data)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -163,7 +163,11 @@ OvmsVehicleToyotaETNGA::OvmsVehicleToyotaETNGA()
         new OvmsPoller::StandardVehiclePollSeries(
             nullptr, GetPollerSignal(), static_cast<uint16_t>(PollState::CHARGE_HANDSHAKE)));
     charge_series->PollSetPidList(2 /* CAN2 bus index */, obdii_polls_charge);
-    PollRequest(m_can2, "!xte.charge", charge_series);
+    // The "!v." name prefix is the poller's documented contract (poller/docs/API.rst):
+    // series so named are auto-removed on vehicle shutdown. Without it this series held a
+    // raw signal aliasing the vehicle's m_pollsignal and was dereferenced after teardown
+    // freed it (use-after-free crash on a no-reboot vehicle switch).
+    PollRequest(m_can2, "!v.xte.charge", charge_series);
 
     PollSetThrottling(0);
 


### PR DESCRIPTION
## Summary

Fixes a use-after-free crash in the poller on a no-reboot vehicle switch (`vehicle module NONE`
then `vehicle module SUBSOL`), root-caused to an e-TNGA naming-convention violation.

## Root cause

The poller has a documented contract (`components/poller/docs/API.rst`):

> `PollSeriesEntry` that are added with a `"!v."` prefix will be automatically removed on
> shutdown of the vehicle class.

`OvmsPollers::ShuttingDownVehicle()` implements this via `RemovePollRequestStarting("!v.")`.

e-TNGA registered two series **without** the prefix — `"!xte.charge"` (the
CHARGE_HANDSHAKE..CHARGE_DC charge series, which holds a raw `VehicleSignal*` aliasing the
vehicle's `m_pollsignal`) and `"!xte.vin"` (a `OnceOffPoll` that binds `this`). Because their
names didn't start with `"!v."`, they were **not** removed from the per-bus poll list when
`OvmsVehicle::ShuttingDown()` deleted `m_pollsignal`. The poller task then dereferenced the
freed signal → `LoadProhibited` crash.

## Fix

Rename both to `"!v.xte.charge"` / `"!v.xte.vin"` so the existing, documented teardown path
reclaims them. **No framework change required** — this honors the contract rather than working
around it.

## Scope note

An earlier revision of this PR added framework-level defense-in-depth (full-list signal
clearing, a teardown flag, `m_poll_series` reset). That was dropped: it's not needed to fix
this bug, and per the single-purpose-PR convention any such hardening belongs in its own
framework PR (one that would also need to cover the `StandardPacketPollSeries` case to protect
other vehicles with the same latent pattern). This PR is now e-TNGA-only.

## Validation

On-vehicle: `vehicle module NONE` then `vehicle module SUBSOL` (the crashing sequence) — expect
zero crashes and base polling re-armed.
