### PR TITLE
bz4x: enable per-cell BMS (mirror Solterra 96S pack) + doc/destructor fixes

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -13,6 +13,10 @@ Open Vehicle Monitor System v3 - Change log
                                               password configured under wifi.ssid
     [network] wifi.priority.interval       -- upgrade-scan period in seconds while on a non-top
                                               network (default: 60, minimum: 10)
+- Toyota bZ4X: per-cell BMS monitoring is now enabled. The /bms/cellmon page and the per-cell
+    voltage/temperature, deviation, and pack-statistics metrics now populate (matching the Subaru
+    Solterra), using the shared 96S CATL pack arrangement. Not yet validated on bZ4X hardware; a
+    bZ4X variant with a differently-sized pack would report an incorrect cell count. No config changes.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the module no longer drains the 12V battery
     while plugged in waiting for a scheduled charge. The charge-wait state now polls sparsely
     and, after a sustained idle wait, sleeps until charging actually starts (waking

--- a/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
@@ -22,17 +22,24 @@ Vehicle identity
 Vehicle-specific support
 ------------------------
 
-The bZ4X currently adds no behavioural overrides on top of the e-TNGA platform, so its supported functions
-match the e-TNGA baseline. In particular it does not declare a BMS pack arrangement, so per-cell BMS
-voltage/temperature monitoring is not enabled — unlike the
-:doc:`Subaru Solterra </components/vehicle_subaru_solterra/docs/index>`.
+The only behaviour the bZ4X adds on top of the e-TNGA platform is its BMS pack arrangement; everything
+else matches the e-TNGA baseline. Being mechanically the Subaru Solterra's twin, it declares the same
+96S CATL ("Type B") pack arrangement (96 cells in 4 stacks of 24; 24 temperature sensors, 6 per stack),
+which enables per-cell BMS voltage/temperature monitoring via the standard ``/bms/cellmon`` page — just
+like the :doc:`Subaru Solterra </components/vehicle_subaru_solterra/docs/index>`.
+
+.. note::
+
+   The per-cell BMS support has been validated on the Solterra but is **not yet validated on bZ4X
+   hardware**. It assumes the bZ4X carries the same 96-cell pack; a variant with a differently-sized
+   pack would report an incorrect cell count.
 
 Web UI
 ------
 
 All e-TNGA web UI pages are available on the bZ4X; see the
 :doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the
-full list.  Note that ``/bms/cellmon`` will appear in the menu but shows
-no cell data because the bZ4X does not declare a BMS pack arrangement.
-The charging pages (``/xte/charge``, ``/xte/reports``) and the TPMS
-configuration page (``/xte/config``) work normally.
+full list.  The per-cell ``/bms/cellmon`` page is populated because the
+bZ4X declares a BMS pack arrangement (see above).  The charging pages
+(``/xte/charge``, ``/xte/reports``) and the TPMS configuration page
+(``/xte/config``) work normally.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/src/vehicle_toyota_bz4x.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/src/vehicle_toyota_bz4x.cpp
@@ -14,13 +14,29 @@
 // Constructor for the OvmsVehicleToyotaBz4x class
 OvmsVehicleToyotaBz4x::OvmsVehicleToyotaBz4x()
 {
-ESP_LOGI(TAG, "Toyota bZ4X vehicle module");  // Log an informational message
+  ESP_LOGI(TAG, "Toyota bZ4X vehicle module");  // Log an informational message
+
+  // Battery pack: 96S CATL (Toyota EM "Type B"), 24 temperature sensors — the
+  // bZ4X is mechanically the Solterra's twin, so this mirrors that arrangement.
+  // 4 stacks of 24 cells (Toyota EM "Stack 1-4 Cell Average Voltage" grouping);
+  // 24 sensors map 6 per stack.
+  BmsSetCellArrangementVoltage(96, 24);
+  BmsSetCellArrangementTemperature(24, 6);
+
+  // Sanity bounds for accepting incoming readings as real (Type B cells: 3.0-4.208 V).
+  BmsSetCellLimitsVoltage(2.5f, 4.3f);
+  BmsSetCellLimitsTemperature(-30.0f, 60.0f);
+
+  // Per-cell deviation thresholds for warn / alert. Starting points;
+  // tighten after observing real cell spread on a healthy pack.
+  BmsSetCellDefaultThresholdsVoltage(0.020f, 0.030f);     // 20 mV warn / 30 mV alert
+  BmsSetCellDefaultThresholdsTemperature(4.0f, 8.0f);     // 4 °C warn / 8 °C alert
 }
 
 // Destructor for the OvmsVehicleToyotaBz4x class
 OvmsVehicleToyotaBz4x::~OvmsVehicleToyotaBz4x()
 {
-ESP_LOGI(TAG, "Toyota bZ4X vehicle module");  // Log an informational message
+  ESP_LOGI(TAG, "Shutdown Toyota bZ4X vehicle module");  // Log an informational message
 }
 
 // Initialization class for the Toyota bZ4X vehicle module

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -46,8 +46,8 @@ Others                      VIN
    (DID ``0x1814``) **are** polled while driving and during DC charging — but without a pack
    arrangement they are stored directly in the cell-voltage/temperature vector metrics rather
    than being routed through the BMS min/max/deviation API.  Subclasses that declare the pack
-   arrangement (notably the Subaru Solterra) therefore show ``BMS v+t Display: Yes`` and get
-   full per-cell history, deviation flags, and pack statistics automatically.
+   arrangement (the Subaru Solterra and Toyota bZ4X) therefore show ``BMS v+t Display: Yes`` and
+   get full per-cell history, deviation flags, and pack statistics automatically.
 
 PID Polling Logic
 =================
@@ -575,9 +575,9 @@ Solterra" or "Toyota bZ4X").
      - Purpose
    * - ``/bms/cellmon``
      - Vehicle
-     - BMS cell monitor — per-cell voltage and temperature display.  Populated only for
-       vehicles that declare a BMS pack arrangement (e.g. Solterra); empty for the base
-       e-TNGA and bZ4X.
+     - BMS cell monitor — per-cell voltage and temperature display.  Populated for
+       vehicles that declare a BMS pack arrangement (Solterra, bZ4X); empty for the
+       bare e-TNGA base.
    * - ``/xte/charge``
      - Vehicle
      - Live charging metrics dashboard — key charge telemetry during a session.


### PR DESCRIPTION
## What

Enable per-cell BMS monitoring on the Toyota bZ4X by declaring the same pack arrangement as its mechanical twin, the Subaru Solterra.

The bZ4X is the Solterra's badge-engineered twin (96S CATL "Type B" pack, 24 temperature sensors). Until now its wrapper declared **no** BMS arrangement, so the e-TNGA base fell back to a plain cell-voltage/temperature vector set and `/bms/cellmon` showed nothing. This adds `BmsSetCellArrangementVoltage(96, 24)` / `Temperature(24, 6)` (plus matching limits and deviation thresholds), which routes the `0x182E`/`0x1814` replies through the BMS API — populating `/bms/cellmon` and the per-cell / deviation / pack-statistics metrics, exactly like the Solterra.

On `master` this needs no auto-detect: the pack is 96 cells, matching the base's fixed-length decode.

## Also in this PR (bZ4X-local cleanups)

- Fix the destructor log message (was a verbatim copy of the constructor's; now `"Shutdown ..."` to match the family convention).
- Fix the column-0 body indentation in the constructor/destructor.
- Update the bZ4X and e-TNGA docs to reflect that the bZ4X now declares a pack arrangement (and that `/bms/cellmon` is populated).
- `changes.txt` entry (user-noticeable behavior change).

## Validation / caveat

**Not yet validated on bZ4X hardware** — the author runs a Solterra. The arrangement assumes the bZ4X carries the same 96-cell pack; on `master` (no length-based auto-detect) a variant with a differently-sized pack would report an incorrect cell count. This is called out in both the doc note and the changelog.