### PR TITLE
etnga: charge-fault diagnostic DID dump (INC-3 of #81)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-etnga-charge-error-dump.md
+++ b/docs/superpowers/plans/2026-06-23-etnga-charge-error-dump.md
@@ -1,0 +1,413 @@
+# e-TNGA charge report — error DID-dump (INC-3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On a charge *fault*, capture a one-shot raw diagnostic snapshot of ~30 OBC DIDs and include it (raw hex) in the multi-phase charge report — async, TWDT-safe, decode-agnostic.
+
+**Architecture:** Stacks on INC-2 (`feature/etnga-charge-limiting-side`). When the OBC reports an abnormal `0x1688` charge-stop outcome, set a fault flag; on the next `CHARGE_WAIT` entry, fire a burst of `OnceOffPoll` reads (the existing `RequestVIN` one-shot pattern) for the fixed DID set — all on ECU `0x745`/`0x74D`. Shared success/fail callbacks store the **raw response bytes** keyed by DID in a mutex-protected map; the report renders them as hex. Decode happens offline against the `solterra-can` RE repo, so no per-DID decode is implemented here.
+
+**Tech Stack:** C++ (ESP-IDF 3.3 / older GCC), the OVMS poller (`OnceOffPoll`/`PollRequest`), the e-TNGA vehicle component. No new persistent polls.
+
+## Why this is safe (the design that earns the increment)
+
+- **Single ECU, confirmed:** all DIDs sit on `0x745` (tx) / `0x74D` (rx) — verified by a full gallia scan of the OBC. No ECU guessing.
+- **Raw capture, not decode:** the dump stores the raw UDS response per DID as hex. Uncertain decodes are irrelevant; the artifact is decoded offline.
+- **`OnceOffPoll`, not blocking:** uses the same async one-shot mechanism as `RequestVIN()` — each read auto-removes after one reply (`SeriesStatus::RemoveNext`); nothing blocks the poller or Events task, so no TWDT exposure. `PollSingleRequest` (which blocks and may not run on the poller task) is **not** used.
+- **`"!v."`-prefixed names:** the `OnceOffPoll`s bind `this`; per the documented poller naming contract (the #123/#124 teardown-UAF lesson) they MUST be registered as `"!v.xte.dmp.*"` so `RemovePollRequestStarting("!v.")` reclaims them on vehicle teardown — otherwise a pending poll dereferences a freed signal.
+- **Threading discipline:** the fault flag is set on the **poller task** (`IncomingPlugInControlSystem`, where `0x1688` is processed); the dump is kicked off and rendered on the **Events task** (`TransitionToChargeWaitState` / `GenerateChargeReport`); the shared results map is mutex-protected and the remaining-counter is `std::atomic`. **No `phases[]` is written from the poller task** — the dump is session-level state, rendered on the Events task.
+
+## Global Constraints
+
+- **C++ for ESP-IDF 3.3 / older GCC.** Match the surrounding style (`snprintf`, `ESP_LOGx(TAG, …)`, `std::bind` with `placeholders::_1..6`, `OvmsMutex`/`OvmsMutexLock`). No exceptions.
+- **No host unit-test suite / no local build.** Per-task gate = inspection + reasoning; compile verified by CI (`gh workflow run build.yml --ref feature/etnga-charge-error-dump`). Do NOT propose a local `make`.
+- **Fault trigger = abnormal `0x1688` codes ONLY:** AC `0x23`,`0x24`,`0x25`,`0x29`; DC `0x32`,`0x33`,`0x39`,`0x3A`. NOT benign stops (unplug `0x27`, IG-off `0x44`, over-60-min `0x38`, connector-unlock `0x2C`, reduced-supply `0x28`, operation `0x26`). This is the user-confirmed set.
+- **Mechanism = transient `OnceOffPoll` burst** (user-confirmed), NOT `PollSingleRequest`, NOT a runtime-rebuilt static poll array.
+- **`"!v.xte.dmp.<hex>"` registration names** — mandatory for teardown reclamation.
+- **Raw hex only** — no per-DID decode in this PR.
+- **Threading:** fault flag `std::atomic<bool>`; remaining-count `std::atomic<int>`; results `std::map<uint16_t,std::string>` guarded by a new `OvmsMutex m_dump_mutex`; never write `m_charge_session.phases` from a dump callback.
+- **Degradable:** a DID that fails/times out is recorded as an explicit "(no reply)" entry, never blocks completion. If no fault occurs, nothing changes.
+- **Single-purpose PR / `changes.txt`** bullet under the existing `????-??-?? ???  ???????  OTA release` pending block (no invented dated header).
+- **Work in** `/home/devuser/wt-etnga-error-dump` on branch `feature/etnga-charge-error-dump` (stacked on `feature/etnga-charge-limiting-side`). Paths below are relative to `vehicle/OVMS.V3/components/vehicle_toyota_etnga/`.
+
+## Interfaces from INC-1/INC-2 (already present)
+
+- `ChargeSessionState` with `phases` (`std::vector<ChargePhase>`), `cur`; `ChargePhase` with `outcome`, `is_dc`, `start_utc`, etc.
+- `OpenChargePhase`/`CloseChargePhase`/`ClassifyLimitingSide` in `etnga_charge_report.cpp`; `GenerateChargeReport()` with the per-phase render loop.
+- `IncomingPollReply` → `IncomingPlugInControlSystem(uint16_t pid)` (`etnga_poll_processor.cpp`) — the `0x745` reply handler; `0x1688` is processed here (sets `m_v_charge_outcome`).
+- `RequestVIN()` (`etnga_poll_processor.cpp`) — the exact `OnceOffPoll` precedent: `OnceOffPoll(successCb, failCb, TX, RX, VEHICLE_POLL_TYPE_READDATA, pid, ISOTP_STD, 0, retry_fail)` registered via `PollRequest(m_can2, "!v.xte.vin", entry)`; success cb `(uint16_t type, uint32_t sent, uint32_t rec, uint16_t pid, CAN_frame_format_t fmt, const std::string& data)`, fail cb `(…, int errorcode)`.
+- ECU IDs `PLUG_IN_CONTROL_SYSTEM_TX = 0x745`, `PLUG_IN_CONTROL_SYSTEM_RX = 0x74D`.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/vehicle_toyota_etnga.h` | members + decls | Fault flag/atomics/map/mutex, dump-phase index + outcome, the DID table extern, decls for `MaybeStartChargeFaultDump`, `IncomingDumpSuccess/Fail`, `IsChargeFaultCode`. |
+| `src/etnga_charge_dump.cpp` (NEW) | dump mechanism | DID table, `IsChargeFaultCode`, `MaybeStartChargeFaultDump` (kick off OnceOffPolls), success/fail callbacks (capture raw → map). |
+| `src/etnga_poll_processor.cpp` | fault detection | In the `0x1688` path, set `m_charge_fault_pending` when `IsChargeFaultCode`. |
+| `src/etnga_poll_states.cpp` | kickoff hook | Call `MaybeStartChargeFaultDump()` in `TransitionToChargeWaitState` (after `CloseChargePhase`). |
+| `src/etnga_charge_report.cpp` | render | Add a "Diagnostic DID dump" section to the report when results exist; clear dump state on session open. |
+| `component.mk` / `CMakeLists.txt` | build | (Only if the component doesn't auto-glob `src/*.cpp` — verify; e-TNGA globs, so likely no change.) |
+| `changes.txt` | changelog | New bullet. |
+
+---
+
+## Task 1: State + DID table + declarations
+
+**Files:** Modify `src/vehicle_toyota_etnga.h`.
+
+**Interfaces produced:** members `std::atomic<bool> m_charge_fault_pending{false}`, `std::atomic<int> m_dump_remaining{0}`, `std::map<uint16_t,std::string> m_dump_results`, `OvmsMutex m_dump_mutex`, `int m_dump_phase_idx = -1`, `int m_dump_outcome = -1`; decls `static bool IsChargeFaultCode(int code);`, `void MaybeStartChargeFaultDump();`, `void IncomingDumpSuccess(uint16_t,uint32_t,uint32_t,uint16_t,CAN_frame_format_t,const std::string&);`, `void IncomingDumpFail(uint16_t,uint32_t,uint32_t,uint16_t,int);`.
+
+- [ ] **Step 1: Add includes + members**
+
+Ensure `<atomic>`, `<map>`, `<string>` are included (check the top of the header; add any missing). In the private member area near `m_charge_session`, add:
+
+```cpp
+    // INC-3: charge-fault diagnostic DID dump (raw one-shot snapshot of OBC DIDs on a fault).
+    std::atomic<bool> m_charge_fault_pending{false};   // set on poller task (0x1688 fault), consumed on Events task
+    std::atomic<int>  m_dump_remaining{0};             // OnceOffPolls still outstanding
+    std::map<uint16_t,std::string> m_dump_results;     // pid -> raw response bytes ("" = no reply)
+    OvmsMutex         m_dump_mutex;                     // guards m_dump_results (poller task writes, Events task reads)
+    int               m_dump_phase_idx = -1;           // which phase faulted (index into m_charge_session.phases)
+    int               m_dump_outcome = -1;             // the 0x1688 code that triggered the dump
+```
+
+- [ ] **Step 2: Add method declarations**
+
+Near the `RequestVIN` / charge-report declarations, add:
+
+```cpp
+    static bool IsChargeFaultCode(int code);   // INC-3: true for abnormal 0x1688 stop codes
+    void MaybeStartChargeFaultDump();          // INC-3: kick off the OnceOffPoll burst (Events task)
+    void IncomingDumpSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec,
+                             uint16_t pid, CAN_frame_format_t format, const std::string& data);
+    void IncomingDumpFail(uint16_t type, uint32_t module_sent, uint32_t module_rec,
+                          uint16_t pid, int errorcode);
+```
+
+- [ ] **Step 3: Inspection check**
+
+Run: `grep -n 'm_charge_fault_pending\|m_dump_remaining\|m_dump_results\|m_dump_mutex\|IsChargeFaultCode\|MaybeStartChargeFaultDump\|IncomingDumpSuccess\|IncomingDumpFail' src/vehicle_toyota_etnga.h` and `grep -n '#include <atomic>\|#include <map>' src/vehicle_toyota_etnga.h`
+Expected: all members + decls present; `<atomic>` and `<map>` included.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vehicle_toyota_etnga.h
+git commit -m "etnga: add charge-fault DID-dump state + decls (INC-3, #81)"
+```
+
+---
+
+## Task 2: The dump mechanism (`etnga_charge_dump.cpp`)
+
+**Files:** Create `src/etnga_charge_dump.cpp`.
+
+**Interfaces consumed:** the Task-1 members; `PLUG_IN_CONTROL_SYSTEM_TX/RX`; `PollRequest`, `OvmsPoller::OnceOffPoll`, `VEHICLE_POLL_TYPE_READDATA`, `ISOTP_STD`; `m_charge_session.phases`.
+**Interfaces produced:** definitions of `IsChargeFaultCode`, `MaybeStartChargeFaultDump`, `IncomingDumpSuccess`, `IncomingDumpFail`, and the file-scope DID table.
+
+- [ ] **Step 1: Create the file with the DID table + fault-code test**
+
+Create `src/etnga_charge_dump.cpp`:
+
+```cpp
+/*
+   Project:   Open Vehicle Monitor System
+   Module:    Vehicle Toyota e-TNGA platform — charge-fault diagnostic DID dump
+   Date:      23rd June 2026
+
+   (C) 2026   Jerry Kezar <solterra@kezarnet.com>
+   Licensed under the MIT License.
+
+   On an abnormal 0x1688 charge-stop, fire a one-shot OnceOffPoll burst over the OBC's
+   diagnostic DIDs (all on 0x745/0x74D) and capture each raw response for the charge report.
+   Raw hex only — decode happens offline against the solterra-can RE repo.
+*/
+
+#include "vehicle_toyota_etnga.h"
+
+using namespace std;
+
+// All diagnostic DIDs live on the Plug-In Control System / OBC (tx 0x745 / rx 0x74D),
+// confirmed by a full gallia scan. Raw responses are captured; no decode here.
+static const uint16_t etnga_dump_dids[] = {
+    // state-machine
+    0x1666, 0x1684, 0x1688, 0x1664, 0x1667, 0x1668, 0x1736,
+    // trip-flag
+    0x16AA, 0x16A9, 0x161B, 0x1806, 0x1702,
+    // connector + safety
+    0x1669, 0x1602, 0x1601, 0x1625, 0x1670, 0x164A,
+    // electrical at fault
+    0x10D4, 0x1654, 0x166C, 0x1621, 0x166B, 0x165E,
+    // thermal
+    0x1632, 0x1705, 0x1829, 0x182A, 0x1657, 0x1658,
+};
+static const int ETNGA_DUMP_DID_COUNT = sizeof(etnga_dump_dids) / sizeof(etnga_dump_dids[0]);
+
+// True only for genuine abnormal stops (per the user-confirmed set) — NOT benign stops.
+bool OvmsVehicleToyotaETNGA::IsChargeFaultCode(int code)
+{
+    switch (code & 0xFF) {
+        case 0x23: case 0x24: case 0x25: case 0x29:   // AC: Abnormal / Battery / High-Power / System
+        case 0x32: case 0x33: case 0x39: case 0x3A:   // DC: Abnormal / Battery / System / Vehicle-System
+            return true;
+        default:
+            return false;
+    }
+}
+```
+
+- [ ] **Step 2: Add the success/fail callbacks**
+
+Append to `etnga_charge_dump.cpp`:
+
+```cpp
+// Poller-task callbacks: store the raw response (or an empty marker on failure) keyed by DID,
+// and decrement the outstanding counter. No phases[] access here (Events task owns that).
+void OvmsVehicleToyotaETNGA::IncomingDumpSuccess(uint16_t, uint32_t, uint32_t,
+        uint16_t pid, CAN_frame_format_t, const std::string& data)
+{
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results[pid] = data;
+    }
+    if (--m_dump_remaining <= 0)
+        ESP_LOGI(TAG, "Charge-fault DID dump complete (%d DIDs captured)", (int) m_dump_results.size());
+}
+
+void OvmsVehicleToyotaETNGA::IncomingDumpFail(uint16_t, uint32_t, uint32_t,
+        uint16_t pid, int errorcode)
+{
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results[pid] = "";   // "" => rendered as "(no reply)"
+    }
+    ESP_LOGD(TAG, "Charge-fault dump: DID %04X no reply (err %d)", pid, errorcode);
+    if (--m_dump_remaining <= 0)
+        ESP_LOGI(TAG, "Charge-fault DID dump complete (%d DIDs)", (int) m_dump_results.size());
+}
+```
+
+- [ ] **Step 3: Add the kickoff**
+
+Append to `etnga_charge_dump.cpp`:
+
+```cpp
+// Events task (called from TransitionToChargeWaitState after CloseChargePhase). If a fault was
+// flagged and no dump is already running, fire a OnceOffPoll for every diagnostic DID. Each
+// auto-removes after one reply; "!v." prefix => reclaimed on teardown (poller naming contract).
+void OvmsVehicleToyotaETNGA::MaybeStartChargeFaultDump()
+{
+    if (!m_charge_fault_pending.exchange(false))
+        return;
+    if (m_dump_remaining.load() > 0)
+        return;   // a dump is already in flight; don't overlap
+
+    using std::placeholders::_1; using std::placeholders::_2; using std::placeholders::_3;
+    using std::placeholders::_4; using std::placeholders::_5; using std::placeholders::_6;
+
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results.clear();
+    }
+    m_dump_phase_idx = (int) m_charge_session.phases.size() - 1;   // the phase that just closed/faulted
+    m_dump_outcome   = m_v_charge_outcome->AsInt();
+    m_dump_remaining = ETNGA_DUMP_DID_COUNT;
+
+    char name[24];
+    for (int i = 0; i < ETNGA_DUMP_DID_COUNT; i++) {
+        uint16_t did = etnga_dump_dids[i];
+        auto entry = std::shared_ptr<OvmsPoller::OnceOffPoll>(
+            new OvmsPoller::OnceOffPoll(
+                std::bind(&OvmsVehicleToyotaETNGA::IncomingDumpSuccess, this, _1, _2, _3, _4, _5, _6),
+                std::bind(&OvmsVehicleToyotaETNGA::IncomingDumpFail,    this, _1, _2, _3, _4, _5),
+                PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX,
+                VEHICLE_POLL_TYPE_READDATA, did,
+                ISOTP_STD, 0, /*retry_fail=*/1));
+        snprintf(name, sizeof(name), "!v.xte.dmp.%04X", did);   // "!v." => teardown-reclaimed
+        PollRequest(m_can2, name, entry);
+    }
+    ESP_LOGW(TAG, "Charge fault (0x%02X) — diagnostic dump of %d OBC DIDs started",
+             m_dump_outcome & 0xFF, ETNGA_DUMP_DID_COUNT);
+}
+```
+
+- [ ] **Step 4: Inspection check**
+
+Run: `grep -n 'etnga_dump_dids\|IsChargeFaultCode\|MaybeStartChargeFaultDump\|OnceOffPoll\|!v.xte.dmp' src/etnga_charge_dump.cpp`
+Expected: 30-DID table; fault-code test with the exact code set; kickoff builds `ETNGA_DUMP_DID_COUNT` OnceOffPolls named `"!v.xte.dmp.%04X"`, shared callbacks bound with `_1.._6`/`_1.._5`. Confirm `m_can2`, `PollRequest`, `OvmsPoller::OnceOffPoll`, `VEHICLE_POLL_TYPE_READDATA`, `ISOTP_STD` match the `RequestVIN` usage in `etnga_poll_processor.cpp` (open it and compare the constructor arg order).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/etnga_charge_dump.cpp
+git commit -m "etnga: charge-fault DID-dump mechanism via OnceOffPoll burst (INC-3, #81)"
+```
+
+---
+
+## Task 3: Detect the fault (set the flag)
+
+**Files:** Modify `src/etnga_poll_processor.cpp` — the `0x1688` (`PID_CHARGE_HISTORY`) handling in `IncomingPlugInControlSystem`.
+
+- [ ] **Step 1: Set the flag on an abnormal outcome**
+
+Locate where `0x1688` / `PID_CHARGE_HISTORY` is decoded (it sets `m_v_charge_outcome`). Immediately after the outcome value is set, add:
+
+```cpp
+            // INC-3: flag a diagnostic dump on a genuine charge fault (consumed on CHARGE_WAIT entry).
+            if (IsChargeFaultCode(outcome_code))
+                m_charge_fault_pending = true;
+```
+
+(Use whatever local holds the decoded code — if the handler decodes into e.g. `int val = m_rxbuf[0];` pass that to `IsChargeFaultCode`. If no local exists, read `GetRxBUint8(m_rxbuf, 0)` consistent with the surrounding decode. Match the existing decode of this PID exactly; do not change what `m_v_charge_outcome` is set to.)
+
+- [ ] **Step 2: Inspection check**
+
+Run: `grep -n 'IsChargeFaultCode\|m_charge_fault_pending\|PID_CHARGE_HISTORY\|0x1688' src/etnga_poll_processor.cpp`
+Expected: the flag is set only inside the `0x1688` handler, guarded by `IsChargeFaultCode`, without altering the existing `m_v_charge_outcome` set. Confirm the code value passed matches how this handler reads the outcome byte.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/etnga_poll_processor.cpp
+git commit -m "etnga: flag diagnostic dump on abnormal 0x1688 outcome (INC-3, #81)"
+```
+
+---
+
+## Task 4: Kick off the dump on CHARGE_WAIT entry
+
+**Files:** Modify `src/etnga_poll_states.cpp` — `TransitionToChargeWaitState`.
+
+- [ ] **Step 1: Call the kickoff after the phase closes**
+
+In `TransitionToChargeWaitState()`, after the existing `CloseChargePhase();` call (INC-1), add:
+
+```cpp
+    MaybeStartChargeFaultDump();   // INC-3: if a fault was flagged, snapshot the OBC diagnostic DIDs
+```
+
+- [ ] **Step 2: Inspection check**
+
+Run: `grep -n 'CloseChargePhase\|MaybeStartChargeFaultDump' src/etnga_poll_states.cpp`
+Expected: `MaybeStartChargeFaultDump()` immediately follows `CloseChargePhase()` in `TransitionToChargeWaitState` (so `phases.back()` is the just-closed faulted phase and `m_dump_phase_idx` is correct). Reason: fault `0x1688` arrives during AC/DC; the AC/DC→WAIT transition closes the phase then kicks the dump — correct ordering.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/etnga_poll_states.cpp
+git commit -m "etnga: start charge-fault dump on CHARGE_WAIT entry (INC-3, #81)"
+```
+
+---
+
+## Task 5: Render the dump + reset on session open
+
+**Files:** Modify `src/etnga_charge_report.cpp`.
+
+- [ ] **Step 1: Clear dump state at session open**
+
+INC-1 opens the session in `TransitionToChargeHandshakeState` (in `etnga_poll_states.cpp`), but the dump state is cleared most safely where the report/session resets are centralized. Add a small helper call: in `GenerateChargeReport()`, AFTER the report is rendered+enqueued (just before the function returns), clear the dump state so it cannot leak into a later session:
+
+```cpp
+    // INC-3: dump state is session-scoped; clear after the report consumes it.
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results.clear();
+    }
+    m_dump_phase_idx = -1;
+    m_dump_outcome = -1;
+    m_dump_remaining = 0;
+```
+
+(Also defensively clear in the existing session-open path if the implementer finds the report is skipped on a no-energy session — but the report-end clear covers the normal flow.)
+
+- [ ] **Step 2: Render the diagnostic dump section**
+
+In `GenerateChargeReport()`, after the per-phase loop and before the "Session events" table, add a dump section guarded by results existing:
+
+```cpp
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        if (!m_dump_results.empty()) {
+            f << "<h2>Diagnostic DID dump</h2>\n";
+            char db[64];
+            snprintf(db, sizeof(db), "Phase %d fault (outcome 0x%02X) — OBC 0x745, raw UDS 0x22 responses.",
+                     m_dump_phase_idx + 1, m_dump_outcome & 0xFF);
+            f << "<p>" << db << "</p>\n";
+            f << "<table><tr><th>DID</th><th>raw response (hex)</th></tr>\n";
+            for (std::map<uint16_t,std::string>::const_iterator it = m_dump_results.begin();
+                 it != m_dump_results.end(); ++it) {
+                f << "<tr><td>0x" << std::hex << std::uppercase << it->first << std::dec << "</td><td>";
+                if (it->second.empty()) f << "(no reply)";
+                else {
+                    char hx[4];
+                    for (size_t k = 0; k < it->second.size(); k++) {
+                        snprintf(hx, sizeof(hx), "%02X ", (uint8_t) it->second[k]);
+                        f << hx;
+                    }
+                }
+                f << "</td></tr>\n";
+            }
+            f << "</table>\n";
+        }
+    }
+```
+
+- [ ] **Step 3: Inspection check**
+
+Run: `grep -n 'Diagnostic DID dump\|m_dump_results\|OvmsMutexLock' src/etnga_charge_report.cpp`
+Expected: one render block (mutex-locked) before the events table; one clear block at report end (mutex-locked). The render must hold `m_dump_mutex` for the whole iteration (poller-task callbacks may still be writing). Confirm `<iomanip>`/`std::hex` usage compiles in this file's style — prefer the `snprintf("%02X")` form shown (avoids `<iomanip>` dependency); for the DID header use `snprintf(db2, sizeof(db2), "0x%04X", it->first)` rather than stream hex manipulators if the file doesn't already use `<iomanip>`. **Implementer: use `snprintf` for both the DID and the bytes to match the file's existing style; do not introduce `<iomanip>` if it isn't already included.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/etnga_charge_report.cpp
+git commit -m "etnga: render charge-fault diagnostic DID dump in report (INC-3, #81)"
+```
+
+---
+
+## Task 6: changes.txt + CI build + validation handoff
+
+- [ ] **Step 1: changes.txt bullet** (under the existing `????-??-?? ???  ???????  OTA release` pending block, matching neighbors, NO invented header):
+
+```
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): when a charge ends abnormally (an OBC
+    fault stop), the charge report now includes a raw diagnostic snapshot of ~30 OBC
+    DIDs captured at the fault, to aid offline diagnosis. Normal charges are unaffected.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add vehicle/OVMS.V3/changes.txt
+git commit -m "etnga: changes.txt for charge-fault DID dump (INC-3, #81)"
+```
+
+- [ ] **Step 3: CI build**
+
+Run: `gh workflow run build.yml --ref feature/etnga-charge-error-dump`, watch with `gh run watch <id> --exit-status`. Expected green. **Pay attention** to: the new `etnga_charge_dump.cpp` being picked up by the component build (e-TNGA globs `src/*.cpp` — verify a `component.mk`/`CMakeLists.txt` glob exists; if the component lists sources explicitly, add `src/etnga_charge_dump.cpp`). Fix any error and amend the relevant commit.
+
+- [ ] **Step 4: On-vehicle validation checklist (record in PR / memory)**
+
+The real gate — car-gated, rare (needs a charge fault):
+1. **No-fault regression:** a normal AC/DC charge produces NO "Diagnostic DID dump" section; no extra bus traffic in CHARGE_WAIT; report otherwise identical to INC-2.
+2. **Fault path:** induce/observe an abnormal stop (e.g. an interrupted DC session that reports `0x32`) → the report shows the dump table with raw hex for the DID set; "(no reply)" rows are tolerated; no TWDT, no crash, poller resumes normally.
+3. **Teardown:** `vehicle module NONE` mid-dump does not crash (the `"!v."` names reclaim the pending OnceOffPolls — this is the #123/#124 contract; explicitly exercise it).
+
+---
+
+## Self-Review
+
+**Spec coverage (design doc §6.4):**
+- ~30 DIDs read individually via `0x22`, one-shot, in CHARGE_WAIT → Tasks 2+4. ✓ (all on 0x745, confirmed.)
+- Triggered by `error_in_phase` → Task 3 (abnormal `0x1688` set). ✓
+- Appended to the report → Task 5. ✓ (rendered as a session-level dump section keyed to the faulted phase, raw hex; per-phase `errors[]` vector deliberately not used to avoid cross-task `phases[]` writes — a documented, safer deviation.)
+- Logged to OVMS log → Tasks 2 (`ESP_LOGW`/`ESP_LOGI`). ✓
+
+**Placeholder scan:** no TBD/TODO; every step has complete code. The `0x1688` decode-local in Task 3 Step 1 is the one "match the existing handler" instruction (unavoidable without pinning the live line; bounded and inspection-gated).
+
+**Threading review:** flag is `atomic<bool>` (poller-set, Events-consumed via `exchange`); counter is `atomic<int>`; `m_dump_results` is always accessed under `m_dump_mutex` (callbacks write, kickoff clears, report reads — all locked); `phases[]` is never touched off the Events task; `OnceOffPoll`s are `"!v."`-named for teardown reclamation. No `PollSingleRequest`. No blocking on either task.
+
+**Type consistency:** callback signatures match the `RequestVIN` precedent (`_1.._6` success, `_1.._5` fail). `IsChargeFaultCode(int)`/`MaybeStartChargeFaultDump()`/`IncomingDumpSuccess/Fail` signatures match between header (Task 1) and definitions (Task 2). `m_dump_*` members written/read consistently across Tasks 2-5. `ETNGA_DUMP_DID_COUNT` drives both the counter and the loop.

--- a/docs/superpowers/plans/2026-06-24-etnga-fault-dump-hardening.md
+++ b/docs/superpowers/plans/2026-06-24-etnga-fault-dump-hardening.md
@@ -1,0 +1,182 @@
+# e-TNGA fault-dump hardening + human-readable decode (INC-3 follow-up) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Make the charge-fault diagnostic DID dump reliable and useful: fix its delivery (don't lose it on low-energy faults; beat the async race) and labeling (#139), and render **human-readable decoded values** beside the raw hex in the report.
+
+**Architecture:** Continues PR #137 (branch `feature/etnga-charge-error-dump`, now based on merged master). The dump still captures raw bytes via the OnceOffPoll burst; this adds (a) latching the *triggering* fault outcome/phase, (b) deferring report generation until the dump completes so the report contains it, (c) generating a report even on a sub-0.05 kWh faulted session, and (d) a confident-subset decode rendered alongside the raw hex.
+
+**Tech Stack:** C++ (ESP-IDF 3.3 / older GCC), the e-TNGA vehicle component. No new polls.
+
+## Global Constraints
+
+- **C++ for ESP-IDF 3.3 / older GCC.** Match surrounding style. No host tests; CI compiles (`gh workflow run build.yml --ref feature/etnga-charge-error-dump`). Do NOT propose local `make`.
+- **Threading discipline (unchanged from #137):** dump callbacks run on the **poller task** and touch only `m_dump_results` (under `m_dump_mutex`) + `m_dump_remaining` (atomic). Report generation, the deferral flag, and `phases[]` are **Events-task only**. Do NOT generate the report or touch `phases[]` from a poller callback.
+- **Decode confidence:** only decode DIDs with a confident decode (existing firmware decoders or known temp formulas — see Task 4). Uncertain DIDs render raw-only (decoded column blank). Do NOT invent decodes.
+- **Raw is always kept** — the decoded value is shown *in addition to* the raw hex, never replacing it.
+- **Single-purpose continuation of #137.** Work in `/home/devuser/wt-etnga-error-dump` on `feature/etnga-charge-error-dump`. Paths relative to `vehicle/OVMS.V3/components/vehicle_toyota_etnga/`.
+
+## Interfaces already in place (INC-3, #137)
+- `m_charge_fault_pending` (atomic<bool>), `m_dump_remaining` (atomic<int>), `m_dump_results` (map<uint16_t,string>), `m_dump_mutex`, `m_dump_phase_idx`, `m_dump_outcome`.
+- `IsChargeFaultCode(int)`, `MaybeStartChargeFaultDump()`, `IncomingDumpSuccess/Fail(...)` in `etnga_charge_dump.cpp`.
+- The `0x1688` handler in `etnga_poll_processor.cpp` sets `m_charge_fault_pending` via `IsChargeFaultCode(outcome_code)`.
+- `GenerateChargeReport()` in `etnga_charge_report.cpp` (skip when `energy < 0.05`; renders the dump table under `m_dump_mutex`; clears dump state at report end; session-open clear in `TransitionToChargeHandshakeState`).
+- Existing decoders: `ChargeOutcomeLabel(int)`, `HlcStateLabel(int)`, `AcOpStatusLabel(int)`; `CalculateBatteryChargingPower`, `CalculatePISWRaw`, station present V/A calculators.
+
+---
+
+## Task 1: Latch the triggering outcome + phase (labeling fix, #139.2)
+
+**Files:** `src/vehicle_toyota_etnga.h` (members), `src/etnga_poll_processor.cpp` (the `0x1688` handler), `src/etnga_charge_dump.cpp` (`MaybeStartChargeFaultDump`).
+
+- [ ] **Step 1:** Add members in the header near the dump state: `int m_dump_trigger_outcome = -1;` and `int m_dump_trigger_phase = -1;`.
+- [ ] **Step 2:** In `etnga_poll_processor.cpp`, where `IsChargeFaultCode(outcome_code)` sets `m_charge_fault_pending = true`, also latch the trigger context at that moment:
+```cpp
+            if (IsChargeFaultCode(outcome_code)) {
+                m_charge_fault_pending = true;
+                m_dump_trigger_outcome = outcome_code;                          // the code that IS the fault
+                m_dump_trigger_phase   = (m_charge_session.cur >= 0)
+                                         ? m_charge_session.cur
+                                         : (int) m_charge_session.phases.size() - 1;  // phase whose fault flagged
+            }
+```
+- [ ] **Step 3:** In `MaybeStartChargeFaultDump()`, REPLACE the `m_dump_outcome = m_v_charge_outcome->AsInt();` / `m_dump_phase_idx = phases.size()-1` lines with the latched values:
+```cpp
+    m_dump_outcome   = m_dump_trigger_outcome;                       // the triggering fault code, not current
+    m_dump_phase_idx = (m_dump_trigger_phase >= 0) ? m_dump_trigger_phase
+                                                   : (int) m_charge_session.phases.size() - 1;
+```
+- [ ] **Step 4:** Inspection: the dump label now reflects the *fault* code. Reason the 2026-06-24 case: trigger `0x29` in Phase 1 → label "Phase 1 fault (outcome 0x29 …)", not "Phase 2 fault (0x26)".
+- [ ] **Step 5:** Commit `etnga: latch triggering fault outcome+phase for the dump (INC-3, #139)`.
+
+---
+
+## Task 2: Generate a report even on a sub-0.05 kWh faulted session (delivery fix, #139.1a)
+
+**Files:** `src/etnga_charge_report.cpp` (`GenerateChargeReport` skip guard).
+
+- [ ] **Step 1:** Change the `energy < 0.05f` skip so it does NOT skip when a fault dump exists/was triggered. Locate the skip guard and add a dump condition:
+```cpp
+    bool have_dump = (m_dump_phase_idx >= 0) || (m_dump_remaining.load() > 0);
+    if ((energy_kwh < 0.05f || m_charge_session.base.empty()) && !have_dump) {
+        // ... existing skip (stub-CSV cleanup) ...
+        return;
+    }
+```
+(So a faulted session still produces a report carrying the diagnostic dump, even with ~no energy.)
+- [ ] **Step 2:** Inspection: a fault with <0.05 kWh now renders a report; a normal <0.05 kWh plug-blip still skips.
+- [ ] **Step 3:** Commit `etnga: don't skip the charge report when a fault dump exists (INC-3, #139)`.
+
+---
+
+## Task 3: Defer report generation until the dump completes (delivery fix, #139.1b — Events-task only)
+
+**Files:** `src/vehicle_toyota_etnga.h` (members), `src/etnga_poll_states.cpp` (`TransitionToAwakeState`, the AWAKE PISW-reconcile in `HandleAwakeState`, and a check in `Ticker1`/`HandleAwakeState`).
+
+**Design:** Report generation stays 100% on the Events task. At session close, if a dump is in flight, set a pending flag and DEFER both the report and the session reset; a per-tick check (Events task) finalizes once the dump completes or a timeout elapses. No cross-task report generation.
+
+- [ ] **Step 1:** Header members: `bool m_report_pending = false;` and `int m_report_pending_deadline = 0;` and a `static const int DUMP_WAIT_SECS = 10;`.
+- [ ] **Step 2:** Add a private helper `void FinalizeChargeSession();` (Events task) implemented in `etnga_charge_report.cpp`:
+```cpp
+// Events-task: write the report and reset the session. Used both for the immediate close
+// path and the deferred (wait-for-dump) path.
+void OvmsVehicleToyotaETNGA::FinalizeChargeSession()
+{
+    GenerateChargeReport();
+    m_charge_session = ChargeSessionState{};
+}
+```
+- [ ] **Step 3:** In `TransitionToAwakeState()` where it currently does `GenerateChargeReport(); m_charge_session = ChargeSessionState{};` (the `in_session` block), replace with a defer-or-finalize:
+```cpp
+        if (m_charge_session.in_session) {
+            ESP_LOGI(TAG, "Charge session closed");
+            LogChargeEvent("Unplugged");
+            if (m_dump_remaining.load() > 0) {       // a fault dump is still capturing — wait for it
+                m_report_pending = true;
+                m_report_pending_deadline = monotonic + DUMP_WAIT_SECS;
+                ESP_LOGI(TAG, "Report deferred — waiting for fault dump (%d DIDs left)", m_dump_remaining.load());
+            } else {
+                FinalizeChargeSession();
+            }
+        } else {
+            m_charge_session = ChargeSessionState{};   // not in session — nothing to finalize
+        }
+        m_charge_wait_slept = false;
+```
+(Note: the old code reset `m_charge_session` unconditionally after the report; now the reset happens inside `FinalizeChargeSession`, or is deferred. Make sure the non-`in_session` path still clears as before.)
+- [ ] **Step 4:** Apply the SAME defer logic to the AWAKE PISW-reconcile close path in `HandleAwakeState` (the `in_session && m_pisw_zero_count >= 2` block): if `m_dump_remaining > 0`, set `m_report_pending`/deadline instead of calling `GenerateChargeReport()` + reset.
+- [ ] **Step 5:** Add a deferral-completion check at the TOP of `HandleAwakeState` (Events task, runs each tick), BEFORE the PISW-reconcile, guarded so it owns the close while pending:
+```cpp
+    if (m_report_pending) {
+        if (m_dump_remaining.load() <= 0 || StandardMetrics.ms_m_monotonic->AsInt() >= m_report_pending_deadline) {
+            ESP_LOGI(TAG, "Fault dump done (or timed out) — finalizing deferred report");
+            FinalizeChargeSession();
+            m_report_pending = false;
+        }
+        return;   // hold normal AWAKE handling (incl. the PISW-reconcile) until the deferred report is written
+    }
+```
+- [ ] **Step 6:** Inspection/reasoning: trace a faulted unplug — session close sees `m_dump_remaining > 0` → defers; ~3-6 s later the dump completes → the per-tick check finalizes (report now contains the full dump); on a hung DID, the 10 s deadline finalizes anyway. Confirm the `return` prevents the PISW-reconcile from double-finalizing while pending, and that `m_report_pending` is cleared on finalize. Confirm `FinalizeChargeSession` resets `m_charge_session` (so `report_pending`'s view of the session stays valid until then).
+- [ ] **Step 7:** Commit `etnga: defer charge report until fault dump completes (INC-3, #139)`.
+
+---
+
+## Task 4: Human-readable decode of the confident DID subset
+
+**Files:** `src/etnga_charge_dump.cpp` (a decode function), `src/vehicle_toyota_etnga.h` (decl).
+
+- [ ] **Step 1:** Declare `std::string DumpDidDecode(uint16_t did, const std::string& raw);` (member).
+- [ ] **Step 2:** Implement in `etnga_charge_dump.cpp` — return a human-readable string for the **confident subset**, else `""` (caller shows raw only). Use `uint8_t` access to `raw` bytes (guard length). Confident decodes:
+```cpp
+// Human-readable decode for the confident DID subset. "" = no confident decode (raw-only).
+std::string OvmsVehicleToyotaETNGA::DumpDidDecode(uint16_t did, const std::string& raw)
+{
+    auto u8  = [&](size_t i)->int { return (i < raw.size()) ? (uint8_t)raw[i] : -1; };
+    auto u16 = [&](size_t i)->int { return (i+1 < raw.size()) ? (((uint8_t)raw[i]<<8)|(uint8_t)raw[i+1]) : -1; };
+    char b[64];
+    switch (did) {
+        case 0x1688: { const char* l = ChargeOutcomeLabel(u8(0)); return l[0] ? l : ""; }
+        case 0x1666: { const char* l = HlcStateLabel(u8(0));     return l[0] ? l : ""; }
+        case 0x1684: { const char* l = AcOpStatusLabel(u8(0));   return l[0] ? l : ""; }
+        case 0x10D4: { int v=u16(0); if(v<0)return ""; snprintf(b,sizeof(b),"%.2f kW", (v-0x8000)*0.01f); return b; }
+        case 0x1829: case 0x182A: { int v=u16(0); if(v<0)return ""; snprintf(b,sizeof(b),"%.1f °C", v/256.0f-50.0f); return b; }  // batt max/min temp, Q8.8 -50
+        case 0x1657: case 0x1658: { int v=u8(0);  if(v<0)return ""; snprintf(b,sizeof(b),"%d °C", v-50); return b; }              // PFC / DC-DC temp, u8 -50
+        case 0x1669: { int v=u8(0); if(v<0)return ""; snprintf(b,sizeof(b),"PISW 0x%02X", v); return b; }
+        default: return "";   // uncertain — raw only
+    }
+}
+```
+(Temp formulas confirmed against the live dump: `0x1829`=`45 00` -> 19.0 °C, `0x182A`=`44 00` -> 18.0 °C, matching the 66 °F battery; `0x1657`=`54` -> 34 °C. If `AcOpStatusLabel`/`HlcStateLabel` are `static`, the unqualified call from this member is fine. Verify each label fn exists with that exact name and a `const char*` return.)
+- [ ] **Step 3:** Inspection: each `case` matches an existing decoder/known formula; default returns `""`; length-guarded.
+- [ ] **Step 4:** Commit `etnga: decode confident DIDs to human-readable for the fault dump (INC-3)`.
+
+---
+
+## Task 5: Render decoded value beside raw hex (report dump table)
+
+**Files:** `src/etnga_charge_report.cpp` (the dump-render block).
+
+- [ ] **Step 1:** In the dump-render block, add a third column "decoded" and the latched trigger label. Change the header line + the per-row emit:
+  - Section intro: use the latched trigger — `Phase <m_dump_phase_idx+1> fault (outcome 0x<m_dump_outcome> "<ChargeOutcomeLabel>")`.
+  - Table header: `<tr><th>DID</th><th>raw (hex)</th><th>decoded</th></tr>`.
+  - Per row: after the raw-hex `<td>`, add `<td>` + `DumpDidDecode(it->first, it->second)` (HTML-escaped; it's controlled text but escape defensively) or empty.
+```cpp
+            f << "<td>" << DumpDidDecode(it->first, it->second) << "</td>";
+```
+- [ ] **Step 2:** Inspection: 3-column table; decoded column populated for the confident subset (outcome label, temps, kW, HLC/AC-op), blank otherwise; the section title cites the triggering `0x29`-style code, not the benign current one.
+- [ ] **Step 3:** Commit `etnga: render decoded DID values + correct trigger label in report (INC-3)`.
+
+---
+
+## Task 6: changes.txt + CI
+
+- [ ] **Step 1:** Update the existing INC-3 `changes.txt` bullet (under the `????` pending block) to mention the dump now shows decoded values and is captured reliably on a fault (reword the existing e-TNGA fault-dump bullet rather than adding a new one).
+- [ ] **Step 2:** Commit. Then `gh workflow run build.yml --ref feature/etnga-charge-error-dump`, watch, fix any compile error.
+- [ ] **Step 3:** On-vehicle validation checklist (record): induce/observe a fault (an interrupted charge that reports `0x23/24/25/29` or `0x32/33/39/3A`) → the report (a) is generated even if ~no energy, (b) contains the full dump table with decoded values, (c) labels the *triggering* fault code/phase. The benign-stop non-fire still holds.
+
+## Self-Review
+- #139.1 (lost dump): Task 2 (no-skip on fault) + Task 3 (defer until complete) → the report reliably contains the dump. ✓
+- #139.2 (mislabel): Task 1 (latch trigger outcome+phase). ✓
+- Human-readable: Task 4 (confident decode) + Task 5 (render decoded col). ✓ Raw kept alongside. ✓
+- Threading: all report/deferral logic on the Events task; poller callbacks unchanged (map+counter only); `phases[]` never touched off-Events. The defer holds `in_session` until finalize — Task 3 Step 5's `return` prevents the PISW-reconcile from racing. ✓
+- Decode confidence: only existing-decoder / known-formula DIDs; uncertain ones raw-only. ✓

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -10,9 +10,11 @@ Open Vehicle Monitor System v3 - Change log
     charge-rate limit per phase — whether the car (battery taper, flagged "cold battery" when
     the pack was cold) or the station capped the rate, with the binding kW shown. AC phases are
     not yet attributed.
-- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): when a charge ends abnormally (an OBC fault
-    stop), the charge report now includes a raw diagnostic snapshot of ~30 OBC DIDs captured at
-    the fault, to aid offline diagnosis. Normal charges are unaffected.
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): when a charge ends with an OBC fault, the
+    charge report now includes a diagnostic snapshot of ~30 OBC DIDs with human-readable
+    decoded values alongside the raw bytes, labelled with the triggering fault. The report is
+    produced for a faulted session even if almost no energy was delivered. Normal charges are
+    unaffected.
 - WiFi: optional priority network list. When enabled, the module prefers known WiFi networks in a
     user-defined order and, while connected to a lower-priority network, periodically scans and
     upgrades to a higher-priority one when it is in range with good signal (>= network wifi.sq.good).

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -10,6 +10,9 @@ Open Vehicle Monitor System v3 - Change log
     charge-rate limit per phase — whether the car (battery taper, flagged "cold battery" when
     the pack was cold) or the station capped the rate, with the binding kW shown. AC phases are
     not yet attributed.
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): when a charge ends abnormally (an OBC fault
+    stop), the charge report now includes a raw diagnostic snapshot of ~30 OBC DIDs captured at
+    the fault, to aid offline diagnosis. Normal charges are unaffected.
 - WiFi: optional priority network list. When enabled, the module prefers known WiFi networks in a
     user-defined order and, while connected to a lower-priority network, periodically scans and
     upgrades to a higher-priority one when it is in range with good signal (>= network wifi.sq.good).

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
@@ -68,6 +68,24 @@ void OvmsVehicleToyotaETNGA::IncomingDumpFail(uint16_t type, uint32_t module_sen
         ESP_LOGI(TAG, "Charge-fault DID dump complete (%d DIDs)", (int) m_dump_results.size());
 }
 
+// Human-readable decode for the confident DID subset. "" = no confident decode (raw-only).
+std::string OvmsVehicleToyotaETNGA::DumpDidDecode(uint16_t did, const std::string& raw)
+{
+    auto u8  = [&](size_t i)->int { return (i < raw.size()) ? (uint8_t)raw[i] : -1; };
+    auto u16 = [&](size_t i)->int { return (i+1 < raw.size()) ? (((uint8_t)raw[i]<<8)|(uint8_t)raw[i+1]) : -1; };
+    char b[64];
+    switch (did) {
+        case 0x1688: { const char* l = ChargeOutcomeLabel(u8(0)); return l[0] ? l : ""; }
+        case 0x1666: { const char* l = HlcStateLabel(u8(0));     return l[0] ? l : ""; }
+        case 0x1684: { const char* l = AcOpStatusLabel(u8(0));   return l[0] ? l : ""; }
+        case 0x10D4: { int v=u16(0); if(v<0)return ""; snprintf(b,sizeof(b),"%.2f kW", (v-0x8000)*0.01f); return b; }
+        case 0x1829: case 0x182A: { int v=u16(0); if(v<0)return ""; snprintf(b,sizeof(b),"%.1f °C", v/256.0f-50.0f); return b; }  // batt max/min temp, Q8.8 -50
+        case 0x1657: case 0x1658: { int v=u8(0);  if(v<0)return ""; snprintf(b,sizeof(b),"%d °C", v-50); return b; }              // PFC / DC-DC temp, u8 -50
+        case 0x1669: { int v=u8(0); if(v<0)return ""; snprintf(b,sizeof(b),"PISW 0x%02X", v); return b; }
+        default: return "";   // uncertain — raw only
+    }
+}
+
 // Events task (called from TransitionToChargeWaitState after CloseChargePhase). If a fault was
 // flagged and no dump is already running, fire a OnceOffPoll for every diagnostic DID. Each
 // auto-removes after one reply; "!v." prefix => reclaimed on teardown (poller naming contract).

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
@@ -1,0 +1,107 @@
+/*
+   Project:   Open Vehicle Monitor System
+   Module:    Vehicle Toyota e-TNGA platform — charge-fault diagnostic DID dump
+   Date:      23rd June 2026
+
+   (C) 2026   Jerry Kezar <solterra@kezarnet.com>
+   Licensed under the MIT License.
+
+   On an abnormal 0x1688 charge-stop, fire a one-shot OnceOffPoll burst over the OBC's
+   diagnostic DIDs (all on 0x745/0x74D) and capture each raw response for the charge report.
+   Raw hex only — decode happens offline against the solterra-can RE repo.
+*/
+
+#include "vehicle_toyota_etnga.h"
+
+using namespace std;
+
+// All diagnostic DIDs live on the Plug-In Control System / OBC (tx 0x745 / rx 0x74D),
+// confirmed by a full gallia scan. Raw responses are captured; no decode here.
+static const uint16_t etnga_dump_dids[] = {
+    // state-machine
+    0x1666, 0x1684, 0x1688, 0x1664, 0x1667, 0x1668, 0x1736,
+    // trip-flag
+    0x16AA, 0x16A9, 0x161B, 0x1806, 0x1702,
+    // connector + safety
+    0x1669, 0x1602, 0x1601, 0x1625, 0x1670, 0x164A,
+    // electrical at fault
+    0x10D4, 0x1654, 0x166C, 0x1621, 0x166B, 0x165E,
+    // thermal
+    0x1632, 0x1705, 0x1829, 0x182A, 0x1657, 0x1658,
+};
+static const int ETNGA_DUMP_DID_COUNT = sizeof(etnga_dump_dids) / sizeof(etnga_dump_dids[0]);
+
+// True only for genuine abnormal stops (per the user-confirmed set) — NOT benign stops.
+bool OvmsVehicleToyotaETNGA::IsChargeFaultCode(int code)
+{
+    switch (code & 0xFF) {
+        case 0x23: case 0x24: case 0x25: case 0x29:   // AC: Abnormal / Battery / High-Power / System
+        case 0x32: case 0x33: case 0x39: case 0x3A:   // DC: Abnormal / Battery / System / Vehicle-System
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Poller-task callbacks: store the raw response (or an empty marker on failure) keyed by DID,
+// and decrement the outstanding counter. No phases[] access here (Events task owns that).
+void OvmsVehicleToyotaETNGA::IncomingDumpSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec,
+        uint16_t pid, CAN_frame_format_t format, const std::string& data)
+{
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results[pid] = data;
+    }
+    if (--m_dump_remaining <= 0)
+        ESP_LOGI(TAG, "Charge-fault DID dump complete (%d DIDs captured)", (int) m_dump_results.size());
+}
+
+void OvmsVehicleToyotaETNGA::IncomingDumpFail(uint16_t type, uint32_t module_sent, uint32_t module_rec,
+        uint16_t pid, int errorcode)
+{
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results[pid] = "";   // "" => rendered as "(no reply)"
+    }
+    ESP_LOGD(TAG, "Charge-fault dump: DID %04X no reply (err %d)", pid, errorcode);
+    if (--m_dump_remaining <= 0)
+        ESP_LOGI(TAG, "Charge-fault DID dump complete (%d DIDs)", (int) m_dump_results.size());
+}
+
+// Events task (called from TransitionToChargeWaitState after CloseChargePhase). If a fault was
+// flagged and no dump is already running, fire a OnceOffPoll for every diagnostic DID. Each
+// auto-removes after one reply; "!v." prefix => reclaimed on teardown (poller naming contract).
+void OvmsVehicleToyotaETNGA::MaybeStartChargeFaultDump()
+{
+    if (!m_charge_fault_pending.exchange(false))
+        return;
+    if (m_dump_remaining.load() > 0)
+        return;   // a dump is already in flight; don't overlap
+
+    using std::placeholders::_1; using std::placeholders::_2; using std::placeholders::_3;
+    using std::placeholders::_4; using std::placeholders::_5; using std::placeholders::_6;
+
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results.clear();
+    }
+    m_dump_phase_idx = (int) m_charge_session.phases.size() - 1;   // the phase that just closed/faulted
+    m_dump_outcome   = m_v_charge_outcome->AsInt();
+    m_dump_remaining = ETNGA_DUMP_DID_COUNT;
+
+    char name[24];
+    for (int i = 0; i < ETNGA_DUMP_DID_COUNT; i++) {
+        uint16_t did = etnga_dump_dids[i];
+        auto entry = std::shared_ptr<OvmsPoller::OnceOffPoll>(
+            new OvmsPoller::OnceOffPoll(
+                std::bind(&OvmsVehicleToyotaETNGA::IncomingDumpSuccess, this, _1, _2, _3, _4, _5, _6),
+                std::bind(&OvmsVehicleToyotaETNGA::IncomingDumpFail,    this, _1, _2, _3, _4, _5),
+                PLUG_IN_CONTROL_SYSTEM_TX, PLUG_IN_CONTROL_SYSTEM_RX,
+                VEHICLE_POLL_TYPE_READDATA, did,
+                ISOTP_STD, 0, /*retry_fail=*/1));
+        snprintf(name, sizeof(name), "!v.xte.dmp.%04X", did);   // "!v." => teardown-reclaimed
+        PollRequest(m_can2, name, entry);
+    }
+    ESP_LOGW(TAG, "Charge fault (0x%02X) — diagnostic dump of %d OBC DIDs started",
+             m_dump_outcome & 0xFF, ETNGA_DUMP_DID_COUNT);
+}

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
@@ -85,8 +85,9 @@ void OvmsVehicleToyotaETNGA::MaybeStartChargeFaultDump()
         OvmsMutexLock lock(&m_dump_mutex);
         m_dump_results.clear();
     }
-    m_dump_phase_idx = (int) m_charge_session.phases.size() - 1;   // the phase that just closed/faulted
-    m_dump_outcome   = m_v_charge_outcome->AsInt();
+    m_dump_outcome   = m_dump_trigger_outcome;                       // the triggering fault code, not current
+    m_dump_phase_idx = (m_dump_trigger_phase >= 0) ? m_dump_trigger_phase
+                                                   : (int) m_charge_session.phases.size() - 1;
     m_dump_remaining = ETNGA_DUMP_DID_COUNT;
 
     char name[24];

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -736,11 +736,11 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
         OvmsMutexLock lock(&m_dump_mutex);
         if (!m_dump_results.empty()) {
             f << "<h2>Diagnostic DID dump</h2>\n";
-            char db[64];
-            snprintf(db, sizeof(db), "Phase %d fault (outcome 0x%02X) — OBC 0x745, raw UDS 0x22 responses.",
-                     m_dump_phase_idx + 1, m_dump_outcome & 0xFF);
+            char db[96];
+            snprintf(db, sizeof(db), "Phase %d fault (outcome 0x%02X \"%s\") — OBC 0x745, raw UDS 0x22 responses.",
+                     m_dump_phase_idx + 1, m_dump_outcome & 0xFF, ChargeOutcomeLabel(m_dump_outcome));
             f << "<p>" << db << "</p>\n";
-            f << "<table><tr><th>DID</th><th>raw response (hex)</th></tr>\n";
+            f << "<table><tr><th>DID</th><th>raw (hex)</th><th>decoded</th></tr>\n";
             for (std::map<uint16_t,std::string>::const_iterator it = m_dump_results.begin();
                  it != m_dump_results.end(); ++it) {
                 char did[8];
@@ -755,7 +755,7 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
                         f << hx;
                     }
                 }
-                f << "</td></tr>\n";
+                f << "</td><td>" << DumpDidDecode(it->first, it->second) << "</td></tr>\n";
             }
             f << "</table>\n";
         }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -555,6 +555,14 @@ void OvmsVehicleToyotaETNGA::RenderPowerSvg(std::ostream& out)
     out << "</svg>\n";
 }
 
+// Events-task: write the report and reset the session. Used both for the immediate close
+// path and the deferred (wait-for-dump) path.
+void OvmsVehicleToyotaETNGA::FinalizeChargeSession()
+{
+    GenerateChargeReport();
+    m_charge_session = ChargeSessionState{};
+}
+
 void OvmsVehicleToyotaETNGA::GenerateChargeReport()
 {
     if (m_charge_session.report_written)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -561,7 +561,8 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
         return;                 // defensive idempotency
     CloseChargePhase();         // close any still-open phase (direct AC/DC->AWAKE safety net)
     const float energy_kwh = StandardMetrics.ms_v_charge_kwh->AsFloat();
-    if (energy_kwh < 0.05f || m_charge_session.base.empty()) {
+    bool have_dump = (m_dump_phase_idx >= 0) || (m_dump_remaining.load() > 0);
+    if ((energy_kwh < 0.05f || m_charge_session.base.empty()) && !have_dump) {
         ESP_LOGD(TAG, "Charge report skipped (%.3f kWh)", energy_kwh);
         if (m_charge_session.csv_file_created) {  // remove the streamed stub CSV via the worker
             etnga_io_job* j = new etnga_io_job;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -722,6 +722,36 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
         f << "</dl>\n";
     }
 
+    // INC-3: diagnostic DID dump (fault-triggered; empty in normal sessions).
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        if (!m_dump_results.empty()) {
+            f << "<h2>Diagnostic DID dump</h2>\n";
+            char db[64];
+            snprintf(db, sizeof(db), "Phase %d fault (outcome 0x%02X) — OBC 0x745, raw UDS 0x22 responses.",
+                     m_dump_phase_idx + 1, m_dump_outcome & 0xFF);
+            f << "<p>" << db << "</p>\n";
+            f << "<table><tr><th>DID</th><th>raw response (hex)</th></tr>\n";
+            for (std::map<uint16_t,std::string>::const_iterator it = m_dump_results.begin();
+                 it != m_dump_results.end(); ++it) {
+                char did[8];
+                snprintf(did, sizeof(did), "0x%04X", it->first);
+                f << "<tr><td>" << did << "</td><td>";
+                if (it->second.empty()) {
+                    f << "(no reply)";
+                } else {
+                    char hx[4];
+                    for (size_t k = 0; k < it->second.size(); k++) {
+                        snprintf(hx, sizeof(hx), "%02X ", (uint8_t) it->second[k]);
+                        f << hx;
+                    }
+                }
+                f << "</td></tr>\n";
+            }
+            f << "</table>\n";
+        }
+    }
+
     f << "<h2>Session events</h2>\n<table><tr><th>Time</th><th>Event</th></tr>\n";
     for (size_t i = 0; i < m_charge_session.events.size(); i++) {
         int rel = m_charge_session.events[i].first - m_charge_session.start_monotonic; if (rel < 0) rel = 0;
@@ -766,4 +796,12 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
     ChargeIoEnqueue(job);
     ESP_LOGI(TAG, "Charge report queued: %s.html (%.2f kWh, %d%%->%d%%)",
         m_charge_session.base.c_str(), energy_kwh, start_soc, end_soc);
+    // INC-3: dump state is session-scoped; clear after the report consumes it.
+    {
+        OvmsMutexLock lock(&m_dump_mutex);
+        m_dump_results.clear();
+    }
+    m_dump_phase_idx = -1;
+    m_dump_outcome = -1;
+    m_dump_remaining = 0;
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -386,7 +386,11 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
             break;
         }
         case PID_CHARGE_HISTORY: {
-            SetChargeOutcome(CalculateChargeOutcome(m_rxbuf));
+            int outcome_code = CalculateChargeOutcome(m_rxbuf);
+            SetChargeOutcome(outcome_code);
+            // INC-3: flag a diagnostic dump on a genuine charge fault (consumed on CHARGE_WAIT entry).
+            if (IsChargeFaultCode(outcome_code))
+                m_charge_fault_pending = true;
             break;
         }
         case PID_CHARGE_STOP_REQ: {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -389,8 +389,13 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
             int outcome_code = CalculateChargeOutcome(m_rxbuf);
             SetChargeOutcome(outcome_code);
             // INC-3: flag a diagnostic dump on a genuine charge fault (consumed on CHARGE_WAIT entry).
-            if (IsChargeFaultCode(outcome_code))
+            if (IsChargeFaultCode(outcome_code)) {
                 m_charge_fault_pending = true;
+                m_dump_trigger_outcome = outcome_code;                          // the code that IS the fault
+                m_dump_trigger_phase   = (m_charge_session.cur >= 0)
+                                         ? m_charge_session.cur
+                                         : (int) m_charge_session.phases.size() - 1;  // phase whose fault flagged
+            }
             break;
         }
         case PID_CHARGE_STOP_REQ: {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -498,6 +498,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeWaitState()
     SetChargeState(PollState::CHARGE_WAIT);
     LogChargeEvent("Charging paused / phase ended");
     CloseChargePhase();       // INC-1: close the active phase (pause / phase end)
+    MaybeStartChargeFaultDump();   // INC-3: if a fault was flagged, snapshot the OBC diagnostic DIDs
 }
 
 void OvmsVehicleToyotaETNGA::TransitionToChargeAcState()

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -104,6 +104,19 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
 {
     int monotonic = StandardMetrics.ms_m_monotonic->AsInt();
 
+    // INC-3: deferred-report completion check. When a fault dump was in flight at session
+    // close, we hold off on GenerateChargeReport until all DIDs are captured (or a timeout
+    // elapses). This runs first so normal AWAKE handling (including the PISW-reconcile
+    // below) cannot double-finalize while the deferred report is still pending.
+    if (m_report_pending) {
+        if (m_dump_remaining.load() <= 0 || monotonic >= m_report_pending_deadline) {
+            ESP_LOGI(TAG, "Fault dump done (or timed out) — finalizing deferred report");
+            FinalizeChargeSession();
+            m_report_pending = false;
+        }
+        return;   // hold normal AWAKE handling (incl. the PISW-reconcile) until the deferred report is written
+    }
+
     // Wake-reconcile: if a charge session was open and the cable is now gone (confirmed
     // fresh read — not stale/transient), the cable was removed while we slept.
     // Guard: only act on a non-stale PISW value to avoid the ~30s OBC post-wake transient
@@ -139,10 +152,17 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
         ESP_LOGI(TAG, "Charge session ended during sleep — finalizing");
         StandardMetrics.ms_v_charge_state->SetValue("done");
         LogChargeEvent("Unplugged (during sleep)");
-        GenerateChargeReport();   // flushes the CSV; no-op + stub-CSV cleanup if no energy delivered
-        m_charge_session = ChargeSessionState{};
+        if (m_dump_remaining.load() > 0) {       // a fault dump is still capturing — wait for it
+            m_report_pending = true;
+            m_report_pending_deadline = monotonic + DUMP_WAIT_SECS;
+            ESP_LOGI(TAG, "Report deferred — waiting for fault dump (%d DIDs left)", m_dump_remaining.load());
+            m_pisw_zero_count = 0;   // consumed — reset the debounce
+            return;   // exit now; next tick will complete via m_report_pending check at top
+        } else {
+            FinalizeChargeSession();
+        }
         m_pisw_zero_count = 0;   // consumed — reset the debounce
-        // fall through to normal AWAKE handling
+        // fall through to normal AWAKE handling (finalize path only)
     }
 
     if (!StandardMetrics.ms_v_env_awake->AsBool()) {
@@ -410,9 +430,16 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
         if (m_charge_session.in_session) {
             ESP_LOGI(TAG, "Charge session closed");
             LogChargeEvent("Unplugged");
-            GenerateChargeReport();   // write the session-end HTML report (no-op if no energy delivered)
+            if (m_dump_remaining.load() > 0) {       // a fault dump is still capturing — wait for it
+                m_report_pending = true;
+                m_report_pending_deadline = monotonic + DUMP_WAIT_SECS;
+                ESP_LOGI(TAG, "Report deferred — waiting for fault dump (%d DIDs left)", m_dump_remaining.load());
+            } else {
+                FinalizeChargeSession();
+            }
+        } else {
+            m_charge_session = ChargeSessionState{};   // not in session — nothing to finalize
         }
-        m_charge_session = ChargeSessionState{};   // reset (clears in_session)
         m_charge_wait_slept = false;   // leaving the charge sub-machine — clear wait flag
     }
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -484,6 +484,16 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
             mkdir(ChargeReportDir().c_str(), 0755);
             m_charge_session.base = ChargeReportDir() + "/" + ts;
         }
+        // INC-3: dump state is session-scoped — clear at session open so a fault dump from a
+        // prior (possibly <0.05 kWh, report-skipped) session can never leak into this report.
+        {
+            OvmsMutexLock lock(&m_dump_mutex);
+            m_dump_results.clear();
+        }
+        m_dump_phase_idx = -1;
+        m_dump_outcome = -1;
+        m_dump_remaining = 0;
+        m_charge_fault_pending = false;
         LogChargeEvent("Plugged in — handshake");
         ESP_LOGI(TAG, "Charge session opened (SOC %d%%)", m_charge_session.start_soc);
     }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -441,6 +441,11 @@ private:
                              uint16_t pid, CAN_frame_format_t format, const std::string& data);
     void IncomingDumpFail(uint16_t type, uint32_t module_sent, uint32_t module_rec,
                           uint16_t pid, int errorcode);
+    // INC-3: deferred report finalization (Events task only)
+    void FinalizeChargeSession();              // write the report + reset m_charge_session
+    bool m_report_pending = false;             // true while waiting for a fault dump to complete
+    int  m_report_pending_deadline = 0;        // monotonic s: give up and finalize after this
+    static const int DUMP_WAIT_SECS = 10;      // max seconds to wait for the dump before finalizing anyway
 
 };
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -272,6 +272,7 @@ private:
     static const char* ChargeOutcomeLabel(int code);    // 0x1688 enum -> human text
     static const char* HlcStateLabel(int code);         // 0x1666 DC HLC state enum -> human text ("" if unknown)
     static const char* AcOpStatusLabel(int code);       // 0x1684 AC-Op state enum -> human text ("" for Stop/unknown)
+    std::string DumpDidDecode(uint16_t did, const std::string& raw);  // INC-3: human-readable decode for the confident DID subset; "" = raw only
     std::string LookupLocationName(float lat, float lon); // matching OVMS named-location (geofence), or ""
 
     // Incoming message handling functions

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <atomic>
+#include <map>
 #include <iosfwd>
 #include <time.h>
 #include "vehicle.h"
@@ -156,6 +158,14 @@ protected:
         bool  report_written = false;    // idempotency guard for GenerateChargeReport
     };
     ChargeSessionState m_charge_session;
+
+    // INC-3: charge-fault diagnostic DID dump (raw one-shot snapshot of OBC DIDs on a fault).
+    std::atomic<bool> m_charge_fault_pending{false};   // set on poller task (0x1688 fault), consumed on Events task
+    std::atomic<int>  m_dump_remaining{0};             // OnceOffPolls still outstanding
+    std::map<uint16_t,std::string> m_dump_results;     // pid -> raw response bytes ("" = no reply)
+    OvmsMutex         m_dump_mutex;                     // guards m_dump_results (poller task writes, Events task reads)
+    int               m_dump_phase_idx = -1;           // which phase faulted (index into m_charge_session.phases)
+    int               m_dump_outcome = -1;             // the 0x1688 code that triggered the dump
 
     static constexpr int TPMS_SLOT_COUNT = 5;
     int8_t m_tpms_corner[TPMS_SLOT_COUNT] = {0};   // slot->corner cache: 0=unread/none, 1=FL,2=FR,3=RL,4=RR
@@ -422,6 +432,13 @@ private:
     void RequestVIN();
     void IncomingVINSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, CAN_frame_format_t format, const std::string &data);
     void IncomingVINFail(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, int errorcode);
+
+    static bool IsChargeFaultCode(int code);   // INC-3: true for abnormal 0x1688 stop codes
+    void MaybeStartChargeFaultDump();          // INC-3: kick off the OnceOffPoll burst (Events task)
+    void IncomingDumpSuccess(uint16_t type, uint32_t module_sent, uint32_t module_rec,
+                             uint16_t pid, CAN_frame_format_t format, const std::string& data);
+    void IncomingDumpFail(uint16_t type, uint32_t module_sent, uint32_t module_rec,
+                          uint16_t pid, int errorcode);
 
 };
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -166,6 +166,8 @@ protected:
     OvmsMutex         m_dump_mutex;                     // guards m_dump_results (poller task writes, Events task reads)
     int               m_dump_phase_idx = -1;           // which phase faulted (index into m_charge_session.phases)
     int               m_dump_outcome = -1;             // the 0x1688 code that triggered the dump
+    int               m_dump_trigger_outcome = -1;     // latched at fault-flag time (poller task); avoids stale code at dump-kickoff
+    int               m_dump_trigger_phase   = -1;     // latched phase index at fault-flag time
 
     static constexpr int TPMS_SLOT_COUNT = 5;
     int8_t m_tpms_corner[TPMS_SLOT_COUNT] = {0};   // slot->corner cache: 0=unread/none, 1=FL,2=FR,3=RL,4=RR


### PR DESCRIPTION
## What

INC-3 of **#81** — on an abnormal OBC charge-stop, capture a one-shot **raw** diagnostic snapshot of ~30 OBC DIDs and include them (hex) in the charge report, to aid offline fault diagnosis. Normal charges are unaffected.

**Stacked on #136 (INC-2) → #135 (INC-1).** Base is the INC-2 branch; this PR's diff is INC-3 only. GitHub retargets to `master` as the stack merges.

## Design — what makes it safe

- **Trigger:** abnormal `0x1688` codes only — AC `0x23/24/25/29`, DC `0x32/33/39/3A` (not benign stops: unplug, IG-off, over-60-min, connector-unlock). Flag set on the poller task in the existing `0x1688` handler (reuses the decoded `outcome_code`; `m_v_charge_outcome` unchanged).
- **Mechanism:** an async burst of `OnceOffPoll`s — the exact `RequestVIN` pattern — one per DID, all on a single ECU (`0x745`/`0x74D`, confirmed by a full gallia scan). **Not** `PollSingleRequest` (which blocks) → **no TWDT exposure**. Each poll auto-removes after one reply.
- **Teardown-safe:** registered as `"!v.xte.dmp.*"` — the `"!v."` prefix is reclaimed by `ShuttingDownVehicle()`, closing the bind-`this` UAF window (the #123/#124 contract).
- **Raw capture, decode offline:** stores raw UDS response bytes per DID (rendered as hex). Zero decode-guessing — uncertain decodes are irrelevant.
- **Threading discipline:** fault flag `atomic<bool>` (poller-set / Events-consumed via `exchange`); results in a `map` guarded by `m_dump_mutex` at every access; remaining-count `atomic<int>`. **`phases[]` is never written from the poller task** — the dump is session-level state, rendered on the Events task. One deliberate, documented deviation from the design doc (session-level dump instead of per-phase `errors[]`) precisely to keep callbacks off `phases[]`.
- **No cross-session leak:** dump state cleared at session open (and report end), so a report-skipped (<0.05 kWh) fault session can't leak a phantom dump into a later report. (This was a review-caught bug, fixed.)

## Validation

- **CI compile: green** (the new `etnga_charge_dump.cpp` builds into the auto-globbed component).
- **On-vehicle: pending** — the rarest gate (needs an actual charge fault):
  1. **No-fault regression:** normal AC/DC charge → no dump section, no extra CHARGE_WAIT traffic, report identical to INC-2.
  2. **Fault path:** an abnormal stop (e.g. interrupted DC → `0x32`) → report shows the raw-hex dump table; "(no reply)" rows tolerated; no TWDT/crash; poller resumes.
  3. **Teardown:** `vehicle module NONE` mid-dump does not crash (the `"!v."` reclamation — explicitly exercise it).

## Review

6 tasks, each spec+quality reviewed (one Important stale-dump leak caught and fixed); final whole-branch review (opus, concurrency-focused) = **Ready to merge**, no Critical/Important.

Part of #81 (error dump; sleep-persist + summary-mode remain).