### PR TITLE
etnga: snappier DRIVING→AWAKE via Ready falling-edge (Refs #78)

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -199,7 +199,25 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
 
 void OvmsVehicleToyotaETNGA::HandleDrivingState()
 {
-    if (m_s_controlstate->AsInt() != ControlState::CS_DRIVING) {
+    // Exit DRIVING on the FIRST of two drive-end signals:
+    //   1. Ready FALLING-EDGE (0x1076, Hybrid Control 0x7D2) — Ready clears the moment the
+    //      power button is pressed, ~2 s before HV actually drops, so it is the snappier
+    //      trigger. We require Ready to have been seen true this drive (m_ready_seen_in_drive)
+    //      before honouring its clear: AWAKE->DRIVING is entered on control mode, not Ready,
+    //      and 0x1076 is DRIVING-only, so ms_v_env_on is still false on the first tick and a
+    //      level check would immediately bounce back to AWAKE.
+    //   2. Control mode leaving Driving (0x10D1, OBC 0x745) — flips at the true key-off
+    //      instant (synchronous with the 0x4E0 HV-active broadcast ceasing) and comes from an
+    //      always-on-in-AWAKE ECU, so it is the reliable backstop.
+    // Both are already polled DRIVING@1s. Ready is only read while 0x7D2 is still awake (it
+    // does not sleep until ~4-7 s after key-off), and a 0x1076 timeout leaves ms_v_env_on
+    // unchanged (IncomingPollError takes no state action) — so #1 fires only on a clean
+    // NotReady, never on a timeout, and #2 backstops if Ready is missed. See issue #78.
+    if (StandardMetrics.ms_v_env_on->AsBool())
+        m_ready_seen_in_drive = true;
+
+    if ((m_ready_seen_in_drive && !StandardMetrics.ms_v_env_on->AsBool()) ||
+        m_s_controlstate->AsInt() != ControlState::CS_DRIVING) {
         TransitionToAwakeState();
         SetReadyStatus(false);
         SetVehicleSpeed(0);
@@ -420,6 +438,7 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
 void OvmsVehicleToyotaETNGA::TransitionToDrivingState()
 {
     m_armed_for_charge = false;
+    m_ready_seen_in_drive = false;   // arm the Ready falling-edge exit fresh for this drive (#78)
     ResetSleepBackoff();   // real drive — resume responsive cooldowns
     SetPollState(PollState::DRIVING);
     m_trip_start_valid = false;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -77,6 +77,9 @@ protected:
     bool m_12v_was_high = false;     // 12V-above-threshold latch: the SLEEP 12V wake fires on the rising edge only
                                      // (level-triggering oscillated; seeded on each sleep entry in TransitionToSleepState)
 
+    bool m_ready_seen_in_drive = false;  // Ready (0x1076) confirmed true since entering DRIVING; arms the
+                                         // Ready-falling-edge fast exit so the still-false entry value can't bounce us out (#78)
+
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
     int  m_cable_watch_start = 0;      // monotonic s when armed (15-min cable watch)
     int  m_charge_state_entry = 0;     // monotonic s of last charge-state entry (handshake 60s timer)


### PR DESCRIPTION
Implements the paired-trigger from the #78 investigation. **Not** a `Closes` — needs on-vehicle validation first.

## Change
`HandleDrivingState()` now exits on the **first** of two drive-end signals:
1. **Ready falling-edge** (`0x1076`, Hybrid Control `0x7D2`) — clears ~2 s before HV drops → the snappier primary.
2. **Control mode leaving Driving** (`0x10D1`, OBC `0x745`) — synchronous with true key-off per the turn-off census → reliable backstop (unchanged from today).

Both PIDs are already polled DRIVING@1s; no new polls.

## Why it is safe
- **Entry-edge guard:** AWAKE→DRIVING is entered on control mode, and `0x1076` is DRIVING-only, so `ms_v_env_on` is still `false` on the first DRIVING tick. A naive level check would bounce straight back to AWAKE. The new `m_ready_seen_in_drive` latch (reset in `TransitionToDrivingState`) requires Ready to have been confirmed true this drive before its clear can trigger an exit — i.e. a true falling-edge, not the entry value.
- **Timeout-safe:** `IncomingPollError` (`etnga_poll_processor.cpp:68`) takes no state action, so a `0x1076` timeout leaves `ms_v_env_on` unchanged. The fast path fires only on a clean NotReady; the `0x10D1` backstop bounds worst case to today’s behavior.

## Validation needed (on-vehicle)
- [ ] `DRIVING→AWAKE` lag drops ~2 s on a real drive.
- [ ] No spurious mid-drive NotReady causing an early exit.

No `changes.txt` entry — internal state-machine timing refinement, no user action/config.

Refs #78.