### PR TITLE
etnga: report v.c.type=ccs on DC fast charge

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -849,7 +849,9 @@ void OvmsVehicleToyotaETNGA::SetChargeType(int chargeType)
     // 0x161C "Charger Power Supply Voltage Type" enum (confirmed 2026-05-10):
     // 0 = None/unconnected, 1 = 100V Series, 2 = 200V Series. raw 0 must clear the
     // metric (no charge connected), NOT report "ccs" — that was the prior bug.
-    // DCFC value is still TBD pending a real DC charge.
+    // This DID encodes only the AC voltage type: a real DC fast-charge (2026-06-13) read 00
+    // here right up to engage, and 0x161C isn't polled in CHARGE_DC. The DC connector ("ccs")
+    // is therefore set from the charge state in TransitionToChargeDcState, not from this poll.
     switch (chargeType)
     {
         case 0x00:

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -374,6 +374,7 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
         bool delivered = (oldState == PollState::CHARGE_AC || oldState == PollState::CHARGE_DC);
         StandardMetrics.ms_v_charge_state->SetValue(delivered ? "done" : "");
         StandardMetrics.ms_v_charge_mode->SetValue("");   // clear AC/DC indicator on session end
+        StandardMetrics.ms_v_charge_type->SetValue("");   // clear connector type (DC sets "ccs" via state; AC safety-net)
         if (m_charge_session.in_session) {
             ESP_LOGI(TAG, "Charge session closed");
             LogChargeEvent("Unplugged");
@@ -485,5 +486,10 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeDcState()
     SetChargingStatus(true);
     SetChargeState(PollState::CHARGE_DC);
     StandardMetrics.ms_v_charge_mode->SetValue("performance");   // DC fast charge -> ABRP is_dcfc (v.c.mode == "performance")
+    // v.c.type is the connector/standard axis (type1/type2/ccs/...), separate from v.c.mode.
+    // 0x161C only encodes the AC voltage type (reads 00 on DC, and isn't polled in CHARGE_DC),
+    // so the DC connector can't come from the poll — set it from the state we already detect.
+    // The e-TNGA DC inlet is CCS. Cleared on session end in TransitionToAwakeState.
+    StandardMetrics.ms_v_charge_type->SetValue("ccs");
     LogChargeEvent("DC charging started");
 }


### PR DESCRIPTION
## What

Populate the standard `v.c.type` metric on DC fast charge.

`v.c.type` is the framework's charge **connector/standard** axis (`type1`/`type2`/`chademo`/`ccs`/…, per `metrics_standard.h` + `docs/.../metrics.rst`), distinct from `v.c.mode` (charge profile). The AC path already sets `type1`/`type2` from `0x161C`; DC was left blank.

## Why 0x161C can't supply it

`0x161C` ("Charger Power Supply Voltage Type", Plug-In Control System) encodes only the **AC** voltage type. The real 2026-06-13 ~100 kW DC session read `00` here right up to engage, and `0x161C` is HANDSHAKE-only cadence (`{5,0,0,0}`) so it isn't polled in `CHARGE_DC` at all. So the DC connector can't come from the poll.

## Change

- `TransitionToChargeDcState()`: set `v.c.type=ccs` (the e-TNGA DC inlet is CCS), next to the existing `v.c.mode=performance`.
- `TransitionToAwakeState()` session-end: clear `v.c.type` alongside `v.c.mode` (DC sets it via state, so it must be cleared on unplug; also an AC safety-net). Survives DC pause/resume since `0x161C` isn't polled in WAIT/DC.
- Refresh the stale `DCFC TBD` comment in `SetChargeType`.

## Validation

CI build only. AC `type1`/`type2` path already validated on-vehicle (live `02→type2` 2026-06-20). DC `ccs` path is **not yet on-vehicle validated** — needs a real DC charge to confirm.

Closes #6.