### PR TITLE
etnga: multi-phase charge-session report (INC-1 of #81)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-etnga-charge-report-multiphase.md
+++ b/docs/superpowers/plans/2026-06-23-etnga-charge-report-multiphase.md
@@ -1,0 +1,486 @@
+# e-TNGA charge report — multi-phase (INC-1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the single-phase e-TNGA charge-session report into a multi-phase model (plug-in → unplug may contain multiple AC/DC active phases), render the Option A layout (one session SVG + per-phase summaries), and add a `phase` column to the per-sample CSV.
+
+**Architecture:** `phases[]` is **purely additive** — the existing session-level aggregates (peak/temp/Ah/station_kWh, SVG buffer, CSV stream) are left exactly as they are so the validated Summary block does not regress; a parallel `std::vector<ChargePhase>` is opened on each `CHARGE_AC`/`CHARGE_DC` entry and closed on `CHARGE_WAIT` (and defensively at report time). Per-phase energy is a snapshot delta of `ms_v_charge_kwh`; per-phase peak/temp/Ah are tracked in the per-tick aggregator. The report gains a `Phases: N` summary line, one `<dl>` block per phase, and phase-boundary markers on the existing SVG.
+
+**Tech Stack:** C++ (ESP-IDF 3.3 / older GCC), OVMS standard metrics, the e-TNGA vehicle component (`components/vehicle_toyota_etnga/`). No new dependencies.
+
+## Global Constraints
+
+- **C++ for ESP-IDF 3.3 / older GCC.** Match the surrounding file's existing style exactly (`snprintf` into stack `char b[]`, `ESP_LOGx(TAG, …)`, no exceptions, no STL surprises beyond what the file already uses: `std::vector`, `std::string`, `std::ostringstream`).
+- **No host unit-test suite.** This firmware compiles on GitHub CI, not locally; behavior is validated on-device. Per task, the gate is **(a) a code-inspection check** (the shown `grep`/reasoning) and **(b) the CI build**. Trigger CI for this branch with `gh workflow run build.yml --ref feature/etnga-charge-multiphase` (push trigger is master-only; feature branches build via manual dispatch or PR) and confirm green before merge. Do **not** propose a local `make` as the verification step.
+- **`phases[]` is additive** — do not remove or repurpose the existing session-level `peak_power`, `temp_*`, `delivered_ah`, `station_kwh`, `svg`, or CSV fields. The Summary block keeps using them.
+- **Pointer safety:** track the open phase with an **index** `int cur = -1`, never a `ChargePhase*` (a `push_back` realloc would dangle a pointer).
+- **HTML-escape free text** before interpolation (outcome labels already routed through `ChargeOutcomeLabel`; no new free text in INC-1, but keep the rule).
+- **Single-purpose PR / `changes.txt`:** this is one vehicle, one feature; add a `changes.txt` entry (new user-facing multi-phase report).
+- **Work in the worktree** `/home/devuser/wt-etnga-charge-multiphase` on branch `feature/etnga-charge-multiphase`. All paths below are relative to `vehicle/OVMS.V3/components/vehicle_toyota_etnga/`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/vehicle_toyota_etnga.h` | `ChargeSessionState` struct + method decls | Add `ChargePhase` struct, `phases`/`cur`/`report_written`; declare `OpenChargePhase(bool)`, `CloseChargePhase()`. |
+| `src/etnga_poll_states.cpp` | State transitions | Call `OpenChargePhase(is_dc)` in AC/DC transitions, `CloseChargePhase()` in WAIT transition. |
+| `src/etnga_charge_report.cpp` | Session stats, CSV, report render, SVG | Phase helpers; per-phase aggregation; CSV `phase` column; multi-phase report; SVG phase markers; report idempotency + defensive close. |
+| `changes.txt` (repo: `vehicle/OVMS.V3/changes.txt`) | User-facing changelog | New entry. |
+
+---
+
+## Task 1: Data model — `ChargePhase` + session fields
+
+**Files:**
+- Modify: `src/vehicle_toyota_etnga.h:87-124` (the `ChargeSessionState` struct) and the method-declaration block near `:199`.
+
+**Interfaces:**
+- Produces: `struct ChargePhase` with fields used by all later tasks; `m_charge_session.phases` (`std::vector<ChargePhase>`), `m_charge_session.cur` (`int`, -1 = none), `m_charge_session.report_written` (`bool`); method decls `void OpenChargePhase(bool is_dc);` and `void CloseChargePhase();`.
+
+- [ ] **Step 1: Add the `ChargePhase` struct + new session fields**
+
+In `src/vehicle_toyota_etnga.h`, inside `struct ChargeSessionState`, immediately before the closing `};` at line 123, add:
+
+```cpp
+        // INC-1: per-phase tracking. phases[] is additive — the session-level
+        // aggregates above stay authoritative for the Summary block.
+        struct ChargePhase {
+            bool   is_dc = false;
+            int    start_monotonic = 0;
+            time_t start_utc = 0;
+            int    start_soc = -1;
+            int    end_monotonic = 0;
+            int    end_soc = -1;
+            float  kwh_at_open = 0.0f;   // ms_v_charge_kwh snapshot at phase open
+            float  energy_kwh = 0.0f;    // computed at close (delta)
+            float  peak_power = 0.0f;    // kW into battery
+            float  delivered_ah = 0.0f;  // phase-local coulomb count
+            bool   temp_seen = false;
+            float  temp_min = 0.0f;
+            float  temp_max = 0.0f;
+            int    outcome = -1;         // 0x1688 latched at close
+        };
+        std::vector<ChargePhase> phases;
+        int   cur = -1;                  // index of the open phase in phases, -1 = none
+        bool  report_written = false;    // idempotency guard for GenerateChargeReport
+```
+
+- [ ] **Step 2: Declare the phase helpers**
+
+In `src/vehicle_toyota_etnga.h`, next to the existing `void GenerateChargeReport();` declaration (around line 199), add:
+
+```cpp
+    void OpenChargePhase(bool is_dc);   // INC-1: start a new charge phase on AC/DC entry
+    void CloseChargePhase();            // INC-1: close the open phase on WAIT / report time
+```
+
+- [ ] **Step 3: Inspection check**
+
+Run: `grep -n 'struct ChargePhase\|std::vector<ChargePhase>\|int   cur = -1\|OpenChargePhase\|CloseChargePhase' src/vehicle_toyota_etnga.h`
+Expected: the struct, `phases`, `cur`, `report_written`, and both method decls are present. `cur` defaults to `-1`; `report_written` to `false`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vehicle_toyota_etnga.h
+git commit -m "etnga: add ChargePhase model + per-session phases[] (INC-1, #81)"
+```
+
+---
+
+## Task 2: Phase lifecycle helpers + transition wiring
+
+**Files:**
+- Modify: `src/etnga_charge_report.cpp` (add the two helpers; place them next to `LogChargeEvent`, after line 153).
+- Modify: `src/etnga_poll_states.cpp:493-527` (the three transition functions).
+
+**Interfaces:**
+- Consumes: `ChargePhase`, `m_charge_session.{phases,cur}` (Task 1).
+- Produces: `OpenChargePhase(bool)` / `CloseChargePhase()` definitions; `phases` populated across a session.
+
+- [ ] **Step 1: Implement the helpers**
+
+In `src/etnga_charge_report.cpp`, after the `LogChargeEvent` function (ends line 153), add:
+
+```cpp
+// INC-1: open a new charge phase on CHARGE_AC / CHARGE_DC entry. No-op if a phase is
+// already open (guards a 1 s state flap from double-opening). Snapshots the session
+// kWh meter so the phase energy is a delta at close.
+void OvmsVehicleToyotaETNGA::OpenChargePhase(bool is_dc)
+{
+    if (!m_charge_session.in_session || m_charge_session.cur >= 0)
+        return;
+    ChargeSessionState::ChargePhase ph;
+    ph.is_dc          = is_dc;
+    ph.start_monotonic = StandardMetrics.ms_m_monotonic->AsInt();
+    ph.start_utc      = StandardMetrics.ms_m_timeutc->AsInt();
+    ph.start_soc      = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+    ph.kwh_at_open    = StandardMetrics.ms_v_charge_kwh->AsFloat();
+    m_charge_session.phases.push_back(ph);
+    m_charge_session.cur = (int) m_charge_session.phases.size() - 1;
+    ESP_LOGD(TAG, "Charge phase %d open (%s)", m_charge_session.cur + 1, is_dc ? "DC" : "AC");
+}
+
+// INC-1: close the open phase on CHARGE_WAIT entry (or defensively at report time).
+// No-op if no phase is open. Energy is the kWh-meter delta since open; outcome latches 0x1688.
+void OvmsVehicleToyotaETNGA::CloseChargePhase()
+{
+    if (m_charge_session.cur < 0)
+        return;
+    ChargeSessionState::ChargePhase& ph = m_charge_session.phases[m_charge_session.cur];
+    ph.end_monotonic = StandardMetrics.ms_m_monotonic->AsInt();
+    ph.end_soc       = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+    ph.energy_kwh    = StandardMetrics.ms_v_charge_kwh->AsFloat() - ph.kwh_at_open;
+    if (ph.energy_kwh < 0.0f) ph.energy_kwh = 0.0f;
+    ph.outcome       = m_v_charge_outcome->AsInt();
+    ESP_LOGD(TAG, "Charge phase %d closed (%.2f kWh, %d%%->%d%%)",
+             m_charge_session.cur + 1, ph.energy_kwh, ph.start_soc, ph.end_soc);
+    m_charge_session.cur = -1;
+}
+```
+
+- [ ] **Step 2: Open a phase on AC entry**
+
+In `src/etnga_poll_states.cpp`, in `TransitionToChargeAcState()` (line 502), after the existing `LogChargeEvent("AC charging started");` (line 510), add:
+
+```cpp
+    OpenChargePhase(false);   // INC-1: AC phase
+```
+
+- [ ] **Step 3: Open a phase on DC entry**
+
+In `TransitionToChargeDcState()` (line 513), after `LogChargeEvent("DC charging started");` (line 526), add:
+
+```cpp
+    OpenChargePhase(true);    // INC-1: DC phase
+```
+
+- [ ] **Step 4: Close the phase on WAIT entry**
+
+In `TransitionToChargeWaitState()` (line 493), after `LogChargeEvent("Charging paused / phase ended");` (line 499), add:
+
+```cpp
+    CloseChargePhase();       // INC-1: close the active phase (pause / phase end)
+```
+
+- [ ] **Step 5: Inspection check**
+
+Run: `grep -n 'OpenChargePhase\|CloseChargePhase' src/etnga_poll_states.cpp src/etnga_charge_report.cpp`
+Expected: definitions in `etnga_charge_report.cpp`; `OpenChargePhase(false)` in the AC transition, `OpenChargePhase(true)` in the DC transition, `CloseChargePhase()` in the WAIT transition. Reason through one session: HANDSHAKE (no phase) → AC entry opens phase 0 → WAIT closes it (`cur=-1`) → AC re-entry opens phase 1. Two phases, correct.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/etnga_charge_report.cpp src/etnga_poll_states.cpp
+git commit -m "etnga: open/close charge phases on AC/DC<->WAIT transitions (INC-1, #81)"
+```
+
+---
+
+## Task 3: Per-phase stat aggregation
+
+**Files:**
+- Modify: `src/etnga_charge_report.cpp:158-200` (`UpdateChargeSessionStats`).
+
+**Interfaces:**
+- Consumes: `m_charge_session.{cur,phases}`, `ChargePhase` fields (Tasks 1-2).
+- Produces: per-phase `peak_power`, `temp_min/max`, `delivered_ah` filled live.
+
+- [ ] **Step 1: Fold per-phase peak/temp into the aggregator**
+
+In `UpdateChargeSessionStats()`, immediately after the existing session ambient block (after line 185, before the `m_charge_session.is_dc = …` line 187), add:
+
+```cpp
+    // INC-1: mirror peak power + battery-temp range into the open phase (additive to the
+    // session-level aggregates above). cur < 0 between phases (WAIT) — skip then.
+    if (m_charge_session.cur >= 0) {
+        ChargeSessionState::ChargePhase& ph = m_charge_session.phases[m_charge_session.cur];
+        if (p > ph.peak_power) ph.peak_power = p;
+        if (!ph.temp_seen) { ph.temp_min = ph.temp_max = t; ph.temp_seen = true; }
+        else if (t < ph.temp_min) ph.temp_min = t;
+        else if (t > ph.temp_max) ph.temp_max = t;
+    }
+```
+
+- [ ] **Step 2: Fold per-phase delivered-Ah into the dt block**
+
+In the delivered-Ah block (lines 190-199), inside the `if (dt > 0 && dt <= 10)` body, after the existing `m_charge_session.delivered_ah += …` line (193), add:
+
+```cpp
+            if (m_charge_session.cur >= 0)
+                m_charge_session.phases[m_charge_session.cur].delivered_ah +=
+                    fabsf(StandardMetrics.ms_v_bat_current->AsFloat()) * (dt / 3600.0f);
+```
+
+- [ ] **Step 3: Inspection check**
+
+Run: `grep -n 'phases\[m_charge_session.cur\]' src/etnga_charge_report.cpp`
+Expected: three references in `UpdateChargeSessionStats` (peak, temp, Ah). Confirm `p` and `t` are already in scope at the insertion point (they are — defined at lines 165 and 169).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/etnga_charge_report.cpp
+git commit -m "etnga: aggregate peak/temp/Ah per charge phase (INC-1, #81)"
+```
+
+---
+
+## Task 4: CSV `phase` column
+
+**Files:**
+- Modify: `src/etnga_charge_report.cpp:243-280` (`AppendChargeCsvRow`).
+
+**Interfaces:**
+- Consumes: `m_charge_session.cur` (Task 1).
+- Produces: CSV header + rows lead with a `phase` column (1-based; `0` = no open phase).
+
+- [ ] **Step 1: Add `phase` to the header**
+
+In `AppendChargeCsvRow`, change the header string (line 244) from starting `"elapsed_s,soc_pct,…"` to lead with `phase,`:
+
+```cpp
+        m_charge_session.csv_buf =
+            "phase,elapsed_s,soc_pct,bms_soc_pct,station_kw,battery_kw,hvac_kw,pack_v,pack_a,"
+            "batt_temp_c,ambient_c,state,station_max_kw,station_max_a,station_max_v,"
+            "car_perm_kw,car_target_a,station_grid_kw,station_present_v,station_present_a,obc_kw\n";
+```
+
+- [ ] **Step 2: Add the phase value to each row**
+
+In the same function, compute the phase number before the `snprintf(row, …)` (before line 262):
+
+```cpp
+    int phase_no = (m_charge_session.cur >= 0) ? (m_charge_session.cur + 1) : 0;
+```
+
+Then change the row format string (line 263) to lead with `%d,` and pass `phase_no` first. The format becomes:
+
+```cpp
+    snprintf(row, sizeof(row),
+        "%d,%d,%.0f,%.1f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%s,%s,"
+        "%.2f,%.0f,%.0f,%.2f,%.0f,%.3f,%.0f,%.0f,%.3f\n",
+        phase_no,
+        elapsed,
+```
+
+(The remaining arguments are unchanged; `phase_no` is the new first arg, `elapsed` stays second.)
+
+- [ ] **Step 3: Inspection check**
+
+Run: `grep -n 'phase,elapsed_s\|int phase_no\|phase_no,' src/etnga_charge_report.cpp`
+Expected: header leads with `phase,`; `phase_no` computed and passed as the first `snprintf` value. Count the format specifiers (21) against the argument count (21) — the leading `%d,` for `phase_no` plus the original 20.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/etnga_charge_report.cpp
+git commit -m "etnga: add phase column to charge CSV (INC-1, #81)"
+```
+
+---
+
+## Task 5: Multi-phase report rendering + idempotency
+
+**Files:**
+- Modify: `src/etnga_charge_report.cpp` — `GenerateChargeReport` head (`:425-438`), Summary `<dl>` (`:472-533`), per-phase insertion after the SVG (`:536`), footer (`:570-571`).
+
+**Interfaces:**
+- Consumes: `m_charge_session.{phases,report_written}`, `CloseChargePhase()`, `ChargeOutcomeLabel` (existing), `ChargePhase` fields.
+- Produces: report with `Phases: N`, one `<dl>` per phase, multi-phase footer; idempotent + defensive phase close.
+
+- [ ] **Step 1: Idempotency + defensive close at report head**
+
+In `GenerateChargeReport()`, at the very top (before line 427's `const float energy_kwh = …`), add:
+
+```cpp
+    if (m_charge_session.report_written)
+        return;                 // defensive idempotency
+    CloseChargePhase();         // close any still-open phase (direct AC/DC->AWAKE safety net)
+```
+
+- [ ] **Step 2: Add the phase count to the Summary**
+
+In the Summary `<dl>`, after the existing `Type` line (the `f << "<dt>Type</dt>…"` at line 495), add a phase-count line:
+
+```cpp
+    {
+        char pc[48];
+        snprintf(pc, sizeof(pc), "%u", (unsigned) m_charge_session.phases.size());
+        f << "<dt>Phases</dt><dd>" << pc << "</dd>\n";
+    }
+```
+
+- [ ] **Step 3: Render per-phase blocks after the SVG**
+
+In `GenerateChargeReport`, immediately after the `RenderPowerSvg(f);` line (536), insert the per-phase loop:
+
+```cpp
+    // INC-1: per-phase summary blocks (Option A — no per-phase sample tables; the full
+    // timeline stays in the single CSV with its phase column).
+    for (size_t i = 0; i < m_charge_session.phases.size(); i++) {
+        const ChargeSessionState::ChargePhase& ph = m_charge_session.phases[i];
+        int pdur = ph.end_monotonic - ph.start_monotonic; if (pdur < 0) pdur = 0;
+        float pavg = (pdur > 0) ? ph.energy_kwh / (pdur / 3600.0f) : 0.0f;
+        char pb[96];
+        f << "<h2>Phase " << (i + 1) << " &mdash; " << (ph.is_dc ? "DC fast" : "AC") << "</h2>\n<dl>\n";
+        if (ph.start_utc > 1000000000) {
+            time_t st = (time_t) ph.start_utc, et = st + pdur; struct tm tmv;
+            char ps[40], pe[40];
+            gmtime_r(&st, &tmv); strftime(ps, sizeof(ps), "%H:%M:%S", &tmv);
+            gmtime_r(&et, &tmv); strftime(pe, sizeof(pe), "%H:%M:%S", &tmv);
+            snprintf(pb, sizeof(pb), "%s &rarr; %s UTC (%dh %02dm %02ds)", ps, pe,
+                     pdur/3600, (pdur%3600)/60, pdur%60);
+            f << "<dt>Active</dt><dd>" << pb << "</dd>\n";
+        }
+        snprintf(pb, sizeof(pb), "%d%% &rarr; %d%% (+%d%%)", ph.start_soc, ph.end_soc,
+                 ph.start_soc >= 0 ? ph.end_soc - ph.start_soc : 0);
+        f << "<dt>SOC</dt><dd>" << pb << "</dd>\n";
+        snprintf(pb, sizeof(pb), "%.2f kWh; %.1f kW peak / %.2f kW avg",
+                 ph.energy_kwh, ph.peak_power, pavg);
+        f << "<dt>Energy</dt><dd>" << pb << "</dd>\n";
+        if (ph.temp_seen) {
+            metric_unit_t tu = OvmsMetricGetUserUnit(GrpTemp, Celcius);
+            const char* tlabel = OvmsMetricUnitLabel(tu);
+            float lo = UnitConvert(Celcius, tu, ph.temp_min), hi = UnitConvert(Celcius, tu, ph.temp_max);
+            snprintf(pb, sizeof(pb), "%.0f%s &rarr; %.0f%s", lo, tlabel, hi, tlabel);
+            f << "<dt>Battery temp</dt><dd>" << pb << "</dd>\n";
+        }
+        {
+            const char* lbl = ChargeOutcomeLabel(ph.outcome);
+            if (lbl[0]) f << "<dt>Outcome</dt><dd>" << lbl << "</dd>\n";
+            else if (ph.outcome >= 0) {
+                snprintf(pb, sizeof(pb), "0x%02X (raw)", ph.outcome & 0xFF);
+                f << "<dt>Outcome</dt><dd>" << pb << "</dd>\n";
+            }
+        }
+        f << "</dl>\n";
+    }
+```
+
+- [ ] **Step 4: Update the footer text and set `report_written`**
+
+Change the footer note (lines 570-571) from the "Single-phase" wording to multi-phase, and set the idempotency flag just before the job enqueue (before line 573's `etnga_io_job* job = new etnga_io_job;`):
+
+```cpp
+    f << "<p class=\"note\">Generated on-module by OVMS (Toyota e-TNGA). Multi-phase; per-phase "
+         "avg power is over each active interval. Estimates are provisional.</p>\n</body></html>\n";
+    m_charge_session.report_written = true;
+```
+
+- [ ] **Step 5: Inspection check**
+
+Run: `grep -n 'report_written\|<dt>Phases</dt>\|Phase " << (i + 1)\|Multi-phase' src/etnga_charge_report.cpp`
+Expected: idempotency guard + `CloseChargePhase()` at the head; `Phases` count in the Summary; the per-phase loop after `RenderPowerSvg`; `report_written = true` before enqueue; multi-phase footer. Confirm `ChargeOutcomeLabel`, `OvmsMetricGetUserUnit`, `UnitConvert`, `Celcius`, `GrpTemp` are already used elsewhere in the file (they are — Summary block) so no new includes are needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/etnga_charge_report.cpp
+git commit -m "etnga: render multi-phase charge report (Option A) + idempotency (INC-1, #81)"
+```
+
+---
+
+## Task 6: SVG phase-boundary markers
+
+**Files:**
+- Modify: `src/etnga_charge_report.cpp:362-366` (inside `RenderPowerSvg`, after the axis lines, before the SOC overlay at line 367).
+
+**Interfaces:**
+- Consumes: `m_charge_session.{phases,start_monotonic}`, the SVG geometry locals `PADL/PADT/PW/PH/tmax/W/PADR/H/PADB` already defined in `RenderPowerSvg`.
+- Produces: a faint vertical dashed line at each phase start/end on the chart.
+
+- [ ] **Step 1: Draw boundary markers**
+
+In `RenderPowerSvg`, after the three axis-line `snprintf`/`out` statements (line 365 is the bottom-time axis), before the `// SOC overlay` comment (line 367), add:
+
+```cpp
+    // INC-1: phase-boundary markers (vertical dashed lines at each phase start/end),
+    // mapped from monotonic seconds onto the same time axis the traces use.
+    for (size_t i = 0; i < m_charge_session.phases.size(); i++) {
+        const ChargeSessionState::ChargePhase& ph = m_charge_session.phases[i];
+        int bounds[2] = { ph.start_monotonic - m_charge_session.start_monotonic,
+                          ph.end_monotonic   - m_charge_session.start_monotonic };
+        for (int k = 0; k < 2; k++) {
+            int ts = bounds[k];
+            if (ts <= 0 || ts > tmax) continue;   // off-chart / unset end
+            float x = PADL + (float)PW * ts / tmax;
+            snprintf(b, sizeof(b),
+                "<line x1=\"%.1f\" y1=\"%d\" x2=\"%.1f\" y2=\"%d\" stroke=\"#bbb\" "
+                "stroke-width=\"0.7\" stroke-dasharray=\"2 2\"/>\n", x, PADT, x, H - PADB);
+            out << b;
+        }
+    }
+```
+
+- [ ] **Step 2: Inspection check**
+
+Run: `grep -n 'phase-boundary markers' src/etnga_charge_report.cpp`
+Expected: the marker loop sits inside `RenderPowerSvg` after the axis lines and before the SOC polyline. Confirm `b`, `PADL`, `PW`, `tmax`, `PADT`, `H`, `PADB` are all in scope there (they are — declared earlier in the function).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/etnga_charge_report.cpp
+git commit -m "etnga: mark phase boundaries on the charge SVG (INC-1, #81)"
+```
+
+---
+
+## Task 7: changes.txt + CI build + validation handoff
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/changes.txt` (repo root-relative; the entry block at the top).
+
+- [ ] **Step 1: Add the changes.txt entry**
+
+At the top of `vehicle/OVMS.V3/changes.txt`, under a dated/author header in the existing format, add:
+
+```
+3.3.xxx  2026-06-23  Jerry Kezar
+  - Toyota e-TNGA: charge-session report is now multi-phase — a single plug-in-to-unplug
+    session that charges, pauses (scheduled wait), then tops off is reported as separate
+    phases, each with its own SOC delta, energy, peak/avg power, temperature range and
+    outcome. The power chart marks phase boundaries; the per-sample CSV gains a leading
+    "phase" column. Single-phase charges are unchanged.
+```
+
+(Match the surrounding entry style — version line, two-space-indented `-` bullets. Use the next version number consistent with the existing top entry.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add vehicle/OVMS.V3/changes.txt
+git commit -m "etnga: changes.txt for multi-phase charge report (INC-1, #81)"
+```
+
+- [ ] **Step 3: Trigger the CI build and confirm green**
+
+Run: `gh workflow run build.yml --ref feature/etnga-charge-multiphase` then watch with `gh run list --branch feature/etnga-charge-multiphase --limit 1` / `gh run watch <id>`.
+Expected: build succeeds (component `vehicle_toyota_etnga` compiles). If it fails, fix the reported file/line and amend the relevant task's commit before proceeding.
+
+- [ ] **Step 4: On-vehicle validation checklist (record results in the PR / memory)**
+
+This is the real gate — INC-1 is not "done" until validated on the Solterra. Verify, on `solterra-ovms`:
+1. **Single-phase parity:** a normal AC (or DC) charge → report shows `Phases: 1`, one phase block whose SOC/energy/peak match the Summary; SVG unchanged bar the (absent, single-phase) boundary markers; CSV has the `phase` column = 1 throughout the active span.
+2. **Multi-phase:** a scheduled-wait charge (wait → engage) or a top-off after full → `Phases: 2`, correct per-phase SOC/energy/peak, phase boundary lines on the SVG, CSV `phase` increments 1→(0 during WAIT)→2.
+3. **No regression:** Summary totals (energy, grid, accounting, implied capacity) match pre-change behavior for a single-phase charge; no new poll errors/crashes.
+
+---
+
+## Self-Review
+
+**Spec coverage (INC-1 section §3 of the design doc):**
+- §3.1 data model (session owns `vector<ChargePhase>`, index not pointer) → Task 1. ✓ (additive variant: session aggregates retained per Global Constraints — a deliberate, documented deviation that lowers regression risk.)
+- §3.2 phase lifecycle (open on AC/DC, close on WAIT, no double-open, defensive close at session end) → Tasks 2 + 5 Step 1. ✓
+- §3.2 phase-local energy = `ms_v_charge_kwh` snapshot delta → Task 2 (`kwh_at_open`) + helper close. ✓
+- §3.3 single CSV + `phase` column → Task 4. ✓
+- §3.4 Option A report (Summary `Phases:N`, session SVG + boundary markers, per-phase `<dl>`, no sample tables, idempotency, skip when no charge) → Tasks 5 + 6. ✓ (skip-when-empty preserved via the existing `energy < 0.05` guard; per-phase limiting-side/errors rows are INC-2/INC-3, correctly absent here.)
+- §3.5 validation (1-phase parity, 2-phase, no regression) → Task 7 Step 4. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code; the `changes.txt` version number is the one intentional fill ("next version consistent with the top entry") — unavoidable without reading the live file, and bounded to a single token.
+
+**Type consistency:** `OpenChargePhase(bool)` / `CloseChargePhase()` signatures match between header (Task 1) and definitions/call sites (Task 2). `ChargeSessionState::ChargePhase` is the nested type name used consistently in Tasks 2/3/5/6. `m_charge_session.cur` is `int` (-1 sentinel) everywhere; `phases` indexed by `cur` and by loop `i`. `report_written` set once (Task 5) and read once (Task 5 head). CSV format specifier/argument counts reconciled in Task 4 Step 3.

--- a/docs/superpowers/specs/2026-06-23-etnga-charge-report-completion-design.md
+++ b/docs/superpowers/specs/2026-06-23-etnga-charge-report-completion-design.md
@@ -1,0 +1,305 @@
+# e-TNGA charge-report completion (issue #81) — design
+
+**Date:** 2026-06-23
+**Issue:** [#81](https://github.com/kezarjg/Open-Vehicle-Monitoring-System-3/issues/81) — Toyota e-TNGA: charging session report generation (HTML, multi-phase, sleep-aware)
+**Status:** design — pending user review
+**Scope:** Complete the five remaining #81 checklist items as a sequence of five single-purpose PRs.
+
+## 1. Background
+
+PR #86 shipped the charge-session report (`etnga_charge_report.cpp`) and PR #122 moved its
+file writes onto an async I/O worker (`etnga_charge_io.cpp`). The report already exceeds the
+issue's "first increment" framing: a single `ChargeSessionState` tracks plug-in time, GPS,
+ambient/battery temp ranges, peak power, coulomb-counted Ah (implied capacity), station kWh,
+an event log (HLC / AC-Op transitions), and a 20 s-downsampled SVG chart; a 20-column
+per-sample CSV is streamed to disk (~1 Hz, flushed ≤30 s / ≤4 KB) and linked from the report.
+Reports + CSVs live at `/sd/charge-reports/` (or `/store/charge-reports/`), capped at the
+newest 50, surfaced at the web pages `/xte/reports` (index) and `/xte/report` (viewer + CSV
+download).
+
+What remains from the #81 scope, and the dependency that orders it:
+
+1. **Multi-phase `phases[]`** — the single `ChargeSessionState` only models one phase
+   (`is_dc` is a scalar). Everything below attaches *per phase*, so this lands first.
+2. **Limiting-side attribution** — per-phase "who capped the rate".
+3. **Error DID-dump** — on a faulted phase.
+4. **Sleep-persisted session state** — serialize the session (incl. `phases[]`) across SLEEP.
+5. **Summary-mode report** — degraded report when the module slept through the charge.
+
+This document specs all five and their sequencing. Each increment is its own single-purpose
+PR (per `CLAUDE.md`), merged and on-vehicle-validated before the next begins. Several items are
+**car-gated** for validation and MUST be built degradable so they ship inert until exercised.
+
+## 2. Current hook points (grounding)
+
+State transitions live in `etnga_poll_states.cpp`:
+
+| Transition fn | Role for this work |
+|---|---|
+| `TransitionToChargeHandshakeState()` | **Session open** — `in_session=false→true`, resets energy counters, seeds GPS/ambient/start-SOC. |
+| `TransitionToChargeAcState()` / `…DcState()` | **Phase open** (INC-1 hook). |
+| `TransitionToChargeWaitState()` | **Phase close** (INC-1 hook). |
+| `TransitionToAwakeState()` (`oldState >= CHARGE_HANDSHAKE`) | **Session close** → `GenerateChargeReport()` then `m_charge_session = {}`. |
+| AWAKE-reconcile PISW=Unconnected path (`m_pisw_zero_count >= 2`) | Alternate **session close** → also calls `GenerateChargeReport()`. |
+| `TransitionToSleepState()` | **Sleep-persist hook** (INC-4). |
+
+Report rendering + CSV streaming + session struct live in `etnga_charge_report.cpp`; the
+struct `ChargeSessionState` and PID enum are in `vehicle_toyota_etnga.h`. Async file ops go
+through `ChargeIoEnqueue()` (`etnga_charge_io.cpp`).
+
+## 3. INC-1 — Multi-phase tracking (foundation)
+
+### 3.1 Data model
+
+Refactor the single `ChargeSessionState` into a **session** that owns a **vector of phases**.
+Session-level fields (one per plug-in→unplug) stay on the session; per-active-interval fields
+move into `ChargePhase`.
+
+```cpp
+struct ChargePhase {
+    bool   is_dc = false;
+    int    start_monotonic = 0, end_monotonic = 0;
+    time_t start_utc = 0;
+    int    start_soc = -1, end_soc = -1;
+    float  peak_power = 0.0f;          // kW into battery
+    float  energy_kwh = 0.0f;          // battery-side, phase-local
+    float  delivered_ah = 0.0f;        // coulomb count, phase-local
+    bool   temp_seen = false; float temp_min = 0.0f, temp_max = 0.0f;
+    int    outcome = -1;               // 0x1688 latched at phase close
+    // INC-2 fills these; default-inert until then:
+    int    limiting_side = 0;          // enum LimSide; 0 = unknown
+    float  limiting_value = 0.0f;
+    // INC-3 fills this; empty until then:
+    std::vector<std::string> errors;
+};
+
+struct ChargeSessionState {
+    bool   in_session = false;
+    int    start_monotonic = 0; time_t start_utc = 0; int start_soc = -1;
+    // session-level GPS + ambient (unchanged):
+    bool   has_loc = false; float start_lat = 0, start_lon = 0;
+    bool   amb_seen = false; float amb_min = 0, amb_max = 0;
+    // session-level energy accounting (unchanged metrics: ms_v_charge_kwh, …, station_kwh):
+    float  station_kwh = 0.0f;
+    bool   report_written = false;     // idempotency (NEW; defensive)
+    std::vector<std::pair<int,const char*>> events;   // session-level event log (unchanged)
+    // CSV streaming state (unchanged; gains a phase index — see 3.3):
+    std::string base; bool csv_started=false, csv_file_created=false;
+    std::string csv_buf; int last_csv_flush=0;
+    // SVG chart buffer (unchanged; whole-session, phase boundaries derived from phase times):
+    struct Sample { int t_s; float kw; int soc; float sta_max; float car_perm; float station_kw; float hvac_kw; };
+    std::vector<Sample> svg; int svg_interval_s = 20; int last_sample_monotonic = 0;
+    std::vector<ChargePhase> phases;
+    ChargePhase* cur = nullptr;        // points into phases.back() while a phase is active
+};
+```
+
+Memory note: the per-phase scalars are tiny; the only large buffers (`svg`, `csv_buf`) stay
+**session-level and bounded** exactly as today. Phases do NOT each hold a sample vector — the
+full timeline stays in the single CSV (3.3). This is the RAM win of layout Option A.
+
+### 3.2 Phase lifecycle
+
+- **Open** a phase on entry to `CHARGE_AC` / `CHARGE_DC` *if no phase is currently open*
+  (`cur == nullptr`): push a `ChargePhase`, set `is_dc`, `start_*`, point `cur` at it.
+  Add a `LogChargeEvent("Phase N start (AC|DC)")`.
+- **Close** the open phase on `TransitionToChargeWaitState()` *if `cur != nullptr`*: set
+  `end_monotonic`, `end_soc`, latch `outcome` from `0x1688`, finalize `peak_power`/temp/energy
+  deltas, then `cur = nullptr`. Event: `"Phase N complete"`.
+- A second `CHARGE_AC`/`DC` entry (post-wait top-off, or a scheduled-wait→engage) opens a
+  **new** phase → `phases.size()` grows. AC↔DC mid-session (rare; cable is fixed) simply closes
+  one phase and opens another.
+- Re-entering `CHARGE_AC`/`DC` while a phase is already open (`cur != nullptr`, e.g. a 1 s
+  state flap) is a **no-op** — guards against double-open.
+- Session close (`TransitionToAwakeState` / PISW-reconcile): if `cur != nullptr`, close it
+  first (defensive — normal exits route through CHARGE_WAIT), then generate the report.
+
+**Phase-local energy/peak/temp:** today these accumulate session-wide on `ChargeSessionState`.
+They move to `cur`. Session totals are derived at report time by summing phases (energy) or
+min/max-ing (temp). The existing standard metrics (`ms_v_charge_kwh`, `ms_v_bat_temp`, …) keep
+their current per-session reset semantics — phase fields are computed by snapshotting at phase
+open/close (`phase.energy = ms_v_charge_kwh@close − @open`), so we do not perturb the metric
+reset logic that #105 fixed.
+
+### 3.3 CSV — single file + phase column
+
+Keep one CSV per session. Add **one leading column `phase`** (1-based; `0` while plugged but
+not in a phase, i.e. WAIT/HANDSHAKE rows if any are written). New header:
+
+```
+phase,elapsed_s,soc_pct,bms_soc_pct,station_kw,battery_kw,hvac_kw,pack_v,pack_a,batt_temp_c,
+ambient_c,state,station_max_kw,station_max_a,station_max_v,car_perm_kw,car_target_a,
+station_grid_kw,station_present_v,station_present_a,obc_kw
+```
+
+`phase` = `cur ? (index+1) : 0`. The `state` column already distinguishes AC/DC; `phase` lets
+a reader split the single CSV per phase without inferring boundaries.
+
+### 3.4 Report layout (Option A — approved)
+
+`GenerateChargeReport()` becomes:
+
+1. **Summary `<dl>`** — plug-in/unplug/duration, location, ambient, **`Phases: N`**, total SOC
+   delta, **summed** energy + grid + accounting, session battery-temp range, **telemetry
+   coverage** (active-charging seconds vs total plugged seconds — sets up INC-4's gap line),
+   overall outcome (last phase's, or worst).
+2. **One session-level SVG** (`RenderPowerSvg`) spanning the whole charge, with **phase-boundary
+   markers** (vertical lines at each phase start/end) and shaded gaps for non-charging spans.
+3. **Per-phase `<h2>` + `<dl>`** block each: active interval, type, SOC delta, energy, peak/avg
+   kW, limiting side (INC-2; omitted while unknown), battery-temp range, outcome, and (INC-3)
+   an errors sublist. **No per-phase `<details>` sample tables.**
+4. **Session events** table (unchanged).
+5. **Estimates** (efficiency, implied capacity) — now summed across phases.
+6. **Sleep-coverage gaps** list (populated by INC-4; empty/omitted until then).
+7. **CSV download** link (unchanged).
+
+Skip/idempotency: report is written once; skip entirely if `phases.empty()` (plugged then
+unplugged, no charge) — replaces today's "no energy delivered" no-op. Set `report_written`.
+
+### 3.5 INC-1 validation
+
+- **Offline:** a 1-phase charge must produce a report substantially equivalent to today's
+  (same summary numbers, same SVG, one phase block). CSV gains the `phase` column.
+- **On-vehicle (Solterra):** (a) a normal single-phase AC or DC charge → 1 phase; (b) a
+  scheduled-wait charge (wait → engage) and/or a top-off after full → **2 phases** with correct
+  per-phase SOC/energy/peak and summed totals; CSV `phase` column increments correctly.
+
+## 4. INC-2 — Limiting-side attribution
+
+Per design doc §6.1. At **phase close**, classify who capped the rate and record
+`limiting_side` + `limiting_value` on the `ChargePhase`; surface in the per-phase report block
+and append to the real-time charge-complete event/notification.
+
+```cpp
+enum LimSide { LIM_UNKNOWN=0, LIM_STATION, LIM_CAR, LIM_CABLE, LIM_OBC, LIM_GRID, LIM_THERMAL };
+```
+
+**Candidate caps** (already-polled unless noted):
+- `station`: `min(0x166A station_max_kw, 0x1679×0x1681 I×V)` (DC).
+- `car`: `0x16A1` car-permission power (DC taper). Sub-attribution "cold battery" if battery
+  temp `0x1829`/`0x182A` below a threshold at the cap point.
+- `cable`: `0x1671 × line_voltage` (AC). **`0x1671` is NOT polled today — new poll** (AC states).
+- `obc`: OBC AC max (model constant ~7.2 kW for Solterra).
+- `grid`: inferred — AC drawn persistently below both cable and OBC caps.
+- `thermal`: power-stage temps `0x1657`/`0x1658` or battery temps crossing derate thresholds
+  **and** peak power fell mid-phase. **`0x1657`/`0x1658` new polls** (low-rate, charge states).
+
+**Algorithm:** at phase close, take the phase's delivered peak; the smallest active cap is the
+limiting side, with a `thermal` override if peak fell during the phase while a temperature
+crossed a known derate threshold. All inputs are phase-tracked min/max/last values — no new
+per-sample storage.
+
+**Degradable:** if the required DIDs for a side never answered, that side is simply not a
+candidate; `LIM_UNKNOWN` renders as an omitted "Limiting side" row (never a wrong guess).
+
+**New polls:** `0x1671` (AC cable perm current), `0x1657` (PFC temp), `0x1658` (DC/DC temp) on
+the OBC (`0x745`), in the AC/DC charge poll states. Thermal battery DIDs `0x1829`/`0x182A` —
+check whether already polled; add if not.
+
+**Validation (car-gated):** AC charge → expect `obc` (7.2 kW) or `cable`/`grid`; the L3 DC case
+→ expect `car` with cold-battery sub-attribution (the 2026-05-10 canonical example: station
+~90 kW, car 42.69 kW, delivered 40.54 kW → `car`).
+
+## 5. INC-3 — Error DID-dump
+
+Per design doc §6.4. When a phase faults (`error_in_phase` — detected via an abnormal `0x1688`
+outcome or an `IncomingPollError` during the phase), perform a **one-shot burst of ~30
+individual `0x22 XX YY` reads** in `CHARGE_WAIT` (a low-rate state — the serialized burst is a
+few seconds and needs no slot management). Append decoded results to the faulted phase's
+`errors[]`; log to the OVMS log; include in the report as a per-phase error sublist.
+
+DID set (design doc §6.4 table): state-machine, trip-flag, connector/safety, electrical-at-
+fault, thermal — ~30 DIDs across `0x16xx`/`0x18xx`/`0x10D4`.
+
+**Mechanism:** a transient one-shot poll list appended on CHARGE_WAIT entry when
+`error_in_phase` is set; results captured in `IncomingPollReply` into a scratch buffer keyed by
+DID, formatted into `errors[]`. Cleared after dump.
+
+**Degradable:** if a DID doesn't answer, record `"0xXXXX: no reply"` rather than blocking.
+
+**Validation (car-gated):** requires a faulted charge — rare. Ship inert; validate
+opportunistically. Unit-confirm the formatting against a synthetic fault if possible.
+
+## 6. INC-4 — Sleep-persisted session state
+
+Per design doc §6.5. On `TransitionToSleepState()` *when `in_session`* (sleep from CHARGE_WAIT,
+or rarely AC/DC under bus-loss), serialize the session to
+`/store/charge-session-state.json` via the async worker.
+
+**Contents:** `in_charge_session`, `session_start_monotonic`, `session_start_soc`, the full
+`phases[]` array (completed + any in-progress), `phase_active_at_sleep`, `armed_for_charge`,
+and a `last_snapshot_at_sleep` block of SOC + key DIDs (`0x1688`, `0x16A0`, `0x1829`, `0x182A`,
+lifetime AC counters from `0x1648`) + wall-clock ISO.
+
+**Write throttle:** ≥60 s between writes; if sleep entry is <60 s since the last write, defer to
+the next sleep entry (matches the §6.5 anti-thrash rule and the #118 sleep/wake oscillation
+concern).
+
+**On wake** (AWAKE resume): if the JSON exists, read the same DIDs, delta-compare to detect
+"did a charge happen while asleep", and restore `phases[]` into `m_charge_session` so the
+eventual report spans the whole session including slept spans. The **sleep-coverage gaps** list
+(report §3.4 item 6) is computed from the wall-clock deltas between active spans.
+
+**Clear:** delete the JSON on session end (after the report is written), and on a clean
+non-charge wake that finds no charge happened.
+
+**Serialization:** hand-rolled minimal JSON writer/parser (no cJSON dependency unless already
+linked) — the schema is small and fixed. HTML/JSON-escape any string fields.
+
+**Validation:** offline — round-trip serialize/deserialize a multi-phase session. On-vehicle —
+the #118 overnight scheduled-charge scenario: module sleeps through the wait, wakes, and the
+final report shows the pre-sleep phase(s) plus the gap list. (Wake delta-compare branching is
+the car-gated part.)
+
+## 7. INC-5 — Summary-mode report
+
+Per design doc §6.3. Depends on INC-4 (knowing a charge happened while asleep) + the OBC counter
+DIDs. When telemetry coverage for a phase is 0% (slept through it), render that phase block from
+**computed values** instead of timeline-derived ones: duration from `0x1648` counter delta,
+type from which counter incremented, energy from SOC-delta × pack capacity (or elapsed × avg),
+temp range from `0x16A0` logged-during-charge max/min, outcome from `0x1688`. The phase block is
+flagged `(summary mode, no live telemetry)`, omits any sample reference, and reports `0%`
+coverage. Same single HTML document.
+
+**New polls:** `0x1648` (AC lifetime minutes/count), `0x16A0` (max/min temp during charge) on
+the OBC — read on wake during the delta-compare, and/or in CHARGE_WAIT.
+
+**Pack capacity** for the energy estimate: use the variant-correct nominal (ties into the
+pack-variant work, [[project_etnga_multivariant]]); 201.1 Ah / model nominal for the 96-cell
+Solterra.
+
+**Validation (most car-gated):** requires an actually-slept-through charge with the counters
+read on both sides. Ship degradable; the non-summary path (INC-4 present, telemetry captured)
+must be unaffected.
+
+## 8. Sequencing & PR plan
+
+| PR | Item | New polls | Validation gate |
+|----|------|-----------|-----------------|
+| 1 | INC-1 multi-phase + Option A report + CSV `phase` col | none | Solterra 1-phase ≈ today; 2-phase scheduled-wait/top-off |
+| 2 | INC-2 limiting-side | `0x1671`, `0x1657`, `0x1658` (+ batt thermal if absent) | AC → obc/cable/grid; DC → car (cold-batt) |
+| 3 | INC-3 error DID-dump | ~30 one-shot DIDs | opportunistic (faulted charge) |
+| 4 | INC-4 sleep-persist JSON | snapshot DIDs incl. `0x1648`/`0x16A0` | #118 overnight scheduled charge |
+| 5 | INC-5 summary-mode | (uses INC-4 counters) | slept-through charge |
+
+INC-1 is a hard prerequisite for all others. INC-2 and INC-3 are independent given INC-1 and may
+reorder. INC-5 requires INC-4. Each PR: `changes.txt` entry (new user-facing feature), single
+vehicle scope, CI-green, on-vehicle validation recorded before the next starts. Car-gated items
+(#3, #5, the DC half of #2) ship degradable and are validated opportunistically — the issue
+stays open tracking the validation tail even after code merges, consistent with prior e-TNGA
+work.
+
+## 9. Risks / open points
+
+- **RAM:** Option A keeps only the bounded `svg` + `csv_buf` buffers; `phases[]` scalars are
+  negligible. No regression vs today. INC-4's `phases[]` JSON is small.
+- **Metric reset interplay:** phase energy is snapshot-derived from `ms_v_charge_kwh` to avoid
+  re-touching the #105 reset fix. Verify no double-reset on pause/resume.
+- **`0x1671` AC cable DID** decode unconfirmed on Solterra — validate the scale before trusting
+  the `cable` attribution; until then it can be a candidate only when plausibly bounded.
+- **Error-trigger definition (INC-3):** what exactly sets `error_in_phase` (which `0x1688`
+  codes, or any `IncomingPollError`) needs pinning in the INC-3 plan.
+- **JSON library:** confirm whether a JSON writer is already linked; prefer hand-rolled minimal
+  if not, to avoid a new dependency in a vehicle component.
+- Several validations are genuinely car-gated; per repo norms unvalidated paths ship degradable
+  and are not asserted correct until exercised on the vehicle.

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,11 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): charge-session report is now multi-phase —
+    a single plug-in-to-unplug session that charges, pauses (scheduled wait), then tops off is
+    reported as separate phases, each with its own SOC delta, energy, peak/avg power,
+    temperature range and outcome. The power chart marks phase boundaries; the per-sample CSV
+    gains a leading "phase" column. Single-phase charges are unchanged.
 - WiFi: optional priority network list. When enabled, the module prefers known WiFi networks in a
     user-defined order and, while connected to a lower-priority network, periodically scans and
     upgrades to a higher-priority one when it is in range with good signal (>= network wifi.sq.good).

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -152,6 +152,41 @@ void OvmsVehicleToyotaETNGA::LogChargeEvent(const char* label)
         std::make_pair(StandardMetrics.ms_m_monotonic->AsInt(), label));
 }
 
+// INC-1: open a new charge phase on CHARGE_AC / CHARGE_DC entry. No-op if a phase is
+// already open (guards a 1 s state flap from double-opening). Snapshots the session
+// kWh meter so the phase energy is a delta at close.
+void OvmsVehicleToyotaETNGA::OpenChargePhase(bool is_dc)
+{
+    if (!m_charge_session.in_session || m_charge_session.cur >= 0)
+        return;
+    ChargeSessionState::ChargePhase ph;
+    ph.is_dc          = is_dc;
+    ph.start_monotonic = StandardMetrics.ms_m_monotonic->AsInt();
+    ph.start_utc      = StandardMetrics.ms_m_timeutc->AsInt();
+    ph.start_soc      = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+    ph.kwh_at_open    = StandardMetrics.ms_v_charge_kwh->AsFloat();
+    m_charge_session.phases.push_back(ph);
+    m_charge_session.cur = (int) m_charge_session.phases.size() - 1;
+    ESP_LOGD(TAG, "Charge phase %d open (%s)", m_charge_session.cur + 1, is_dc ? "DC" : "AC");
+}
+
+// INC-1: close the open phase on CHARGE_WAIT entry (or defensively at report time).
+// No-op if no phase is open. Energy is the kWh-meter delta since open; outcome latches 0x1688.
+void OvmsVehicleToyotaETNGA::CloseChargePhase()
+{
+    if (m_charge_session.cur < 0)
+        return;
+    ChargeSessionState::ChargePhase& ph = m_charge_session.phases[m_charge_session.cur];
+    ph.end_monotonic = StandardMetrics.ms_m_monotonic->AsInt();
+    ph.end_soc       = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+    ph.energy_kwh    = StandardMetrics.ms_v_charge_kwh->AsFloat() - ph.kwh_at_open;
+    if (ph.energy_kwh < 0.0f) ph.energy_kwh = 0.0f;
+    ph.outcome       = m_v_charge_outcome->AsInt();
+    ESP_LOGD(TAG, "Charge phase %d closed (%.2f kWh, %d%%->%d%%)",
+             m_charge_session.cur + 1, ph.energy_kwh, ph.start_soc, ph.end_soc);
+    m_charge_session.cur = -1;
+}
+
 // Live aggregation while charging: peak power, battery-temp range, ambient range,
 // delivered-Ah, per-tick CSV row, and downsampled SVG buffer.
 // Called every tick from HandleChargeAcState / HandleChargeDcState.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -474,6 +474,9 @@ void OvmsVehicleToyotaETNGA::RenderPowerSvg(std::ostream& out)
 
 void OvmsVehicleToyotaETNGA::GenerateChargeReport()
 {
+    if (m_charge_session.report_written)
+        return;                 // defensive idempotency
+    CloseChargePhase();         // close any still-open phase (direct AC/DC->AWAKE safety net)
     const float energy_kwh = StandardMetrics.ms_v_charge_kwh->AsFloat();
     if (energy_kwh < 0.05f || m_charge_session.base.empty()) {
         ESP_LOGD(TAG, "Charge report skipped (%.3f kWh)", energy_kwh);
@@ -543,6 +546,11 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
         f << "<dt>Ambient</dt><dd>" << b << "</dd>\n";
     }
     f << "<dt>Type</dt><dd>" << (m_charge_session.is_dc ? "DC fast" : "AC") << "</dd>\n";
+    {
+        char pc[48];
+        snprintf(pc, sizeof(pc), "%u", (unsigned) m_charge_session.phases.size());
+        f << "<dt>Phases</dt><dd>" << pc << "</dd>\n";
+    }
     snprintf(b, sizeof(b), "%d%% &rarr; %d%% (+%d%%)", start_soc, end_soc, start_soc>=0?end_soc-start_soc:0);
     f << "<dt>SOC</dt><dd>" << b << "</dd>\n";
     // "From grid" is an AC-charge concept (the 0x161D grid-input poll only answers on AC);
@@ -585,6 +593,47 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     f << "<h2>Charging power</h2>\n";
     RenderPowerSvg(f);
 
+    // INC-1: per-phase summary blocks (Option A — no per-phase sample tables; the full
+    // timeline stays in the single CSV with its phase column).
+    for (size_t i = 0; i < m_charge_session.phases.size(); i++) {
+        const ChargeSessionState::ChargePhase& ph = m_charge_session.phases[i];
+        int pdur = ph.end_monotonic - ph.start_monotonic; if (pdur < 0) pdur = 0;
+        float pavg = (pdur > 0) ? ph.energy_kwh / (pdur / 3600.0f) : 0.0f;
+        char pb[96];
+        f << "<h2>Phase " << (i + 1) << " &mdash; " << (ph.is_dc ? "DC fast" : "AC") << "</h2>\n<dl>\n";
+        if (ph.start_utc > 1000000000) {
+            time_t st = (time_t) ph.start_utc, et = st + pdur; struct tm tmv;
+            char ps[40], pe[40];
+            gmtime_r(&st, &tmv); strftime(ps, sizeof(ps), "%H:%M:%S", &tmv);
+            gmtime_r(&et, &tmv); strftime(pe, sizeof(pe), "%H:%M:%S", &tmv);
+            snprintf(pb, sizeof(pb), "%s &rarr; %s UTC (%dh %02dm %02ds)", ps, pe,
+                     pdur/3600, (pdur%3600)/60, pdur%60);
+            f << "<dt>Active</dt><dd>" << pb << "</dd>\n";
+        }
+        snprintf(pb, sizeof(pb), "%d%% &rarr; %d%% (+%d%%)", ph.start_soc, ph.end_soc,
+                 ph.start_soc >= 0 ? ph.end_soc - ph.start_soc : 0);
+        f << "<dt>SOC</dt><dd>" << pb << "</dd>\n";
+        snprintf(pb, sizeof(pb), "%.2f kWh; %.1f kW peak / %.2f kW avg",
+                 ph.energy_kwh, ph.peak_power, pavg);
+        f << "<dt>Energy</dt><dd>" << pb << "</dd>\n";
+        if (ph.temp_seen) {
+            metric_unit_t tu = OvmsMetricGetUserUnit(GrpTemp, Celcius);
+            const char* tlabel = OvmsMetricUnitLabel(tu);
+            float lo = UnitConvert(Celcius, tu, ph.temp_min), hi = UnitConvert(Celcius, tu, ph.temp_max);
+            snprintf(pb, sizeof(pb), "%.0f%s &rarr; %.0f%s", lo, tlabel, hi, tlabel);
+            f << "<dt>Battery temp</dt><dd>" << pb << "</dd>\n";
+        }
+        {
+            const char* lbl = ChargeOutcomeLabel(ph.outcome);
+            if (lbl[0]) f << "<dt>Outcome</dt><dd>" << lbl << "</dd>\n";
+            else if (ph.outcome >= 0) {
+                snprintf(pb, sizeof(pb), "0x%02X (raw)", ph.outcome & 0xFF);
+                f << "<dt>Outcome</dt><dd>" << pb << "</dd>\n";
+            }
+        }
+        f << "</dl>\n";
+    }
+
     f << "<h2>Session events</h2>\n<table><tr><th>Time</th><th>Event</th></tr>\n";
     for (size_t i = 0; i < m_charge_session.events.size(); i++) {
         int rel = m_charge_session.events[i].first - m_charge_session.start_monotonic; if (rel < 0) rel = 0;
@@ -617,8 +666,9 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
           << "\">Download per-sample CSV</a></p>\n";
     }
 
-    f << "<p class=\"note\">Generated on-module by OVMS (Toyota e-TNGA). Single-phase; avg power is over the "
-         "whole plug-in interval. Estimates are provisional.</p>\n</body></html>\n";
+    f << "<p class=\"note\">Generated on-module by OVMS (Toyota e-TNGA). Multi-phase; per-phase "
+         "avg power is over each active interval. Estimates are provisional.</p>\n</body></html>\n";
+    m_charge_session.report_written = true;
     // Hand the rendered HTML to the async writer; it writes the file and prunes off-thread.
     etnga_io_job* job = new etnga_io_job;
     job->op        = etnga_io_job::WRITE_TRUNCATE;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -219,6 +219,16 @@ void OvmsVehicleToyotaETNGA::UpdateChargeSessionStats()
         else if (amb > m_charge_session.amb_max) m_charge_session.amb_max = amb;
     }
 
+    // INC-1: mirror peak power + battery-temp range into the open phase (additive to the
+    // session-level aggregates above). cur < 0 between phases (WAIT) — skip then.
+    if (m_charge_session.cur >= 0) {
+        ChargeSessionState::ChargePhase& ph = m_charge_session.phases[m_charge_session.cur];
+        if (p > ph.peak_power) ph.peak_power = p;
+        if (!ph.temp_seen) { ph.temp_min = ph.temp_max = t; ph.temp_seen = true; }
+        else if (t < ph.temp_min) ph.temp_min = t;
+        else if (t > ph.temp_max) ph.temp_max = t;
+    }
+
     m_charge_session.is_dc = (static_cast<PollState>(m_poll_state) == PollState::CHARGE_DC);
 
     // Delivered-Ah (charge-side coulomb): integrate pack current over dt.
@@ -226,6 +236,9 @@ void OvmsVehicleToyotaETNGA::UpdateChargeSessionStats()
         int dt = now - m_charge_session.last_sample_monotonic;
         if (dt > 0 && dt <= 10) {   // ignore gaps (pause / lock-isolation / sleep) so delivered_ah stays accurate
             m_charge_session.delivered_ah += fabsf(StandardMetrics.ms_v_bat_current->AsFloat()) * (dt / 3600.0f);
+            if (m_charge_session.cur >= 0)
+                m_charge_session.phases[m_charge_session.cur].delivered_ah +=
+                    fabsf(StandardMetrics.ms_v_bat_current->AsFloat()) * (dt / 3600.0f);
             float pv = StandardMetrics.ms_v_charge_voltage->AsFloat();
             float pa = StandardMetrics.ms_v_charge_current->AsFloat();
             float skw = m_charge_session.is_dc ? (pv * pa / 1000.0f) : m_v_charge_grid_power->AsFloat();

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -289,7 +289,7 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
         //                     plus raw station_grid_kw / station_present_v / station_present_a
         //   obc_kw          : diagnostic — raw 0x10D4 (under-reads on DC, issue #109)
         m_charge_session.csv_buf =
-            "elapsed_s,soc_pct,bms_soc_pct,station_kw,battery_kw,hvac_kw,pack_v,pack_a,"
+            "phase,elapsed_s,soc_pct,bms_soc_pct,station_kw,battery_kw,hvac_kw,pack_v,pack_a,"
             "batt_temp_c,ambient_c,state,station_max_kw,station_max_a,station_max_v,"
             "car_perm_kw,car_target_a,station_grid_kw,station_present_v,station_present_a,obc_kw\n";
         m_charge_session.csv_started = true;
@@ -307,9 +307,11 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
     float present_a = StandardMetrics.ms_v_charge_current->AsFloat();
     float grid_kw   = m_v_charge_grid_power->AsFloat();
     float station_kw = m_charge_session.is_dc ? (present_v * present_a / 1000.0f) : grid_kw;
+    int phase_no = (m_charge_session.cur >= 0) ? (m_charge_session.cur + 1) : 0;
     snprintf(row, sizeof(row),
-        "%d,%.0f,%.1f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%s,%s,"
+        "%d,%d,%.0f,%.1f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%s,%s,"
         "%.2f,%.0f,%.0f,%.2f,%.0f,%.3f,%.0f,%.0f,%.3f\n",
+        phase_no,
         elapsed,
         StandardMetrics.ms_v_bat_soc->AsFloat(),
         m_v_bat_soc_bms->AsFloat(),

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -414,6 +414,23 @@ void OvmsVehicleToyotaETNGA::RenderPowerSvg(std::ostream& out)
     snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", W-PADR, PADT, W-PADR, H-PADB); out << b;
     snprintf(b, sizeof(b), "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#ccc\"/>\n", PADL, H-PADB, W-PADR, H-PADB); out << b;
 
+    // INC-1: phase-boundary markers (vertical dashed lines at each phase start/end),
+    // mapped from monotonic seconds onto the same time axis the traces use.
+    for (size_t i = 0; i < m_charge_session.phases.size(); i++) {
+        const ChargeSessionState::ChargePhase& ph = m_charge_session.phases[i];
+        int bounds[2] = { ph.start_monotonic - m_charge_session.start_monotonic,
+                          ph.end_monotonic   - m_charge_session.start_monotonic };
+        for (int k = 0; k < 2; k++) {
+            int ts = bounds[k];
+            if (ts <= 0 || ts > tmax) continue;   // off-chart / unset end
+            float x = PADL + (float)PW * ts / tmax;
+            snprintf(b, sizeof(b),
+                "<line x1=\"%.1f\" y1=\"%d\" x2=\"%.1f\" y2=\"%d\" stroke=\"#bbb\" "
+                "stroke-width=\"0.7\" stroke-dasharray=\"2 2\"/>\n", x, PADT, x, H - PADB);
+            out << b;
+        }
+    }
+
     // SOC overlay (right axis, 0-100).
     out << "<polyline fill=\"none\" stroke=\"#39c\" stroke-width=\"1\" stroke-dasharray=\"1 3\" points=\"";
     for (size_t i = 0; i < s.size(); i++) {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -497,6 +497,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeWaitState()
     SetChargingStatus(false);
     SetChargeState(PollState::CHARGE_WAIT);
     LogChargeEvent("Charging paused / phase ended");
+    CloseChargePhase();       // INC-1: close the active phase (pause / phase end)
 }
 
 void OvmsVehicleToyotaETNGA::TransitionToChargeAcState()
@@ -508,6 +509,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeAcState()
     SetChargeState(PollState::CHARGE_AC);
     StandardMetrics.ms_v_charge_mode->SetValue("standard");      // AC charging (OVMS-standard v.c.mode)
     LogChargeEvent("AC charging started");
+    OpenChargePhase(false);   // INC-1: AC phase
 }
 
 void OvmsVehicleToyotaETNGA::TransitionToChargeDcState()
@@ -524,4 +526,5 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeDcState()
     // The e-TNGA DC inlet is CCS. Cleared on session end in TransitionToAwakeState.
     StandardMetrics.ms_v_charge_type->SetValue("ccs");
     LogChargeEvent("DC charging started");
+    OpenChargePhase(true);    // INC-1: DC phase
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -120,6 +120,27 @@ protected:
         bool  csv_file_created = false;   // <base>.csv exists on disk (first flush truncates)
         std::string csv_buf;              // rows pending flush (batched to limit flash write cycles)
         int   last_csv_flush = 0;         // monotonic s of last flush
+        // INC-1: per-phase tracking. phases[] is additive — the session-level
+        // aggregates above stay authoritative for the Summary block.
+        struct ChargePhase {
+            bool   is_dc = false;
+            int    start_monotonic = 0;
+            time_t start_utc = 0;
+            int    start_soc = -1;
+            int    end_monotonic = 0;
+            int    end_soc = -1;
+            float  kwh_at_open = 0.0f;   // ms_v_charge_kwh snapshot at phase open
+            float  energy_kwh = 0.0f;    // computed at close (delta)
+            float  peak_power = 0.0f;    // kW into battery
+            float  delivered_ah = 0.0f;  // phase-local coulomb count
+            bool   temp_seen = false;
+            float  temp_min = 0.0f;
+            float  temp_max = 0.0f;
+            int    outcome = -1;         // 0x1688 latched at close
+        };
+        std::vector<ChargePhase> phases;
+        int   cur = -1;                  // index of the open phase in phases, -1 = none
+        bool  report_written = false;    // idempotency guard for GenerateChargeReport
     };
     ChargeSessionState m_charge_session;
 
@@ -197,6 +218,8 @@ private:
     void UpdateChargeSessionStats();   // live aggregation while charging (peak power, temp range, type)
     void RenderPowerSvg(std::ostream& out);  // stream the inline SVG power(+SOC)-vs-time chart from m_charge_session.svg
     void GenerateChargeReport();       // write the session-end HTML report to /store/charge-reports/
+    void OpenChargePhase(bool is_dc);   // INC-1: start a new charge phase on AC/DC entry
+    void CloseChargePhase();            // INC-1: close the open phase on WAIT / report time
     void LogChargeEvent(const char* label);            // append a timestamped event
     void AppendChargeCsvRow();                          // buffer one CSV row (header on first call)
     void FlushChargeCsv();                              // write buffered CSV rows to <base>.csv


### PR DESCRIPTION
## What

First increment toward closing **#81** — makes the Toyota e-TNGA charge-session report **multi-phase**. A single plug-in→unplug session that charges, pauses (scheduled wait), then tops off is now reported as separate phases, each with its own SOC delta, energy, peak/avg power, temperature range, and outcome.

Layout is **Option A**: the existing session-level SVG chart (now with phase-boundary markers) + a per-phase `<dl>` summary block each. The per-sample CSV gains a leading `phase` column. Single-phase charges render equivalently to before.

## Why this shape

`#81` has five remaining items (multi-phase, limiting-side attribution, error DID-dump, sleep-persisted state, summary-mode) that form a dependency tree rooted at multi-phase. They'll land as **five sequential single-purpose PRs**; this is the first. Design doc + plan are included:
- `docs/superpowers/specs/2026-06-23-etnga-charge-report-completion-design.md` (all five + sequencing)
- `docs/superpowers/plans/2026-06-23-etnga-charge-report-multiphase.md` (INC-1)

## Key design decisions

- **`phases[]` is additive** — the existing session-level aggregates, SVG buffer, CSV stream, and Summary numbers are left untouched so validated single-phase behavior cannot regress; the per-phase vector is tracked in parallel.
- **Open phase tracked by index** (`cur`, -1 = none), never a pointer into the vector (realloc safety).
- **Per-phase energy = snapshot delta** of `ms_v_charge_kwh` (the meter is reset only at session open per the #105 fix, so phase deltas telescope to the session total).

## How it works

- Phase opens on `CHARGE_AC`/`CHARGE_DC` entry, closes on `CHARGE_WAIT` (and defensively at report time for the direct AC/DC→AWAKE safety-net path). Double-open/close guarded.
- `GenerateChargeReport()` is idempotent (`report_written`) and funnels both session-close paths through one defensive phase-close.

## Validation

- **CI compile: green** (workflow_dispatch on this branch — Solterra / bZ4X / Lexus RZ wrappers, which depend on the base `vehicle_toyota_etnga`).
- **On-vehicle: pending** (the real gate): single-phase parity, a 2-phase scheduled-wait / top-off charge, and no Summary regression. #81 stays open tracking this + the remaining four increments.

## Review

Each task was spec+quality reviewed; a final whole-branch review (incl. integration checks against the #118 sleep-in-CHARGE_WAIT path, #105 metric-reset, the CSV worker, and ESP32 RAM) returned **Ready to merge** with no Critical/Important findings.

Closes part of #81 (does not fully close — four increments remain).