### PR TITLE
etnga: human-readable PID names in the charge-fault dump

### DIFF
--- a/docs/superpowers/plans/2026-06-24-etnga-dump-pid-names.md
+++ b/docs/superpowers/plans/2026-06-24-etnga-dump-pid-names.md
@@ -1,0 +1,110 @@
+# e-TNGA: human-readable PID names in the charge-fault dump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a human-readable name for each DID in the charge-fault diagnostic dump table (`DID | description | raw (hex) | decoded`).
+
+**Architecture:** A static `DumpDidName(uint16_t)` maps each of the 30 dump DIDs to its solterra-can RE label; the dump render in `GenerateChargeReport` gains a "description" column between the DID and raw cells. Static-string names only — no decode change.
+
+**Tech Stack:** C++ (ESP-IDF 3.3 / older GCC), the e-TNGA vehicle component. No new polls.
+
+## Global Constraints
+
+- **C++ for ESP-IDF 3.3 / older GCC.** Match surrounding style. No host tests; CI compiles (`gh workflow run build.yml --ref feature/etnga-dump-pid-names`). Do NOT propose a local `make`.
+- **Names are verbatim** from the spec's name table — do NOT paraphrase or invent. `default: return "";`.
+- **Single-purpose branch off master** (`feature/etnga-dump-pid-names`) — unrelated to PR #140. Work in `/home/devuser/wt-etnga-dump-names`. Paths relative to `vehicle/OVMS.V3/components/vehicle_toyota_etnga/`.
+
+## Interfaces already in place
+- The dump render in `etnga_charge_report.cpp` (under `OvmsMutexLock lock(&m_dump_mutex)`): header `f << "<table><tr><th>DID</th><th>raw (hex)</th><th>decoded</th></tr>\n";` then per-row `f << "<tr><td>" << did << "</td><td>";` … raw bytes … `f << "</td><td>" << DumpDidDecode(it->first, it->second) << "</td></tr>\n";`.
+- `DumpDidDecode` (member) + `LimSideLabel` (static) are nearby label helpers; `static const char* TAG`.
+
+---
+
+## Task 1: `DumpDidName` helper
+
+**Files:** `src/vehicle_toyota_etnga.h` (decl), `src/etnga_charge_dump.cpp` (impl).
+
+- [ ] **Step 1: Declare** in `src/vehicle_toyota_etnga.h`, near the `DumpDidDecode` declaration:
+```cpp
+    static const char* DumpDidName(uint16_t did);   // solterra-can RE label for a dump DID; "" if unknown
+```
+- [ ] **Step 2: Implement** in `src/etnga_charge_dump.cpp` (near `DumpDidDecode`):
+```cpp
+// Human-readable name for a dump DID (solterra-can RE labels). "" for an unexpected DID.
+const char* OvmsVehicleToyotaETNGA::DumpDidName(uint16_t did)
+{
+    switch (did) {
+        case 0x1666: return "HLC Comm Sequence Status";
+        case 0x1684: return "AC Charging Operation Status";
+        case 0x1688: return "Charging History Information";
+        case 0x1664: return "Charging Control Signal Status";
+        case 0x1667: return "CCM Charge Stop Request";
+        case 0x1668: return "DC Charging Control Status";
+        case 0x1736: return "DC Operation Mode";
+        case 0x16AA: return "DC Fault / Trip-Flag Register";
+        case 0x16A9: return "DC Power-Limit History Flags";
+        case 0x161B: return "Charge-Limit Status Flags";
+        case 0x1806: return "AC Charging Relay Flags";
+        case 0x1702: return "HV Charging Relay Flags";
+        case 0x1669: return "PISW Status";
+        case 0x1602: return "Connector Connect Status";
+        case 0x1601: return "Connector Status Voltage";
+        case 0x1625: return "Charging Lid Switch Status";
+        case 0x1670: return "Hood Switch Signal";
+        case 0x164A: return "HV Circuit Shutdown Signal";
+        case 0x10D4: return "Battery Charging Power";
+        case 0x1654: return "AC Input Current";
+        case 0x166C: return "Station Present Output Current";
+        case 0x1621: return "HV Battery Total Voltage";
+        case 0x166B: return "Station Present Output Voltage";
+        case 0x165E: return "PFC Boost Output Voltage";
+        case 0x1632: return "AC Inlet Temperature Cluster";
+        case 0x1705: return "DC Inlet Temperature Cluster";
+        case 0x1829: return "Battery Maximum Temperature";
+        case 0x182A: return "Battery Minimum Temperature";
+        case 0x1657: return "PFC Temperature";
+        case 0x1658: return "DC/DC Converter Temperature";
+        default:     return "";
+    }
+}
+```
+- [ ] **Step 3: Inspection check** — Run: `grep -c 'case 0x' src/etnga_charge_dump.cpp` includes 30 new cases for `DumpDidName`; `grep -n 'DumpDidName' src/vehicle_toyota_etnga.h src/etnga_charge_dump.cpp` shows the decl + def. Spot-check 3 names against the spec table (`0x1657`→"PFC Temperature", `0x1829`→"Battery Maximum Temperature", `0x16AA`→"DC Fault / Trip-Flag Register").
+- [ ] **Step 4: Commit** — `git add src/vehicle_toyota_etnga.h src/etnga_charge_dump.cpp && git commit -m "etnga: add DumpDidName — human-readable names for fault-dump DIDs"`.
+
+---
+
+## Task 2: Render the description column
+
+**Files:** `src/etnga_charge_report.cpp` (dump render block).
+
+- [ ] **Step 1: Header** — change the dump table header to add a description column after DID:
+```cpp
+            f << "<table><tr><th>DID</th><th>description</th><th>raw (hex)</th><th>decoded</th></tr>\n";
+```
+- [ ] **Step 2: Per-row cell** — change the per-row open from `f << "<tr><td>" << did << "</td><td>";` to insert the description cell before the raw cell:
+```cpp
+                f << "<tr><td>" << did << "</td><td>" << DumpDidName(it->first) << "</td><td>";
+```
+(The raw-bytes loop + `</td><td>decoded</td></tr>` close are unchanged, so the row is now `DID | description | raw | decoded` — 4 cells matching the 4 headers.)
+- [ ] **Step 3: Inspection check** — Run: `grep -n 'th>description\|DumpDidName(it->first)' src/etnga_charge_report.cpp`. Confirm the header has 4 `<th>` (DID, description, raw, decoded) and the row emits 4 `<td>` (DID, DumpDidName, raw, decoded); both inside the existing `m_dump_mutex` lock.
+- [ ] **Step 4: Commit** — `git add src/etnga_charge_report.cpp && git commit -m "etnga: show DID name column in the fault-dump report table"`.
+
+---
+
+## Task 3: changes.txt + CI
+
+- [ ] **Step 1: changes.txt** — under the existing `????-??-?? ???  ???????  OTA release` pending block (no invented header), add:
+```
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge-fault diagnostic DID dump now labels
+    each DID with a human-readable name (e.g. "PFC Temperature", "HLC Comm Sequence Status")
+    alongside the raw bytes and decoded value.
+```
+- [ ] **Step 2: Commit** — `git add vehicle/OVMS.V3/changes.txt && git commit -m "etnga: changes.txt for fault-dump DID names"`.
+- [ ] **Step 3: CI build** — `gh workflow run build.yml --ref feature/etnga-dump-pid-names`, watch, fix any compile error.
+- [ ] **Step 4: On-vehicle (opportunistic)** — on the next charge fault, the dump table shows the description column populated (`0x1657 | PFC Temperature | 51 | 31 °C`). Cosmetic; decoded values + raw bytes unchanged.
+
+## Self-Review
+- Name helper (30 DIDs, verbatim, default "") → Task 1. ✓
+- Description column (header + per-row, between DID and raw) → Task 2. ✓
+- changes.txt → Task 3. ✓
+- Placeholder scan: no TBD; all 30 names inline. Type consistency: `DumpDidName(uint16_t)` decl (Task 1) matches the call `DumpDidName(it->first)` (Task 2; `it->first` is `uint16_t`). ✓

--- a/docs/superpowers/specs/2026-06-24-etnga-dump-pid-names-design.md
+++ b/docs/superpowers/specs/2026-06-24-etnga-dump-pid-names-design.md
@@ -1,0 +1,79 @@
+# e-TNGA: human-readable PID names in the charge-fault dump — design
+
+**Date:** 2026-06-24
+**Issue:** follow-up to #137 (charge-fault diagnostic DID dump)
+**Status:** design — pending user review
+
+## Problem
+
+The charge-fault diagnostic dump (merged via #137) renders a 3-column table — `DID | raw (hex) | decoded` — in the charge report. The `decoded` column shows a value for the confident subset (temps, kW, state labels), but every row's identity is just the bare hex DID (`0x1657`), so a reader has to look up what each DID *is*. Add a human-readable **name** per DID.
+
+## Design
+
+Add a new **"description" column** to the dump table, so it reads `DID | description | raw (hex) | decoded`:
+
+```
+DID     description                  raw     decoded
+0x1657  PFC Temperature              51      31 °C
+0x1666  HLC Comm Sequence Status     FF      HLC: Unconnected
+0x1688  Charging History Information 26      AC Charging Stop (Operation)
+```
+
+A new static helper `DumpDidName(uint16_t did)` returns the name (a `const char*`), or `""` for an unexpected DID. The names are the solterra-can RE labels (sourced from `plug-in-charge-control.md` / `charging_state_machine_architecture.md` §6.4) — all 30 dump DIDs have a documented name, so the column is populated for every row.
+
+### Name table (verbatim values)
+
+| DID | name |
+|---|---|
+| `0x1666` | HLC Comm Sequence Status |
+| `0x1684` | AC Charging Operation Status |
+| `0x1688` | Charging History Information |
+| `0x1664` | Charging Control Signal Status |
+| `0x1667` | CCM Charge Stop Request |
+| `0x1668` | DC Charging Control Status |
+| `0x1736` | DC Operation Mode |
+| `0x16AA` | DC Fault / Trip-Flag Register |
+| `0x16A9` | DC Power-Limit History Flags |
+| `0x161B` | Charge-Limit Status Flags |
+| `0x1806` | AC Charging Relay Flags |
+| `0x1702` | HV Charging Relay Flags |
+| `0x1669` | PISW Status |
+| `0x1602` | Connector Connect Status |
+| `0x1601` | Connector Status Voltage |
+| `0x1625` | Charging Lid Switch Status |
+| `0x1670` | Hood Switch Signal |
+| `0x164A` | HV Circuit Shutdown Signal |
+| `0x10D4` | Battery Charging Power |
+| `0x1654` | AC Input Current |
+| `0x166C` | Station Present Output Current |
+| `0x1621` | HV Battery Total Voltage |
+| `0x166B` | Station Present Output Voltage |
+| `0x165E` | PFC Boost Output Voltage |
+| `0x1632` | AC Inlet Temperature Cluster |
+| `0x1705` | DC Inlet Temperature Cluster |
+| `0x1829` | Battery Maximum Temperature |
+| `0x182A` | Battery Minimum Temperature |
+| `0x1657` | PFC Temperature |
+| `0x1658` | DC/DC Converter Temperature |
+
+(High confidence for 23; the 7 bit-field/relay registers — `0x16AA`, `0x16A9`, `0x161B`, `0x1806`, `0x1702`, plus the documented category labels — are named at register/category level, which is what the RE supports.)
+
+## Files
+
+| File | Change |
+|---|---|
+| `src/vehicle_toyota_etnga.h` | declare `static const char* DumpDidName(uint16_t did);` |
+| `src/etnga_charge_dump.cpp` | implement `DumpDidName` (switch over the 30 DIDs → names above; default `""`) |
+| `src/etnga_charge_report.cpp` | dump render: add `<th>description</th>` to the header and a `<td>DumpDidName(it->first)</td>` cell per row, between the DID and raw columns (inside the existing `m_dump_mutex` lock) |
+| `vehicle/OVMS.V3/changes.txt` | entry: the charge-fault dump now labels each DID with a human-readable name |
+
+## Scope / non-goals
+
+- **In:** the name helper + the description column. Names are static strings (no decode of the bit-field registers — that's a separate, RE-gated effort; the *value* decode stays as-is in `DumpDidDecode`).
+- **Out:** any change to which DIDs are dumped, the decode logic, or the trigger/delivery (all merged in #137). This is a **separate single-purpose branch off master** — unrelated to PR #140 (the CAN-stale fix).
+- No new polls.
+
+## Validation
+
+- **Compile:** CI.
+- **On-vehicle:** on the next charge fault, the dump table shows the description column populated (e.g. `0x1657 | PFC Temperature | 51 | 31 °C`). Cosmetic; the decoded values and raw bytes are unchanged.

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,9 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge-fault diagnostic DID dump now labels
+    each DID with a human-readable name (e.g. "PFC Temperature", "HLC Comm Sequence Status")
+    alongside the raw bytes and decoded value.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): charge-session report is now multi-phase —
     a single plug-in-to-unplug session that charges, pauses (scheduled wait), then tops off is
     reported as separate phases, each with its own SOC delta, energy, peak/avg power,

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_dump.cpp
@@ -86,6 +86,44 @@ std::string OvmsVehicleToyotaETNGA::DumpDidDecode(uint16_t did, const std::strin
     }
 }
 
+// Human-readable name for a dump DID (solterra-can RE labels). "" for an unexpected DID.
+const char* OvmsVehicleToyotaETNGA::DumpDidName(uint16_t did)
+{
+    switch (did) {
+        case 0x1666: return "HLC Comm Sequence Status";
+        case 0x1684: return "AC Charging Operation Status";
+        case 0x1688: return "Charging History Information";
+        case 0x1664: return "Charging Control Signal Status";
+        case 0x1667: return "CCM Charge Stop Request";
+        case 0x1668: return "DC Charging Control Status";
+        case 0x1736: return "DC Operation Mode";
+        case 0x16AA: return "DC Fault / Trip-Flag Register";
+        case 0x16A9: return "DC Power-Limit History Flags";
+        case 0x161B: return "Charge-Limit Status Flags";
+        case 0x1806: return "AC Charging Relay Flags";
+        case 0x1702: return "HV Charging Relay Flags";
+        case 0x1669: return "PISW Status";
+        case 0x1602: return "Connector Connect Status";
+        case 0x1601: return "Connector Status Voltage";
+        case 0x1625: return "Charging Lid Switch Status";
+        case 0x1670: return "Hood Switch Signal";
+        case 0x164A: return "HV Circuit Shutdown Signal";
+        case 0x10D4: return "Battery Charging Power";
+        case 0x1654: return "AC Input Current";
+        case 0x166C: return "Station Present Output Current";
+        case 0x1621: return "HV Battery Total Voltage";
+        case 0x166B: return "Station Present Output Voltage";
+        case 0x165E: return "PFC Boost Output Voltage";
+        case 0x1632: return "AC Inlet Temperature Cluster";
+        case 0x1705: return "DC Inlet Temperature Cluster";
+        case 0x1829: return "Battery Maximum Temperature";
+        case 0x182A: return "Battery Minimum Temperature";
+        case 0x1657: return "PFC Temperature";
+        case 0x1658: return "DC/DC Converter Temperature";
+        default:     return "";
+    }
+}
+
 // Events task (called from TransitionToChargeWaitState after CloseChargePhase). If a fault was
 // flagged and no dump is already running, fire a OnceOffPoll for every diagnostic DID. Each
 // auto-removes after one reply; "!v." prefix => reclaimed on teardown (poller naming contract).

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -740,12 +740,12 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
             snprintf(db, sizeof(db), "Phase %d fault (outcome 0x%02X \"%s\") — OBC 0x745, raw UDS 0x22 responses.",
                      m_dump_phase_idx + 1, m_dump_outcome & 0xFF, ChargeOutcomeLabel(m_dump_outcome));
             f << "<p>" << db << "</p>\n";
-            f << "<table><tr><th>DID</th><th>raw (hex)</th><th>decoded</th></tr>\n";
+            f << "<table><tr><th>DID</th><th>description</th><th>raw (hex)</th><th>decoded</th></tr>\n";
             for (std::map<uint16_t,std::string>::const_iterator it = m_dump_results.begin();
                  it != m_dump_results.end(); ++it) {
                 char did[8];
                 snprintf(did, sizeof(did), "0x%04X", it->first);
-                f << "<tr><td>" << did << "</td><td>";
+                f << "<tr><td>" << did << "</td><td>" << DumpDidName(it->first) << "</td><td>";
                 if (it->second.empty()) {
                     f << "(no reply)";
                 } else {

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -273,6 +273,7 @@ private:
     static const char* HlcStateLabel(int code);         // 0x1666 DC HLC state enum -> human text ("" if unknown)
     static const char* AcOpStatusLabel(int code);       // 0x1684 AC-Op state enum -> human text ("" for Stop/unknown)
     std::string DumpDidDecode(uint16_t did, const std::string& raw);  // INC-3: human-readable decode for the confident DID subset; "" = raw only
+    static const char* DumpDidName(uint16_t did);   // solterra-can RE label for a dump DID; "" if unknown
     std::string LookupLocationName(float lat, float lon); // matching OVMS named-location (geofence), or ""
 
     // Incoming message handling functions


### PR DESCRIPTION
## What

Follow-up to #137. The charge-fault diagnostic DID dump rendered a `DID | raw (hex) | decoded` table where each row's identity was just the bare hex DID. This adds a **"description" column** with a human-readable name per DID:

```
DID     description                  raw   decoded
0x1657  PFC Temperature              51    31 °C
0x1666  HLC Comm Sequence Status     FF    HLC: Unconnected
0x1688  Charging History Information 26    AC Charging Stop (Operation)
```

## How

- New static `DumpDidName(uint16_t did)` maps each of the 30 dump DIDs to its **solterra-can RE label** (sourced from `plug-in-charge-control.md` / the charging-state-machine design doc §6.4 — 23 high-confidence, the 7 bit-field/relay registers named at category level). `""` for an unexpected DID.
- The dump render gains a `description` column between DID and raw (inside the existing `m_dump_mutex` lock).

Static strings only — no change to which DIDs are dumped, the decode logic, or the trigger/delivery.

## Validation
- **CI: green.**
- **On-vehicle:** cosmetic — on the next charge fault the dump table shows the name column populated; decoded values + raw bytes unchanged.

Single-purpose, off master (independent of PR #140). Design+plan in `docs/superpowers`.