### PR TITLE
etnga: fix stale m_s_pollstate reference in state_machine.rst

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -18,7 +18,7 @@ Two parallel states
      - Type
      - Source
      - Values
-   * - ``PollState`` (``m_s_pollstate``)
+   * - ``PollState`` (base-class ``m_poll_state``)
      - Driver-owned; selects which OBD-II PIDs are polled
      - Internal transitions in ``etnga_poll_states.cpp``
      - ``SLEEP``, ``AWAKE``, ``DRIVING``, ``CHARGE_HANDSHAKE``,


### PR DESCRIPTION
Doc-only fix surfaced while triaging #24.

The `m_s_pollstate` shadow member was removed in `7534e13e` ("unify poll state"), but `vehicle_toyota_etnga/docs/state_machine.rst` still named it in the "Two parallel states" table. This points it at the base-class `m_poll_state` the driver actually uses — consistent with how the rest of the same doc already refers to it.

No code or behavior change.