### PR TITLE
etnga: derive BMS cell/sensor counts from reply length + auto-arrange

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -13,6 +13,10 @@ Open Vehicle Monitor System v3 - Change log
                                               password configured under wifi.ssid
     [network] wifi.priority.interval       -- upgrade-scan period in seconds while on a non-top
                                               network (default: 60, minimum: 10)
+- Toyota e-TNGA: BMS per-cell handling now derives the cell and temperature-sensor counts from the
+    0x182E / 0x1814 reply length instead of a fixed 96-cell / 24-sensor pack, and auto-aligns the BMS
+    arrangement total to match. This makes per-cell BMS index-safe across e-TNGA pack variants. No
+    change for the existing 96-cell pack (Solterra / bZ4X); short replies are still rejected. No config changes.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the module no longer drains the 12V battery
     while plugged in waiting for a scheduled charge. The charge-wait state now polls sparsely
     and, after a sustained idle wait, sleeps until charging actually starts (waking

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -153,11 +153,13 @@ float OvmsVehicleToyotaETNGA::CalculateBatterySOCBMS(const std::string& data)
 
 std::vector<float> OvmsVehicleToyotaETNGA::CalculateBatteryCellVoltages(const std::string& data)
 {
-    // 0x182E payload: 96 cells × uint16 BE; each LSB = 5/65535 V (~76 µV).
+    // 0x182E payload: N cells × uint16 BE; each LSB = 5/65535 V (~76 µV).
+    // Cell count is taken from the reply length so differently-sized e-TNGA
+    // packs (bZ4X / Solterra / RZ) are index-safe — there is no cell-count PID.
     std::vector<float> voltages;
-    voltages.reserve(96);
+    voltages.reserve(data.size() / 2);
 
-    for (size_t i = 0; i < 192; i += 2) {
+    for (size_t i = 0; i + 1 < data.size(); i += 2) {
         uint16_t raw = GetRxBUint16(data, i);
         voltages.push_back(static_cast<float>(raw) * 5.0f / 65535.0f);
     }
@@ -183,9 +185,12 @@ std::vector<float> OvmsVehicleToyotaETNGA::CalculateBatteryCapacityArray(const s
 
 std::vector<float> OvmsVehicleToyotaETNGA::CalculateBatteryTemperatures(const std::string& data)
 {
+    // 0x1814 payload: N sensors × int16 BE Q8.8, −50 °C. Sensor count from reply
+    // length (no sensor-count PID) so all e-TNGA pack variants are index-safe.
     std::vector<float> temperatures;
+    temperatures.reserve(data.size() / 2);
 
-    for (size_t i = 0; i < 48; i += 2) {
+    for (size_t i = 0; i + 1 < data.size(); i += 2) {
         int16_t temperatureRaw = GetRxBInt16(data, i);
         float temperature = static_cast<float>(temperatureRaw) / 256.0f - 50.0f;
         temperatures.push_back(temperature);
@@ -743,6 +748,10 @@ void OvmsVehicleToyotaETNGA::SetBatteryCellVoltages(const std::vector<float>& vo
     // BMS API so it can maintain per-cell history, deviation flags, and pack stats.
     // Otherwise fall back to a direct vector set.
     if (BmsGetCellArangementVoltage() > 0) {
+        // Auto-detect: align the BMS voltage arrangement total with the actual
+        // reply size. 0 = keep the subclass-declared cells-per-module grouping.
+        // No-op (returns false) when the count already matches, e.g. Solterra 96.
+        BmsCheckChangeCellArrangementVoltage(static_cast<int>(voltages.size()), 0);
         BmsRestartCellVoltages();
         for (size_t i = 0; i < voltages.size(); ++i) {
             BmsSetCellVoltage(static_cast<int>(i), voltages[i]);
@@ -799,6 +808,9 @@ void OvmsVehicleToyotaETNGA::SetBatteryTemperatures(const std::vector<float>& te
     // the BMS API so it can maintain per-cell history, deviation flags, and pack stats.
     // Otherwise fall back to a direct vector set (legacy / un-arranged subclasses).
     if (BmsGetCellArangementTemperature() > 0) {
+        // Auto-detect: align the BMS temperature arrangement total with the actual
+        // reply size. 0 = keep the subclass-declared sensors-per-module grouping.
+        BmsCheckChangeCellArrangementTemperature(static_cast<int>(temperatures.size()), 0);
         BmsRestartCellTemperatures();
         for (size_t i = 0; i < temperatures.size(); ++i) {
             BmsSetCellTemperature(static_cast<int>(i), temperatures[i]);


### PR DESCRIPTION
## What

Make the e-TNGA BMS per-cell handling **pack-size-agnostic**. Today the decode hard-codes 96 cells (192-byte `0x182E`) and 24 temperature sensors (48-byte `0x1814`). This PR derives the counts from the reply length and aligns the BMS arrangement total to match, so e-TNGA variants with differently-sized packs are index-safe (there is no cell-count PID to query).

- `CalculateBatteryCellVoltages` / `CalculateBatteryTemperatures`: decode N readings from `data.size()` instead of a fixed loop bound.
- `SetBatteryCellVoltages` / `SetBatteryTemperatures`: call `BmsCheckChangeCellArrangement{Voltage,Temperature}(count, 0)` — aligns the total, keeps the subclass-declared per-module grouping, and is a no-op when the count already matches.

## Provenance

Reconstructed from the stale `feature/etnga-multivariant` branch (93 commits behind master) onto current master. The branch's `0x182E`/`0x1814` decode and `Set*` functions were byte-identical to today's master, so the decode/auto-arrange ports cleanly.

## ⚠️ One deliberate deviation from the branch — needs your call

Since that branch was written, master gained **short-reply size guards** in the PID handler (`etnga_poll_processor.cpp` rejects `< 192 B` / `< 48 B`, from the PR #104 review hardening). The branch had no such guards — it *trusted the reply length*. Trusting the length means a **truncated** 180-byte reply would auto-shrink the Solterra's arrangement 96→90 and corrupt it — reintroducing exactly what PR #104 fixed, on the daily driver.

So I **kept master's guards** and left `etnga_poll_processor.cpp` untouched. Consequences:
- ✅ Solterra / bZ4X (96S pack): behavior is **byte-identical** (192/48-byte reply → 96/24 → arrange no-op).
- ✅ A genuinely **larger** pack (reply ≥ nominal) auto-grows safely.
- ⚠️ A **smaller** pack is **not** auto-detected — its short reply is rejected by the size guard (indistinguishable from a truncated reply).
- The branch's third commit (`c8834613`, skip-on-empty guard) is therefore **redundant** here and omitted.

**Question for review:** is grow-only the behavior you want, or do you want the branch's original "trust the length, allow shrink" behavior? The latter needs the `< 192`/`< 48` guards relaxed and the empty-guard added back — at the cost of the partial-reply protection. I went with the safe default; happy to switch.

## Validation

No on-vehicle validation possible from here: it is a **no-op on the 96S Solterra** (the only e-TNGA hardware available), and there is no differently-sized e-TNGA pack to test against. Compile-checked via CI.

## Relationship to the other PRs

Independent of #130 (bZ4X BMS) and #131 (Lexus RZ) — those declare the 96-cell arrangement and work without this. This PR is the forward-compat layer that would let a future differently-sized variant self-align.