### PR TITLE
etnga: suspend charge logging/accounting during a CAN-stale window (#138)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-etnga-charge-stale-suspend.md
+++ b/docs/superpowers/plans/2026-06-24-etnga-charge-stale-suspend.md
@@ -1,0 +1,170 @@
+# e-TNGA: suspend charge logging during CAN-stale (#138) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the CAN poll path goes quiet during a charge (e.g. car locked → OBD gateway isolates the OBC), suspend the per-sample CSV row, the `station_kwh`/`delivered_ah` accumulation, and the SVG chart sample so they don't record/integrate frozen values — and zero the live power metrics for display honesty — resuming automatically when polls return.
+
+**Architecture:** A `m_last_poll_monotonic` timestamp stamped on every `IncomingPollReply` (poller task) is the "bus-alive" signal. `UpdateChargeSessionStats` (vehicle-ticker task) early-returns when `now − m_last_poll_monotonic > 3 s`, after zeroing the live power/current metrics and bumping the integrator dt baselines so resume doesn't bridge the gap. Fully fixes the #138 per-tick corruption; the headline `v.c.kwh` is already gap-clamped (per-reply + `EnergyIntervalHours` 60 s clamp) and needs no change.
+
+**Tech Stack:** C++ (ESP-IDF 3.3 / older GCC), the e-TNGA vehicle component. No new polls, no new dependencies.
+
+## Global Constraints
+
+- **C++ for ESP-IDF 3.3 / older GCC.** Match the surrounding file's style (`StandardMetrics.ms_*`, `ESP_LOGx(TAG, …)`).
+- **No host unit-test suite / not locally buildable.** Per-task gate = code-inspection check (shown `grep`/reasoning) + the GitHub CI build (`gh workflow run build.yml --ref fix/etnga-charge-stale-suspend`). Do NOT propose a local `make`.
+- **`CHARGE_STALE_SECS = 3`** — the charge poll path runs at 1 s; 3 missed = clearly stale but quick. Verbatim value.
+- **Detection signal is a dedicated `m_last_poll_monotonic`** stamped on *every* `IncomingPollReply` (any ECU) — NOT a metric `Age()` (the power metrics are zeroed on stale, which would be circular). It is a plain cross-task `int` (poller writes, ticker reads), consistent with the existing `m_charge_fault_pending` pattern — benign unsynchronized scalar.
+- **Power-zeroing is display-only** — it does not touch the energy integrals; `v.c.kwh` recomputes from pack V×I on the next reply.
+- **Suspend = the whole per-tick body** of `UpdateChargeSessionStats` (CSV, `station_kwh`/`delivered_ah`, SVG, peak/temp/ambient) via an early `return`.
+- **Single-purpose PR / `changes.txt`** entry. Work in `/home/devuser/wt-etnga-stale-suspend` on `fix/etnga-charge-stale-suspend`. Paths relative to `vehicle/OVMS.V3/components/vehicle_toyota_etnga/`.
+
+---
+
+## Task 1: Detection — `m_last_poll_monotonic` + stamp
+
+**Files:**
+- Modify: `src/vehicle_toyota_etnga.h` (add the member)
+- Modify: `src/etnga_poll_processor.cpp` (`IncomingPollReply`, stamp at the top)
+
+**Interfaces:**
+- Produces: member `int m_last_poll_monotonic = 0;` — monotonic seconds of the last poll reply (any ECU), `0` = none yet. Read by `UpdateChargeSessionStats` (Task 2).
+
+- [ ] **Step 1: Add the member**
+
+In `src/vehicle_toyota_etnga.h`, near the other charge/timing members (e.g. by `m_charge_state_entry` / `m_charge_session`), add:
+
+```cpp
+    int m_last_poll_monotonic = 0;   // #138: monotonic s of the last poll reply (any ECU); charge-stale detection
+```
+
+- [ ] **Step 2: Stamp it at the top of `IncomingPollReply`**
+
+In `src/etnga_poll_processor.cpp`, `IncomingPollReply(...)` opens with `{` then `// Check if this is the first frame of the multi-frame response`. Insert the stamp as the very first statement (so it fires on every frame, including partial multi-frame frames — any frame proves the bus is alive):
+
+```cpp
+void OvmsVehicleToyotaETNGA::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length)
+{
+    m_last_poll_monotonic = StandardMetrics.ms_m_monotonic->AsInt();   // #138: bus-alive timestamp for charge-stale detection
+
+    // Check if this is the first frame of the multi-frame response
+    if (job.mlframe == 0) {
+```
+
+- [ ] **Step 3: Inspection check**
+
+Run: `grep -n 'm_last_poll_monotonic' src/vehicle_toyota_etnga.h src/etnga_poll_processor.cpp`
+Expected: the member declared with default `0`; the stamp is the first statement of `IncomingPollReply` (before the `if (job.mlframe == 0)` block). Confirm `StandardMetrics.ms_m_monotonic->AsInt()` is the monotonic-seconds source used elsewhere in these files (it is).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vehicle_toyota_etnga.h src/etnga_poll_processor.cpp
+git commit -m "etnga: stamp last-poll-reply timestamp for charge-stale detection (#138)"
+```
+
+---
+
+## Task 2: Suspend — early-return branch in `UpdateChargeSessionStats`
+
+**Files:**
+- Modify: `src/etnga_charge_report.cpp` (`UpdateChargeSessionStats`)
+
+**Interfaces:**
+- Consumes: `m_last_poll_monotonic` (Task 1); `m_charge_session.{last_sample_monotonic,last_svg_monotonic}` (existing).
+
+- [ ] **Step 1: Add the can-stale branch**
+
+In `UpdateChargeSessionStats()`, the function begins:
+```cpp
+    if (!m_charge_session.in_session)
+        return;
+
+    int now = StandardMetrics.ms_m_monotonic->AsInt();
+
+    float p = StandardMetrics.ms_v_charge_power->AsFloat();
+```
+Insert the branch BETWEEN the `int now = …;` line and the `float p = …;` line:
+
+```cpp
+    // #138: if the CAN poll path has gone quiet (e.g. car locked → OBD gateway isolated from the
+    // OBC), the charge metrics are frozen. Suspend per-sample logging + accumulation so we don't
+    // record/integrate stale values; resume automatically when polls return.
+    const int CHARGE_STALE_SECS = 3;   // charge poll path runs at 1s; 3 missed = clearly stale but quick
+    if (m_last_poll_monotonic == 0 || now - m_last_poll_monotonic > CHARGE_STALE_SECS) {
+        // Display honesty: zero the live power/current so the app/server/CSV don't show a frozen value.
+        // (Does not touch the energy integrals; v.c.kwh recomputes from pack V×I on the next reply.)
+        StandardMetrics.ms_v_charge_power->SetValue(0);
+        StandardMetrics.ms_v_bat_power->SetValue(0);
+        StandardMetrics.ms_v_bat_current->SetValue(0);
+        // Keep the dt baselines current so resume doesn't bridge the gap into delivered_ah / station_kwh / SVG.
+        m_charge_session.last_sample_monotonic = now;
+        m_charge_session.last_svg_monotonic = now;
+        return;   // skip peak/temp/ambient, station_kwh/delivered_ah, CSV row, SVG sample
+    }
+```
+
+- [ ] **Step 2: Inspection check**
+
+Run: `grep -n 'CHARGE_STALE_SECS\|m_last_poll_monotonic\|last_svg_monotonic = now' src/etnga_charge_report.cpp`
+Expected: the branch sits after `int now = …` and before `float p = …`; zeroes the three metrics; bumps `last_sample_monotonic` AND `last_svg_monotonic`; `return`s. Confirm `last_svg_monotonic` is the real member name (grep it in the struct). Reason: during a ≥3 s lock the function returns each tick (no CSV/accumulation/SVG), the live power reads 0; on the first poll reply `m_last_poll_monotonic` advances → branch skipped → normal logging resumes with `dt ≈ 1 s` (no bridged gap).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/etnga_charge_report.cpp
+git commit -m "etnga: suspend charge logging/accounting during a CAN-stale window (#138)"
+```
+
+---
+
+## Task 3: changes.txt + CI build + validation
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/changes.txt`
+
+- [ ] **Step 1: Add the changes.txt bullet** (under the existing `????-??-?? ???  ???????  OTA release` pending block, 4-space continuation indent, NO invented dated header):
+
+```
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): if the CAN bus goes quiet mid-charge (e.g. the
+    car is locked, isolating the diagnostic gateway from the OBC), the charge report no longer
+    records frozen/stale telemetry — the per-sample log, energy accounting and chart pause until
+    the bus responds again, so the reported station energy and efficiency stay honest. Live charge
+    power reads 0 during such a gap.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add vehicle/OVMS.V3/changes.txt
+git commit -m "etnga: changes.txt for CAN-stale charge-logging suspend (#138)"
+```
+
+- [ ] **Step 3: CI build**
+
+Run: `gh workflow run build.yml --ref fix/etnga-charge-stale-suspend`, then watch (`gh run watch <id> --exit-status`). Expected green. Fix any compile error and amend the relevant task commit.
+
+- [ ] **Step 4: On-vehicle validation checklist (record in PR / memory)**
+
+The repro is a lock mid-AC-charge for more than a few seconds. Expect:
+1. The CSV **stops adding rows** during the lock (no frozen rows; no `battery_kw>0 @ pack_a=0`).
+2. The report's `station_kwh` / efficiency are sensible — **no phantom ~0.2 kWh station energy, no >100% efficiency**.
+3. Live `v.c.power` reads **0** during the lock and recovers on unlock.
+4. The session/phase is **not** torn down (still gated on `pisw`/`ac_op`/`hlc`).
+5. On unlock, logging/accounting **resume** cleanly (no bridged spike in `station_kwh`/`delivered_ah`).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Detection (`m_last_poll_monotonic` stamp, `> 3 s`) → Task 1. ✓
+- Suspend per-tick CSV + `station_kwh`/`delivered_ah` + SVG + peak/temp via early return → Task 2. ✓
+- Power-zeroing (display-only) → Task 2. ✓
+- dt-baseline bump on stale → Task 2. ✓
+- Resume (automatic) → Task 2 (no code; the branch simply stops firing). ✓
+- `v.c.kwh` unchanged (already gap-clamped) → not touched, by design. ✓
+- `changes.txt` → Task 3. ✓
+
+**Placeholder scan:** no TBD/TODO; every step has complete code; `CHARGE_STALE_SECS = 3` is concrete.
+
+**Type consistency:** `m_last_poll_monotonic` (`int`) declared in Task 1, read in Task 2 — same name. Zeroed metrics (`ms_v_charge_power`/`ms_v_bat_power`/`ms_v_bat_current`) and bumped members (`last_sample_monotonic`/`last_svg_monotonic`) are existing names (Task 2 Step 2 inspection re-confirms `last_svg_monotonic`). Monotonic source `StandardMetrics.ms_m_monotonic->AsInt()` consistent across both tasks.

--- a/docs/superpowers/specs/2026-06-24-etnga-charge-stale-suspend-design.md
+++ b/docs/superpowers/specs/2026-06-24-etnga-charge-stale-suspend-design.md
@@ -1,0 +1,81 @@
+# e-TNGA: suspend charge logging/accounting during a CAN-stale window (#138) — design
+
+**Date:** 2026-06-24
+**Issue:** [#138](https://github.com/kezarjg/Open-Vehicle-Monitoring-System-3/issues/138) — charge CSV + energy accounting filled with stale values during a lock (CAN-quiet)
+**Status:** design — pending user review
+
+## Problem
+
+When the car is **locked during an AC charge**, the OBD gateway isolates the diagnostic path from the OBC, so the charge metrics stop updating (CAN goes quiet). But `UpdateChargeSessionStats()` runs every tick (~1 s) and keeps logging + integrating **frozen** values:
+
+- the per-sample **CSV row** is written with stale data (`battery_kw` held at its last value while `pack_a` clears to 0 — physically impossible: kW at 0 A);
+- the e-TNGA per-tick energy accumulator **`station_kwh`** (∫ frozen grid power) over-counts by ~0.2 kWh over a ~110 s lock, and **`delivered_ah`** under-counts (`pack_a`=0);
+- the **SVG chart** records a flat stale plateau.
+
+Net result: phantom station energy and a nonsensical efficiency (observed: "52% to battery" / "158%"). The state machine itself rides the lock correctly (only a *fresh* `pisw=0`/`ac_op=0`/`hlc=0xFF` ends a phase/session) — this is purely a logged/accumulated **data-quality** bug.
+
+**Not affected (verified):** the headline **`v.c.kwh`** ("delivered") is integrated by e-TNGA *per poll-reply* (`SetBatteryChargingPower`), not per-tick, and `EnergyIntervalHours` already clamps gaps >60 s to 1 s — so a lock contributes no integration during it and a clamped bridge on resume. It is **not** significantly over-counted; no fix needed there. The corruption is entirely the **per-tick** work in `UpdateChargeSessionStats`.
+
+The existing staleness handlers use `IsStale()` (`SM_STALE_MID` = **120 s**) — far too slow to catch a lock.
+
+## Goal
+
+Quickly detect that the CAN poll path has stopped responding and **suspend all per-sample logging + energy accumulation** until it resumes, so a lock leaves an honest **gap** rather than a fabricated plateau, and every energy number reflects only measured charging.
+
+## Design
+
+### Detection — a dedicated "last poll reply" timestamp
+
+Add a member `int m_last_poll_monotonic = 0;`, stamped to `ms_m_monotonic` at the top of **`IncomingPollReply()`** on *every* reply (any ECU). In `UpdateChargeSessionStats()`:
+
+```cpp
+const int CHARGE_STALE_SECS = 3;   // charge poll path runs at 1s; 3 missed = clearly stale but quick
+int now = StandardMetrics.ms_m_monotonic->AsInt();
+bool can_stale = (m_last_poll_monotonic == 0) || (now - m_last_poll_monotonic > CHARGE_STALE_SECS);
+```
+
+Rationale for a dedicated stamp rather than a metric's `Age()`: (a) we *zero* the power metrics on stale, so using their Age would be circular; (b) "when did we last hear from the car at all" is the semantically-correct signal and is robust to which ECU/DID — the whole OBD path freezes together under a lock (observed: `pack_a`/`0x7D2` telemetry cleared, not just the OBC `0x745`). The stamp is written on the poller task and read on the vehicle-ticker task; it is a plain `int` like the existing `m_charge_fault_pending` cross-task pattern — a benign unsynchronized scalar (worst case: one tick early/late at the boundary).
+
+### Suspend — early-return branch at the top of `UpdateChargeSessionStats()`
+
+When `can_stale` (and `in_session`):
+
+1. **Zero the live power/current metrics** for display honesty — during the lock these are frozen at their last value (e.g. 6.85 kW, which is what the CSV/app/server would otherwise show); 0 reads as "not measuring":
+   ```cpp
+   StandardMetrics.ms_v_charge_power->SetValue(0);
+   StandardMetrics.ms_v_bat_power->SetValue(0);
+   StandardMetrics.ms_v_bat_current->SetValue(0);
+   ```
+   This is **display-only** — it does not touch the energy integrals (`v.c.kwh` recomputes from pack V×I on the next reply; the per-tick accumulators are suspended below). It does **not** end the charge (gated on `ac_op`/`pisw`), and the existing "keep charge-state fresh" code holds `v.c.state = charging`. It mirrors the existing 120 s `ResetStaleMetrics` power-zeroing, just on the quick charge-stale clock.
+2. **Bump the dt baselines** so resume doesn't bridge the gap:
+   ```cpp
+   m_charge_session.last_sample_monotonic = now;
+   m_charge_session.last_svg_monotonic   = now;
+   ```
+3. **`return;`** — skipping the per-sample CSV row (`AppendChargeCsvRow`), the `station_kwh`/`delivered_ah` accumulation, the SVG sample push, and peak/temp/ambient folding (frozen values add nothing).
+
+The rest of `UpdateChargeSessionStats()` (the normal logging/accumulation) runs only when **not** stale.
+
+### Resume — automatic
+
+The next poll reply advances `m_last_poll_monotonic`; `can_stale` goes false; the next tick resumes normal logging/accumulation. Because the dt baselines were kept current during the gap, the first post-resume `delivered_ah`/`station_kwh` step is a normal ~1 s interval (the existing `dt > 0 && dt <= 10` clamp also covers any longer gap).
+
+## Scope / non-goals
+
+- **In:** the suspension + power-zeroing above. One member + one stamp line in `IncomingPollReply`; one branch + a `CHARGE_STALE_SECS` const in `UpdateChargeSessionStats` (`etnga_charge_report.cpp`).
+- **Out:** changing the 120 s `ResetStaleMetrics` handler (leave as-is; the charge-specific quick path lives in `UpdateChargeSessionStats`), the lock-detection state-machine behaviour (already correct), and any report annotation of the gap (the honest numbers are the deliverable; a "telemetry coverage" line is a possible later nicety, not this fix).
+- No new polls.
+
+## Files
+
+| File | Change |
+|---|---|
+| `src/vehicle_toyota_etnga.h` | add `int m_last_poll_monotonic = 0;` |
+| `src/etnga_poll_processor.cpp` | stamp `m_last_poll_monotonic = ms_m_monotonic` at the top of `IncomingPollReply` |
+| `src/etnga_charge_report.cpp` | `CHARGE_STALE_SECS` const + the `can_stale` early-return branch in `UpdateChargeSessionStats` |
+| `vehicle/OVMS.V3/changes.txt` | entry: charge energy accounting stays honest during a lock; `v.c.power` reads 0 during a CAN-stale window |
+
+## Validation
+
+- **Compile:** CI.
+- **On-vehicle (the repro):** lock the car mid-AC-charge for >a few seconds. Expect: the CSV stops adding rows during the lock (no frozen-value rows / no `battery_kw>0 @ pack_a=0`), the SVG shows a gap, the report's `station_kwh`/efficiency/delivered-kWh are sensible (no phantom ~0.2 kWh, no >100% efficiency), `v.c.power` reads 0 during the lock and recovers on unlock, and the session/phase is not torn down.

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,11 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): if the CAN bus goes quiet mid-charge (e.g. the
+    car is locked, isolating the diagnostic gateway from the OBC), the charge report no longer
+    records frozen/stale telemetry — the per-sample log, energy accounting and chart pause until
+    the bus responds again, so the reported station energy and efficiency stay honest. Live charge
+    power reads 0 during such a gap.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): charge-session report is now multi-phase —
     a single plug-in-to-unplug session that charges, pauses (scheduled wait), then tops off is
     reported as separate phases, each with its own SOC delta, energy, peak/avg power,

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -513,53 +513,37 @@ void OvmsVehicleToyotaETNGA::RenderPowerSvg(std::ostream& out)
         }
     }
 
-    // SOC overlay (right axis, 0-100).
-    out << "<polyline fill=\"none\" stroke=\"#39c\" stroke-width=\"1\" stroke-dasharray=\"1 3\" points=\"";
-    for (size_t i = 0; i < s.size(); i++) {
-        float x = PADL + (float)PW * s[i].t_s / tmax;
-        float soc = s[i].soc < 0 ? 0.0f : (s[i].soc > 100 ? 100.0f : (float)s[i].soc);
-        float y = PADT + (float)PH * (1.0f - soc / 100.0f);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
-    }
-    out << "\"/>\n";
-
-    // Car-permitted limit (the BMS taper curve).
-    out << "<polyline fill=\"none\" stroke=\"#0a0\" stroke-width=\"1\" stroke-dasharray=\"5 3\" points=\"";
-    for (size_t i = 0; i < s.size(); i++) {
-        float x = PADL + (float)PW * s[i].t_s / tmax;
-        float v = s[i].car_perm; if (v < 0) v = 0; if (v > pmax) v = pmax;
-        float y = PADT + (float)PH * (1.0f - v / pmax);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
-    }
-    out << "\"/>\n";
-
-    // Station power (actual from EVSE).
-    out << "<polyline fill=\"none\" stroke=\"#e80\" stroke-width=\"1.5\" points=\"";
-    for (size_t i = 0; i < s.size(); i++) {
-        float x = PADL + (float)PW * s[i].t_s / tmax;
-        float v = s[i].station_kw; if (v < 0) v = 0; if (v > pmax) v = pmax;
-        float y = PADT + (float)PH * (1.0f - v / pmax);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
-    }
-    out << "\"/>\n";
-    // HVAC power (into cabin / My-Room).
-    out << "<polyline fill=\"none\" stroke=\"#a0a\" stroke-width=\"1.5\" points=\"";
-    for (size_t i = 0; i < s.size(); i++) {
-        float x = PADL + (float)PW * s[i].t_s / tmax;
-        float v = s[i].hvac_kw; if (v < 0) v = 0; if (v > pmax) v = pmax;
-        float y = PADT + (float)PH * (1.0f - v / pmax);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
-    }
-    out << "\"/>\n";
-    // Delivered power (primary trace).
-    out << "<polyline fill=\"none\" stroke=\"#06c\" stroke-width=\"2\" points=\"";
-    for (size_t i = 0; i < s.size(); i++) {
-        float x = PADL + (float)PW * s[i].t_s / tmax;
-        float v = s[i].kw; if (v < 0) v = 0; if (v > pmax) v = pmax;
-        float y = PADT + (float)PH * (1.0f - v / pmax);
-        snprintf(b, sizeof(b), "%.1f,%.1f ", x, y); out << b;
-    }
-    out << "\"/>\n";
+    // #138 follow-up: render each trace with breaks at time gaps. When the sample time jumps by
+    // more than ~2 sample intervals — a CAN-stale window (logging suspended) or an inter-phase WAIT
+    // pause — start a new polyline segment instead of drawing a straight line across the missing
+    // data, so the chart shows an honest gap. Each trace clamps its value to [0, scale] and maps to y.
+    const int svg_iv = m_charge_session.svg_interval_s > 0 ? m_charge_session.svg_interval_s : 20;
+    const int gap_threshold = 2 * svg_iv;
+    auto emitTrace = [&](const char* poly, float scale, float (*pick)(const ChargeSessionState::Sample&)) {
+        out << poly << " points=\"";
+        int prev = -1; char bb[32];
+        for (size_t i = 0; i < s.size(); i++) {
+            if (prev >= 0 && s[i].t_s - prev > gap_threshold)   // gap -> break the line
+                out << "\"/>\n" << poly << " points=\"";
+            prev = s[i].t_s;
+            float x = PADL + (float)PW * s[i].t_s / tmax;
+            float v = pick(s[i]); if (v < 0) v = 0; if (v > scale) v = scale;
+            float y = PADT + (float)PH * (1.0f - v / scale);
+            snprintf(bb, sizeof(bb), "%.1f,%.1f ", x, y); out << bb;
+        }
+        out << "\"/>\n";
+    };
+    // SOC overlay (right axis, 0-100), car-permitted limit, station power, HVAC power, delivered (primary).
+    emitTrace("<polyline fill=\"none\" stroke=\"#39c\" stroke-width=\"1\" stroke-dasharray=\"1 3\"", 100.0f,
+              [](const ChargeSessionState::Sample& smp)->float { return (float)smp.soc; });
+    emitTrace("<polyline fill=\"none\" stroke=\"#0a0\" stroke-width=\"1\" stroke-dasharray=\"5 3\"", pmax,
+              [](const ChargeSessionState::Sample& smp)->float { return smp.car_perm; });
+    emitTrace("<polyline fill=\"none\" stroke=\"#e80\" stroke-width=\"1.5\"", pmax,
+              [](const ChargeSessionState::Sample& smp)->float { return smp.station_kw; });
+    emitTrace("<polyline fill=\"none\" stroke=\"#a0a\" stroke-width=\"1.5\"", pmax,
+              [](const ChargeSessionState::Sample& smp)->float { return smp.hvac_kw; });
+    emitTrace("<polyline fill=\"none\" stroke=\"#06c\" stroke-width=\"2\"", pmax,
+              [](const ChargeSessionState::Sample& smp)->float { return smp.kw; });
 
     // Legend (bottom).
     int ly = H - 6;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -248,6 +248,22 @@ void OvmsVehicleToyotaETNGA::UpdateChargeSessionStats()
 
     int now = StandardMetrics.ms_m_monotonic->AsInt();
 
+    // #138: if the CAN poll path has gone quiet (e.g. car locked → OBD gateway isolated from the
+    // OBC), the charge metrics are frozen. Suspend per-sample logging + accumulation so we don't
+    // record/integrate stale values; resume automatically when polls return.
+    const int CHARGE_STALE_SECS = 3;   // charge poll path runs at 1s; 3 missed = clearly stale but quick
+    if (m_last_poll_monotonic == 0 || now - m_last_poll_monotonic > CHARGE_STALE_SECS) {
+        // Display honesty: zero the live power/current so the app/server/CSV don't show a frozen value.
+        // (Does not touch the energy integrals; v.c.kwh recomputes from pack V×I on the next reply.)
+        StandardMetrics.ms_v_charge_power->SetValue(0);
+        StandardMetrics.ms_v_bat_power->SetValue(0);
+        StandardMetrics.ms_v_bat_current->SetValue(0);
+        // Keep the dt baselines current so resume doesn't bridge the gap into delivered_ah / station_kwh / SVG.
+        m_charge_session.last_sample_monotonic = now;
+        m_charge_session.last_svg_monotonic = now;
+        return;   // skip peak/temp/ambient, station_kwh/delivered_ah, CSV row, SVG sample
+    }
+
     float p = StandardMetrics.ms_v_charge_power->AsFloat();
     if (p > m_charge_session.peak_power)
         m_charge_session.peak_power = p;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -13,6 +13,8 @@
 
 void OvmsVehicleToyotaETNGA::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length)
 {
+    m_last_poll_monotonic = StandardMetrics.ms_m_monotonic->AsInt();   // #138: bus-alive timestamp for charge-stale detection
+
     // Check if this is the first frame of the multi-frame response
     if (job.mlframe == 0) {
         m_rxbuf.clear();

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -82,6 +82,7 @@ protected:
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
     int  m_cable_watch_start = 0;      // monotonic s when armed (15-min cable watch)
     int  m_charge_state_entry = 0;     // monotonic s of last charge-state entry (handshake 60s timer)
+    int m_last_poll_monotonic = 0;   // #138: monotonic s of the last poll reply (any ECU); charge-stale detection
     bool m_charge_wait_slept = false;  // true after Tier-2 CHARGE_WAIT sleep; selects the short re-sleep threshold
     int  m_pisw_zero_count = 0;        // consecutive fresh AWAKE PISW==0x00 reads; debounces the OBC post-wake transient
     uint32_t m_pisw_last_modified = 0;  // LastModified() of the last PISW reading counted, so the debounce counts distinct polls not 1s ticks

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -82,7 +82,7 @@ protected:
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
     int  m_cable_watch_start = 0;      // monotonic s when armed (15-min cable watch)
     int  m_charge_state_entry = 0;     // monotonic s of last charge-state entry (handshake 60s timer)
-    int m_last_poll_monotonic = 0;   // #138: monotonic s of the last poll reply (any ECU); charge-stale detection
+    std::atomic<int> m_last_poll_monotonic{0};   // #138: monotonic s of the last poll reply (any ECU); charge-stale detection (cross-task: poller writes, ticker reads — atomic like m_charge_fault_pending)
     bool m_charge_wait_slept = false;  // true after Tier-2 CHARGE_WAIT sleep; selects the short re-sleep threshold
     int  m_pisw_zero_count = 0;        // consecutive fresh AWAKE PISW==0x00 reads; debounces the OBC post-wake transient
     uint32_t m_pisw_last_modified = 0;  // LastModified() of the last PISW reading counted, so the debounce counts distinct polls not 1s ticks


### PR DESCRIPTION
## What

Fixes **#138**. When the car is locked mid-AC-charge, the OBD gateway isolates the diagnostic path from the OBC and the charge metrics freeze — but `UpdateChargeSessionStats` kept logging a CSV row and integrating energy every tick with the frozen values, producing stale rows (`battery_kw>0` at `pack_a=0`), phantom `station_kwh` (~0.2 kWh over a ~110 s lock), and a nonsensical efficiency (observed 52% / 158%).

## Fix

- **Detect quickly:** new `std::atomic<int> m_last_poll_monotonic`, stamped on every `IncomingPollReply` (any ECU = bus alive). In `UpdateChargeSessionStats`, `can_stale = now − m_last_poll_monotonic > 3 s` (the charge poll path runs at 1 s).
- **Suspend:** when stale, early-return — skipping the CSV row, the `station_kwh`/`delivered_ah` accumulation, the SVG sample, and peak/temp. The dt baselines (`last_sample_monotonic`/`last_svg_monotonic`) are bumped each stale tick so resume doesn't bridge the gap into the integrals.
- **Display honesty:** zero `v.c.power`/`v.b.power`/`v.b.current` during the gap (reads 0 = "not measuring" instead of a frozen value). Display-only — does not touch the energy integrals.
- **Resume:** automatic — the next reply advances the stamp, the branch stops firing.

**Not changed (verified):** the headline `v.c.kwh` is integrated *per reply* (not per tick) and already has a 60 s gap-clamp (`EnergyIntervalHours`), so it is not over-counted — out of scope by design.

## Validation

- **CI: green.**
- **On-vehicle (the repro): pending** — lock the car mid-AC-charge for >a few seconds; expect: CSV stops adding rows during the lock, `station_kwh`/efficiency sensible (no phantom), `v.c.power` reads 0 then recovers on unlock, session not torn down, no resume spike.

## Review

3 tasks, controller-verified + final whole-branch review (concurrency-focused) = Ready to merge, no Critical/Important (the one Minor — make the cross-task member atomic — applied here). Design+plan in `docs/superpowers`.

Closes #138.