### PR TITLE
etnga: latch v.d.cp on charge handshake so `stat` does not report "Not charging"

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -95,7 +95,13 @@ void OvmsVehicleToyotaETNGA::ResetStaleMetrics() // Reset stale variables
     // reads stale even though the cable is physically holding the door open — don't
     // force it off there, or the UI/server shows the port closed mid-charge. The arm
     // logic in HandleAwakeState has already latched by then, so holding "open" is safe.
+    // in_session extends that to the AWAKE pass-through of a CHARGE_WAIT sleep/resume:
+    // the cable is still seated, but we're briefly below CHARGE_HANDSHAKE and resume goes
+    // to CHARGE_WAIT (never back through handshake), so a clear here would stick for the
+    // rest of the session. On unplug the session closes and the AWAKE lid poll re-reads
+    // the real value within 10s, so this cannot strand the port "open".
     if (StandardMetrics.ms_v_door_chargeport->IsStale() && StandardMetrics.ms_v_door_chargeport->AsBool() &&
+            !m_charge_session.in_session &&
             static_cast<PollState>(m_poll_state) < PollState::CHARGE_HANDSHAKE) {
         ESP_LOGD(TAG, "Charging Door is stale. Manually setting to off");
         SetChargingDoorStatus(false);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -460,6 +460,16 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
     SetPollState(PollState::CHARGE_HANDSHAKE);
     SetChargingStatus(false);    // not yet delivering energy (AC/DC states set true)
     SetChargeState(PollState::CHARGE_HANDSHAKE);
+
+    // We only get here on a seated PISW (>= 0x02), which means the cable is in and the lid
+    // is physically open.  Latch it: the lid (0x1625) polls @10s in AWAKE and never in the
+    // charge states, so a plug-in that wakes us from SLEEP arrives here on the @5s PISW read
+    // before the lid is ever sampled — without this, v.d.cp stays false for the whole session
+    // and the base CommandStat (gated on ms_v_door_chargeport) prints "Not charging".
+    // ResetStaleMetrics only forces the lid closed below CHARGE_HANDSHAKE, so this holds until
+    // the session ends and AWAKE resumes polling 0x1625.
+    SetChargingDoorStatus(true);
+
     if (!m_charge_session.in_session) {
         ResetSleepBackoff();   // brand-new charge session — resume responsive cooldowns
         m_charge_wait_slept = false;   // brand-new session — fresh responsive wait window


### PR DESCRIPTION
Fixes #143.

### Problem

Mid-charge, `stat` prints **`Not charging`** while every charge metric is correct (`v.c.charging=yes`, `v.c.state=charging`, `v.c.power=6.7kW`, `xte.v.c.gridpower=7.095kW`). Charging itself, the metrics, and the session report are all unaffected — only `stat` (and anything else gated on the charge-port door) is wrong.

`OvmsVehicle::CommandStat` (`components/vehicle/vehicle.cpp:1594`) gates its entire charge block on the door metric, and e-TNGA does not override it:

```cpp
bool chargeport_open = StdMetrics.ms_v_door_chargeport->AsBool();
if (chargeport_open && charge_state != "") { ... } else { writer->puts("Not charging"); }
```

`v.d.cp` was observed `no` during an active AC charge on a module with 22 h uptime and 0 crashes — so this is **not** the mid-charge-reboot case the existing comments anticipate.

### Root cause

Both PIDs live on the **Plug-In Control System ECU**, but poll at different rates:

| PID | AWAKE | charge states |
|---|---|---|
| `0x1669` (PISW) | **5 s** | HS=1, WAIT=30, AC=10, DC=10 |
| `0x1625` (charge lid) | **10 s** | **0 — never polled** |

`HandleAwakeState` transitions to `CHARGE_HANDSHAKE` on `pisw >= 0x02` **alone** (the lid only bounds how long we linger in AWAKE). So a plug-in that **wakes the module from SLEEP** reaches handshake on the 5 s PISW read, before the 10 s lid poll ever runs. The lid is never polled again in the charge states, and `ResetStaleMetrics` only ever *clears* the metric — never sets it. `v.d.cp` stays false for the whole session.

That is why it looks intermittent: if the car was already AWAKE for >10 s when the cable went in, the lid latches and `stat` behaves.

### Fix

A seated PISW (`>= 0x02`) means the cable is in, so the lid is physically open.

1. **`TransitionToChargeHandshakeState`** — latch `SetChargingDoorStatus(true)`. This is the one place cable-seated is already established, and it is reached on both the plug-in-from-SLEEP path and the mid-charge-reboot path.

2. **`ResetStaleMetrics`** — also skip the stale-clear while `m_charge_session.in_session`. Without this, a **CHARGE_WAIT sleep/resume** passes back through AWAKE with the session still open; since resume re-enters `CHARGE_WAIT` rather than handshake, the stale-clear would drop the port to closed for the remainder of the session and reproduce the same bug on the charge's second phase.

Safety: on unplug the session closes (`FinalizeChargeSession` resets the struct) and the AWAKE lid poll re-reads the real `0x1625` value within 10 s, so the port cannot be stranded "open".

This mirrors the existing keep-fresh block in `HandleChargeAcState`/`HandleChargeDcState`, which already force-refreshes `ms_v_charge_inprogress` and `ms_v_charge_state` for exactly this class of bug — `ms_v_door_chargeport` simply wasn't covered.

### Scope

16 added lines across 2 files. No new metrics, no config keys, no behavior change beyond the door metric. No `changes.txt` entry: per repo convention that file is for changes users must notice or act on, and this is a display fix requiring nothing on the user's side.

### Validation status

- ✅ **Compiles** — CI `Firmware build` green on `047f53ce` (run `29009226822`).
- ❌ **Not yet validated on-vehicle.** The failing path is an AC charge started **from a sleeping module**. Needs:
  - plug in while asleep → `stat` shows `Standard - Charging` with voltage/current, not `Not charging`;
  - a pause/resume cycle (CHARGE_WAIT → sleep → AWAKE → CHARGE_WAIT) → port stays open across the second phase (this is the case the naive one-line fix got wrong);
  - unplug → port returns to closed, no leak into AWAKE/DRIVING.
