### PR TITLE
lexus_rz: add EXPERIMENTAL fork-only Lexus RZ (LEXRZ) over e-TNGA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
           ENABLE_VEHICLES: >-
             CONFIG_OVMS_VEHICLE_SUBARU_SOLTERRA
             CONFIG_OVMS_VEHICLE_TOYOTA_BZ4X
+            CONFIG_OVMS_VEHICLE_LEXUS_RZ
         run: |
           # Route the cross-compilers through ccache via a PATH shim: invoked as
           # e.g. xtensa-esp32-elf-gcc, ccache finds the real compiler next on PATH.

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -13,6 +13,11 @@ Open Vehicle Monitor System v3 - Change log
                                               password configured under wifi.ssid
     [network] wifi.priority.interval       -- upgrade-scan period in seconds while on a non-top
                                               network (default: 60, minimum: 10)
+- New experimental vehicle type "LEXRZ" (Lexus RZ), built on the Toyota e-TNGA base. Inherits the
+    e-TNGA CAN polling, charging state machine, and support baseline, and declares a best-guess
+    shared-EV-core pack (same 96S CATL arrangement as the Solterra/bZ4X). EXPERIMENTAL and NOT
+    validated on a real Lexus RZ; compiled into the fork build but disabled by default in menuconfig
+    (CONFIG_OVMS_VEHICLE_LEXUS_RZ). No config changes.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the module no longer drains the 12V battery
     while plugged in waiting for a scheduled charge. The charge-wait state now polls sparsely
     and, after a sustained idle wait, sleeps until charging actually starts (waking

--- a/vehicle/OVMS.V3/components/vehicle_lexus_rz/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/vehicle_lexus_rz/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(srcs)
+set(include_dirs)
+
+if (CONFIG_OVMS_VEHICLE_LEXUS_RZ)
+  list(APPEND srcs "src/vehicle_lexus_rz.cpp")
+  list(APPEND include_dirs "src")
+endif ()
+
+# requirements can't depend on config
+idf_component_register(SRCS ${srcs}
+                       INCLUDE_DIRS ${include_dirs}
+                       PRIV_REQUIRES "main"
+                       WHOLE_ARCHIVE)

--- a/vehicle/OVMS.V3/components/vehicle_lexus_rz/LICENSE
+++ b/vehicle/OVMS.V3/components/vehicle_lexus_rz/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Jerry Kezar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vehicle/OVMS.V3/components/vehicle_lexus_rz/component.mk
+++ b/vehicle/OVMS.V3/components/vehicle_lexus_rz/component.mk
@@ -1,0 +1,14 @@
+#
+# Main component makefile.
+#
+# This Makefile can be left empty. By default, it will take the sources in the
+# src/ directory, compile them and link them into lib(subdirectory_name).a
+# in the build directory. This behaviour is entirely configurable,
+# please read the ESP-IDF documents if you need to do this.
+#
+
+ifdef CONFIG_OVMS_VEHICLE_LEXUS_RZ
+COMPONENT_ADD_INCLUDEDIRS:=src
+COMPONENT_SRCDIRS:=src
+COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive
+endif

--- a/vehicle/OVMS.V3/components/vehicle_lexus_rz/src/vehicle_lexus_rz.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_lexus_rz/src/vehicle_lexus_rz.cpp
@@ -1,0 +1,50 @@
+/*
+   Project:       Open Vehicle Monitor System
+   Module:        Vehicle Lexus RZ
+   Date:          7th June 2026
+
+   (C) 2026       Jerry Kezar <solterra@kezarnet.com>
+
+   EXPERIMENTAL / UNVALIDATED — see vehicle_lexus_rz.h. Fork-only.
+
+   Licensed under the MIT License. See the LICENSE file for details.
+*/
+
+#include "ovms_log.h"
+#include "vehicle_lexus_rz.h"
+
+OvmsVehicleLexusRZ::OvmsVehicleLexusRZ()
+{
+  ESP_LOGI(TAG, "Lexus RZ vehicle module (EXPERIMENTAL / UNVALIDATED)");
+
+  // Best-guess shared-EV-core pack: same as the Solterra/bZ4X (96S CATL "Type B",
+  // 24 temperature sensors) until validated on a real RZ. The e-TNGA base decodes
+  // a fixed 96-cell 0x182E / 24-sensor 0x1814 reply, so an RZ variant with a
+  // differently-sized pack (e.g. RZ 450e) would report an incorrect cell count.
+  BmsSetCellArrangementVoltage(96, 24);
+  BmsSetCellArrangementTemperature(24, 6);
+
+  BmsSetCellLimitsVoltage(2.5f, 4.3f);
+  BmsSetCellLimitsTemperature(-30.0f, 60.0f);
+
+  BmsSetCellDefaultThresholdsVoltage(0.020f, 0.030f);
+  BmsSetCellDefaultThresholdsTemperature(4.0f, 8.0f);
+}
+
+OvmsVehicleLexusRZ::~OvmsVehicleLexusRZ()
+{
+  ESP_LOGI(TAG, "Shutdown Lexus RZ vehicle module");
+}
+
+class OvmsVehicleLexusRZInit
+{
+  public:
+    OvmsVehicleLexusRZInit();
+} MyOvmsVehicleLexusRZInit __attribute__ ((init_priority (9000)));
+
+OvmsVehicleLexusRZInit::OvmsVehicleLexusRZInit()
+  {
+  ESP_LOGI(OvmsVehicleLexusRZ::TAG, "Registering Vehicle: Lexus RZ (9000) [EXPERIMENTAL/UNVALIDATED]");
+
+  MyVehicleFactory.RegisterVehicle<OvmsVehicleLexusRZ>("LEXRZ","Lexus RZ");
+  }

--- a/vehicle/OVMS.V3/components/vehicle_lexus_rz/src/vehicle_lexus_rz.h
+++ b/vehicle/OVMS.V3/components/vehicle_lexus_rz/src/vehicle_lexus_rz.h
@@ -1,0 +1,32 @@
+/*
+   Project:       Open Vehicle Monitor System
+   Module:        Vehicle Lexus RZ
+   Date:          7th June 2026
+
+   (C) 2026       Jerry Kezar <solterra@kezarnet.com>
+
+   EXPERIMENTAL / UNVALIDATED: this wrapper inherits the Toyota e-TNGA logic
+   wholesale and declares best-guess shared-EV-core pack constants. It has NOT
+   been validated against a real Lexus RZ. Fork-only — do not upstream until
+   validated on hardware. The pack arrangement assumes the same 96-cell pack as
+   the Solterra / bZ4X; an RZ variant with a differently-sized pack would report
+   an incorrect cell count.
+
+   Licensed under the MIT License. See the LICENSE file for details.
+*/
+
+#ifndef __VEHICLE_LEXUS_RZ_H__
+#define __VEHICLE_LEXUS_RZ_H__
+
+#include "../../vehicle_toyota_etnga/src/vehicle_toyota_etnga.h"  // Toyota e-TNGA base
+
+class OvmsVehicleLexusRZ : public OvmsVehicleToyotaETNGA
+{
+public:
+  OvmsVehicleLexusRZ();
+  ~OvmsVehicleLexusRZ();
+  static constexpr const char* TAG = "v-lexus-rz";
+
+};
+
+#endif // __VEHICLE_LEXUS_RZ_H__

--- a/vehicle/OVMS.V3/main/Kconfig
+++ b/vehicle/OVMS.V3/main/Kconfig
@@ -731,6 +731,15 @@ config OVMS_VEHICLE_SUBARU_SOLTERRA
     help
         Enable to include support for Subaru Solterra vehicles.
 
+config OVMS_VEHICLE_LEXUS_RZ
+    bool "Include support for Lexus RZ vehicles (EXPERIMENTAL/UNVALIDATED)"
+    default n
+    depends on OVMS
+    help
+        Enable to include support for Lexus RZ vehicles.
+        EXPERIMENTAL: inherits the Toyota e-TNGA logic and has not been validated
+        on a real Lexus RZ. Off by default.
+
 endmenu # Vehicle Support
 
 menu "Component Options"


### PR DESCRIPTION
## What

Add a thin **Lexus RZ** vehicle (`LEXRZ`, "Lexus RZ") that inherits the Toyota e-TNGA base wholesale — same pattern as the Subaru Solterra and Toyota bZ4X wrappers. The RZ is another e-TNGA EV, so it picks up the shared CAN polling, charging state machine, TPMS, web UI, etc. for free, and declares a best-guess shared-EV-core BMS pack arrangement (96S CATL "Type B", 24 temp sensors) to enable per-cell BMS.

## Scope

Self-contained — touches only:
- New `components/vehicle_lexus_rz/` (CMakeLists.txt, component.mk, LICENSE, `src/vehicle_lexus_rz.{cpp,h}`)
- `main/Kconfig` — `CONFIG_OVMS_VEHICLE_LEXUS_RZ`, **default n**
- `.github/workflows/build.yml` — added to the fork CI `ENABLE_VEHICLES` list so it's compile-checked
- `changes.txt`

No changes to the e-TNGA base or any other vehicle.

## EXPERIMENTAL / UNVALIDATED

This has **not** been tested against a real Lexus RZ — it's a fork-only, default-off stub for future work, marked EXPERIMENTAL in the Kconfig help, the source headers, and the registration log. The pack arrangement assumes the same 96-cell pack as the Solterra/bZ4X; an RZ variant with a differently-sized pack would report an incorrect cell count. Not intended for upstream until validated on hardware.

## Note

This was extracted clean from the stale `feature/etnga-multivariant` branch onto current master. The BMS pack-size **auto-detect** that lived alongside it on that branch is intentionally **not** included here — it's a separate e-TNGA framework change and belongs in its own PR.