### PR TITLE
chore: merge upstream openvehicles/master (34 commits behind → up to date)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ THE USE OR OTHER DEALINGS IN THE SYSTEM.
 ## Links
 
 - _User Resources_
+  - [History of Changes](https://raw.githubusercontent.com/openvehicles/Open-Vehicle-Monitoring-System-3/refs/heads/master/vehicle/OVMS.V3/changes.txt) affecting user level features & interfaces
   - _User and Developer Guides: (hint: version selection in left menu at the bottom)_
     - [Stable release (OTA version "main")](https://docs.openvehicles.com/en/stable/)
     - [Latest nightly build (OTA version "edge")](https://docs.openvehicles.com/en/latest/)

--- a/changes.txt
+++ b/changes.txt
@@ -1,1 +1,0 @@
-vehicle/OVMS.V3/changes.txt

--- a/changes.txt
+++ b/changes.txt
@@ -1,0 +1,1 @@
+vehicle/OVMS.V3/changes.txt

--- a/docs/source/userguide/scripting.rst
+++ b/docs/source/userguide/scripting.rst
@@ -1276,6 +1276,7 @@ The ``Poll`` object is for the polling subsystem and has the following methods:
               "request": <string>|<Uint8Array>,   // hex encoded string or binary byte array
             },
            "states": [ t0, t1, t2, t3 ], // Repeating poll states (offset by 'poll_offset' param) only 4 allowed.
+           "shift": [ t0, t1, t2, t3 ], // Poll time shift per state in seconds.
            "decode": { // [Not used if dbc_decode is true]
              <metric.name>|<value_name> :
                {

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -14,6 +14,8 @@ Open Vehicle Monitor System v3 - Change log
       [xsq] bms.contactor.1h.limit (int)     -- limit for contactor cycles changes per hour for alerting; default 8
 
 2026-05-17 MB   3.3.006  OTA release
+- OTA/firmware: include tools to mitigate 4MB firmware size limit by upgrading the partitioning scheme;
+    for details see: https://docs.openvehicles.com/en/latest/userguide/partitioning.html
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,
     charge time counters AC/DC and parked battery state times (by SOC & temperature ranges)
     (inspired by OBD Amigos)

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -2990,12 +2990,21 @@ duk_ret_t OvmsPollers::DukOvmsPollerPollAdd(duk_context *ctx)
         canbus* device;
         std::string request;
         int timeout;
+        uint32_t txid, rxid;
+        uint8_t protocol;
+        uint16_t type, pid;
 
         MyPollers.Duk_GetRequestFromObject(ctx, -1, busname, false,
           device,
-          poll.txmoduleid, poll.rxmoduleid, poll.protocol,
-          poll.type, poll.pid,
+          txid, rxid, protocol,
+          type, pid,
           request, timeout, error, errordesc);
+
+        poll.txmoduleid = txid;
+        poll.rxmoduleid = rxid;
+        poll.protocol = protocol;
+        poll.type = type;
+        poll.pid = pid;
 
         size_t rqsize = request.size();
         if ( rqsize == 0)

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -2883,7 +2883,8 @@ void DukTapePoller::UnregisterPoller(canbus* bus,const std::string & name)
  *         type: <int>,     // [Opt] type (defaults to READDATA type 0x22)
  *         request: <string>|<Uint8Array>,   // hex encoded string or binary byte array
  *       },
- *      states: [ t1, t2, t3, t4], // Repeating poll states.
+ *      states: [ t1, t2, t3, t4 ], // Repeating poll states (poll intervals in seconds).
+ *      shift: [ t1, t2, t3, t4 ], // Poll time shifts in seconds.
  *      decode: [ // Not used if dbc is specified.
  *        <metric.name>|<value_name> :
  *          {
@@ -3052,6 +3053,24 @@ duk_ret_t OvmsPollers::DukOvmsPollerPollAdd(duk_context *ctx)
               }
             duk_pop(ctx);
             // -- {poll_item} {states_list}
+            }
+          }
+        // shift: [ t1, t2, t3, t4 ], // Poll time shift per state in seconds.
+        if (duk_get_prop_string(ctx, -1, "shift") )
+          // -- {poll_item} {shift_list}
+          {
+          int state_count = duk_get_length(ctx, -1);
+          if (state_count > VEHICLE_POLL_NSTATES)
+            state_count = VEHICLE_POLL_NSTATES;
+          for (duk_idx_t stateidx = 0; stateidx < state_count ; ++stateidx)
+            {
+            if (duk_get_prop_index(ctx, -1, stateidx))
+              // -- {poll_item} {shift_list} {shift_item}
+              {
+              poll.ts.shift[stateidx] = duk_to_int(ctx, -1);
+              }
+            duk_pop(ctx);
+            // -- {poll_item} {shift_list}
             }
           }
         polls.push_back(poll);
@@ -4251,7 +4270,11 @@ OvmsPoller::OvmsNextPollResult OvmsPoller::StandardPollSeries::NextPollEntry(pol
     if (mybus == bus)
       {
       uint16_t polltime = m_poll_plcur->polltime[pollstate];
-      if (( polltime > 0) && ((pollticker % polltime) == 0))
+      uint8_t pollshift = m_poll_plcur->ts.shift[pollstate];
+      // Note: poll shifts reset at max_ticker (3600 seconds) cycle reset
+      if ( ((polltime > 0) && (pollticker >= pollshift) && (((pollticker - pollshift) % polltime) == 0))
+        // Treat shifts with interval 0 as quasi single shot (poll once per max_ticker cycle):
+        || ((polltime == 0) && (pollshift > 0) && (pollticker == pollshift)) )
         {
         entry = *m_poll_plcur;
         IFTRACE(Poller) ESP_LOGD(TAG, "Found Poll Entry for Standard Poll");

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -138,7 +138,7 @@ class OvmsPollLimiter {
 
 class OvmsPoller : public InternalRamAllocated {
   public:
-    typedef struct
+    typedef struct __attribute__ ((__packed__))
       {
       uint32_t txmoduleid;                      // transmission CAN ID (address), 0x7df = OBD2 broadcast
       uint32_t rxmoduleid;                      // expected response CAN ID or 0 for broadcasts

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -160,7 +160,18 @@ class OvmsPoller : public InternalRamAllocated {
           const uint8_t* data;                  // pointer to payload data (single/multi frame request)
           } xargs;
         };
-      uint16_t polltime[VEHICLE_POLL_NSTATES];  // poll intervals in seconds for used poll states
+      union
+        {
+        uint16_t polltime[VEHICLE_POLL_NSTATES];  // poll intervals in seconds for used poll states
+        struct
+          {
+          uint16_t cycle[VEHICLE_POLL_NSTATES];   // poll intervals in seconds for used poll states
+          uint8_t  shift[VEHICLE_POLL_NSTATES];   // shift poll times by seconds for used poll states
+                                                  // Notes:
+                                                  // - shifts start over at max_ticker cycle reset (3600 seconds)
+                                                  // - shifts with cycle=0 translate to once per max_ticker cycle
+          } ts;
+        };
       uint8_t  pollbus;                         // 0 = default CAN bus from PollSetPidList(), 1…4 = specific
       uint8_t  protocol;                        // ISOTP_STD / ISOTP_EXTADR / ISOTP_EXTFRAME / VWTP_20
       } poll_pid_t;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -81,6 +81,14 @@ struct DashboardConfig;
 // 
 // See OvmsVehicle::PollSingleRequest() on how to send dynamic requests with additional arguments.
 // 
+// Since version 3.3.006 the poll cycle timing can be shifted by up to 255 seconds per state.
+// To define shifted poll intervals, use the new 'ts' union member in place of the interval
+// array. Example/template:
+//  { TXID, RXID, TYPE, PID, {.ts={ {…TIMES…}, {…SHIFTS…} }}, 0, ISOTP_STD }
+// Notes:
+// - shifts start over at the max_ticker cycle overrun reset (3600 seconds)
+// - shifts with cycle=0 translate to once per max_ticker cycle (at the shift offset)
+// 
 // VWTP_20: this protocol implements the VW (VAG) specific "TP 2.0", which establishes
 // OSI layer 5 communication channels to devices (ECU modules) via a CAN gateway.
 // On VWTP_20 poll entries, simply set the TXID to the gateway base ID (normally 0x200)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -118,8 +118,10 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       if (raw_temp != 0x7F) 
         {
         can_bat_temp = _temp;
-        }      
-      can_bat_voltage = (float)((CAN_UINT(3) >> 5) & 0x3FF) / 2.0f;
+        }
+      float _volt = (float)((CAN_UINT(3) >> 5) & 0x3FF) / 2.0f;
+      can_bat_voltage = _volt < 450.0f ? _volt : 0.0f; // ignore invalid voltage reading > 450V
+      can_bat_voltage = 
       can_charge_climit = (c >> 20) & 0x3Fu;        
       break;
       }
@@ -130,8 +132,9 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
     case 0x5D7: // Speed, ODO
       {
       REQ_DLC(6);
-      // Apply scaling 
-      can_speed = (float)CAN_UINT(0) / 100.0f;
+      // Apply scaling
+      float _speed = (float)CAN_UINT(0) / 100.0f;
+      can_speed = _speed < 200.0f ? _speed : 0.0f; // ignore invalid speed reading > 200km/h  
       can_odometer = (float)(CAN_UINT32(2)>>4) / 100.0f;
       can_odometer_trip = (float)(CAN_UINT(4)>>4) / 100.0f;
       break;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -113,15 +113,12 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       {
       REQ_DLC(5);
       uint8_t raw_temp = (c >> 13) & 0x7Fu;
-      float _temp = (float)raw_temp - 40.0f;      
-      // Ignore invalid sensor reading (0x7F = 127 → 87°C after offset)
-      if (raw_temp != 0x7F) 
-        {
-        can_bat_temp = _temp;
-        }
+      float _temp = (float)raw_temp - 40.0f;
+      if (_temp < 85.0f)
+        can_bat_temp = _temp;    // Ignore invalid sensor reading
       float _volt = (float)((CAN_UINT(3) >> 5) & 0x3FF) / 2.0f;
-      can_bat_voltage = _volt < 450.0f ? _volt : 0.0f; // ignore invalid voltage reading > 450V
-      can_bat_voltage = 
+      if (_volt < 450.0f) 
+        can_bat_voltage = _volt; // ignore invalid voltage reading > 450V
       can_charge_climit = (c >> 20) & 0x3Fu;        
       break;
       }
@@ -134,7 +131,8 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       REQ_DLC(6);
       // Apply scaling
       float _speed = (float)CAN_UINT(0) / 100.0f;
-      can_speed = _speed < 200.0f ? _speed : 0.0f; // ignore invalid speed reading > 200km/h  
+      if (_speed < 200.0f) 
+        can_speed = _speed;    // ignore invalid speed reading > 200km/h
       can_odometer = (float)(CAN_UINT32(2)>>4) / 100.0f;
       can_odometer_trip = (float)(CAN_UINT(4)>>4) / 100.0f;
       break;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -189,7 +189,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       {
       REQ_DLC(4);
       float _soc = (float) CAN_BYTE(3);
-      if (_soc <= 100.0f) can_soc = _soc; // SOC
+      if (_soc <= 100.0f && _soc >= 0.1f) can_soc = _soc; // SOC
       can_chargeport = (CAN_BYTE(0) & 0x20) != 0; // ChargingPlugConnected
       can_duration_full = (((c >> 22) & 0x3FFu) < 0x3FF) ? (c >> 22) & 0x3FFu : 0;
       float _range_est = ((c >> 12) & 0x3FFu); // VehicleAutonomy

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -812,12 +812,14 @@ void OvmsVehicleSmartEQ::PollReply_BCM_TPMS_InputCapt(const char* data, uint16_t
     {
     // Pressure: big-endian 16 bit *0.75 kPa
     uint16_t praw = CAN_UINT(8 + (i*2));
-    if (praw != 0xffff)
-      m_tpms_pressure[i] = (float)praw * 0.75f;    // only valid values, 0xffff = invalid
+    float pressure_kpa = (float)praw * 0.75f;
+    if (pressure_kpa >= 10.0f && pressure_kpa <= 500.0f)
+      m_tpms_pressure[i] = pressure_kpa;    // only valid values
     // Temperature: raw byte + offset -30.0
     uint16_t traw = (uint16_t)(uint8_t)CAN_BYTE(16 + i);
-    if (traw != 0xffff)
-      m_tpms_temperature[i] = (float)traw - 30.0f; // only valid values, 0xffff = invalid
+    float temp = (float)traw - 30.0f;
+    if (temp <= 100.0f)
+      m_tpms_temperature[i] = temp; // only valid values
     m_tpms_lowbatt[i] = static_cast<bool>((raw >> i) & 0x01);
     }
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -1003,7 +1003,18 @@ void OvmsVehicleSmartEQ::PollReply_OBL_ChargerAC(const char* data, uint16_t repl
   }
   UpdateChargeMetrics();
 }
-
+// #1 poll fast charger 3-phase
+void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_V(const char* data, uint16_t reply_len, int idx) {
+  REQUIRE_LEN(2);
+  mt_obl_main_volts->SetElemValue(idx, CAN_UINT(0) / 2.0);
+}
+//#2 poll fast charger 3-phase
+void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_A(const char* data, uint16_t reply_len, int idx) {
+  REQUIRE_LEN(2);
+  float value = ((CAN_UINT(0) * 0.625) - 2000) / 10.0;
+  mt_obl_main_amps->SetElemValue(idx, value);
+}
+//#3 poll + charge metrics update #1, #2, #3
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Power(const char* data, uint16_t reply_len) {
   // POSITIVE RESPONSE FORMAT: 62 50 4A <Byte> <Byte>
   // Spec: offset -20000.0, bytescount 2, unit W
@@ -1014,21 +1025,6 @@ void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Power(const char* data, uint16_t re
   mt_obl_main_CHGpower->SetElemValue(0, power_kw);
   mt_obl_main_CHGpower->SetElemValue(1, 0);
   UpdateChargeMetrics();
-}
-
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_A(const char* data, uint16_t reply_len, int idx) {
-  REQUIRE_LEN(2);
-  float value = ((CAN_UINT(0) * 0.625) - 2000) / 10.0;
-  mt_obl_main_amps->SetElemValue(idx, value);
-  if (idx == 2)
-    UpdateChargeMetrics();
-}
-
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_V(const char* data, uint16_t reply_len, int idx) {
-  REQUIRE_LEN(2);
-  mt_obl_main_volts->SetElemValue(idx, CAN_UINT(0) / 2.0);
-  if (idx == 2)
-    UpdateChargeMetrics();
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_LeakageDiag(const char* data, uint16_t reply_len) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -699,7 +699,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_BattState(const char* data, uint16_t repl
 
   // P = V × I (in kW)
   float pack_power_kw = (v_pack_term * i_pack) / 1000.0f;
-  StdMetrics.ms_v_bat_voltage->SetValue(v_pack_term);
+  //StdMetrics.ms_v_bat_voltage->SetValue(v_pack_term);
   StdMetrics.ms_v_bat_current->SetValue(i_pack * -1.0f); // invert to charge(+)/discharge(-) convention
   StdMetrics.ms_v_bat_power->SetValue(pack_power_kw);
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -892,7 +892,7 @@ void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_Volt(const char* data, uint16_t repl
   // POSITIVE RESPONSE FORMAT: 62 30 24 <Byte>
   REQUIRE_LEN(1);
   uint8_t raw = CAN_BYTE(0);
-  float value = 4.0f + raw * 0.1f;     // offset 4.0, step 0.1
+  float value = 4.0f + raw * 0.1f;      // offset 4.0, step 0.1
   mt_evc_dcdc->SetElemValue(1, value);  // dcdc_volt
   StdMetrics.ms_v_charge_12v_voltage->SetValue(value);
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -225,6 +225,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
+    smartCoolDownPolling(20); // 20 seconds cooldown to allow the vehicle to wake up
     m_cmd_wakeup = true;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -85,6 +85,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
 
   if (enable && !IsOnHVACEQ()) 
     {
+    CommandWakeup();
     uint8_t data[4] = {0x40, 0x01, 0x00, 0x00};
     canbus *obd;
     obd = m_can1;
@@ -96,10 +97,9 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
         break;
         }
       obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(500 / portTICK_PERIOD_MS);
+      vTaskDelay(1000 / portTICK_PERIOD_MS);
       }
-
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+      
     if (IsOnHVACEQ())
       {
       // if true, climate will be restarted after 5 minutes by Ticker1, if false, climate will not be restarted after 5 minutes

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -96,10 +96,10 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
         break;
         }
       obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(200 / portTICK_PERIOD_MS);
+      vTaskDelay(500 / portTICK_PERIOD_MS);
       }
 
-    vTaskDelay(200 / portTICK_PERIOD_MS);
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
     if (IsOnHVACEQ())
       {
       // if true, climate will be restarted after 5 minutes by Ticker1, if false, climate will not be restarted after 5 minutes

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -85,7 +85,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
 
   if (enable && !IsOnHVACEQ()) 
     {
-    CommandWakeup();
     uint8_t data[4] = {0x40, 0x01, 0x00, 0x00};
     canbus *obd;
     obd = m_can1;
@@ -93,7 +92,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
       {
       if (IsOnHVACEQ())
         {
-        StdMetrics.ms_v_env_awake->SetValue(true);
         ESP_LOGD(TAG, "Climate control is now on");
         break;
         }
@@ -101,6 +99,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
 
+    vTaskDelay(200 / portTICK_PERIOD_MS);
     if (IsOnHVACEQ())
       {
       // if true, climate will be restarted after 5 minutes by Ticker1, if false, climate will not be restarted after 5 minutes
@@ -197,7 +196,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandHomelink(int button, i
       return OvmsVehicle::CommandHomelink(button, durationms);
   }
 }
-
+// this command is not implemented by the EQ, but we can use it to trigger a simulated wakeup
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
   if(!IsCANwrite())
     {
@@ -211,22 +210,22 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
 
   if(!IsAwakeEQ()) 
     {
-    uint8_t data[4] = {0x40, 0x00, 0x00, 0x00};
+    uint8_t data[8] = {0xc3, 0x00, 0x00, 0x00, 0x14, 0x70, 0x96, 0x85};
     canbus *obd;
     obd = m_can1;
 
-    for (int i = 0; i < 15; i++) 
+    for (int i = 0; i < 5; i++) 
       {
       if (IsAwakeEQ()) 
         {
         res = Success;
         break;
         }      
-      obd->WriteStandard(0x634, 4, data);
+      obd->WriteStandard(0x350, 8, data);
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
-    StdMetrics.ms_v_env_awake->SetValue(true);
+    m_cmd_wakeup = true;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 
   else 
@@ -250,11 +249,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandLock(const char* pin) 
 
   if(m_indicator) 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000","30082002"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000","30082002"}, false, false);
     }
   else 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000"}, false, false);
     }
     
   if(res == Success)  
@@ -291,11 +290,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandUnlock(const char* pin
 
   if(m_indicator) 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001","30082002"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001","30082002"}, false, false);
     }
   else 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001"}, false, false);
     }
 
   if(res == Success) 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -213,6 +213,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
     uint8_t data[8] = {0xc3, 0x00, 0x00, 0x00, 0x14, 0x70, 0x96, 0x85};
     canbus *obd;
     obd = m_can1;
+    smartCoolDownPolling(30); // 30 seconds cooldown to allow the vehicle to wake up
 
     for (int i = 0; i < 5; i++) 
       {
@@ -225,7 +226,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
-    smartCoolDownPolling(20); // 20 seconds cooldown to allow the vehicle to wake up
     m_cmd_wakeup = true;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -405,9 +405,14 @@ void OvmsVehicleSmartEQ::xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCom
       {
       writer->puts("Error: vehicle 12V DC-DC converter not active");
       return;
+      }
+    if (smarteq->m_poll_cooldown) 
+      {
+      writer->puts("Error: vehicle 12V DC-DC polling not active");
+      return;
       } 
         
-    float can12V = StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f);   // DCDC voltage = mt_evc_dcdc->GetElemValue(1)
+    float can12V = (smarteq->mt_evc_dcdc->GetElemValue(1) + smarteq->mt_evc_dcdc->GetElemValue(3) + smarteq->mt_evc_dcdc->GetElemValue(4)) / 3;   // DCDC 12V
     if (can12V < 13.1f) 
       {
       writer->puts("Error: vehicle 12V is not charging, 12V voltage is not stable for ADC calibration!");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -468,8 +468,24 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandPreset(int verbosity, 
   {
     auto m = MyConfig.GetParamMap("vehicle");
     bool changed = false;
-    if (m.find("12v.alert") == m.end())
-      { m["12v.alert"] = "0.8"; changed = true; }
+    auto it_ref = m.find("12v.ref");    
+    auto it_alert = m.find("12v.alert");
+    if (PRESET_VERSION == PRESET_VERSION_12VREF) 
+    {
+      m["12v.ref"] = "12.5";
+      m["12v.alert"] = "0.9";
+      changed = true;
+    }
+    if (it_ref == m.end())
+      {
+      m["12v.ref"] = "12.5";
+      changed = true;
+      }
+    if (it_alert == m.end())
+      {
+      m["12v.alert"] = "0.9";
+      changed = true;
+      }
     if (need_stream)
       { m["stream"] = "10"; changed = true; }
     // TPMS migration: read from already-loaded map_xsq
@@ -629,7 +645,8 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandSetDefault(int verbosi
   // vehicle section
   auto map_vehicle = MyConfig.GetParamMap("vehicle");
   map_vehicle["stream"] = "10";
-  map_vehicle["12v.alert"] = "0.8";
+  map_vehicle["12v.ref"] = "12.5";
+  map_vehicle["12v.alert"] = "0.9";
   MyConfig.SetParamMap("vehicle", map_vehicle);
 
   // ota section

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -77,11 +77,11 @@ OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCanVector(uint32_t tx
 
   OvmsVehicle::vehicle_command_t res = Fail;
   res = wakeup ? CommandWakeup() : Success;
-  
+
+  vTaskDelay(200 / portTICK_PERIOD_MS);
   if (res == Success)
     {
-    vTaskDelay(1500 / portTICK_PERIOD_MS);
-    if (!IsAwakeEQ()) 
+    if (wakeup && !can_awake) 
       {
       ESP_LOGE(TAG, "vehicle not awake");
       m_ddt4all_exec = 5; // reduce cooldown on error

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
@@ -79,28 +79,28 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 0:
     {
       // indicator 5x on
-      CommandCanVector(0x745, 0x765, {"30082002","30082002"}, false, true);
+      CommandCanVector(0x745, 0x765, {"30082002","30082002"}, false, false);
       res = Success;
       break;
     }
     case 1:
     {
       // open trunk
-      CommandCanVector(0x745, 0x765, {"300500","300500","300500","300500","300500"}, false, true);
+      CommandCanVector(0x745, 0x765, {"300500","300500","300500","300500","300500"}, false, false);
       res = Success;
       break;
     }
     case 2:
     {
       // AUTO_WIPE false
-      CommandCanVector(0x74d, 0x76d, {"2E033C00"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033C00"}, false, false);
       res = Success;
       break;
     }
     case 3:
     {
       // AUTO_WIPE true
-      CommandCanVector(0x74d, 0x76d, {"2E033C80"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033C80"}, false, false);
       res = Success;
       break;
     }
@@ -148,70 +148,70 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 6:
     {
       // BIPBIP_Lock false
-      CommandCanVector(0x745, 0x765, {"3B1400"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B1400"}, false, false);
       res = Success;
       break;
     }
     case 7:
     {
       // BIPBIP_Lock true
-      CommandCanVector(0x745, 0x765, {"3B1480"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B1480"}, false, false);
       res = Success;
       break;
     }
     case 8:
     {
       // REAR_WIPER_LINK false
-      CommandCanVector(0x745, 0x765, {"3B5800"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5800"}, false, false);
       res = Success;
       break;
     }
     case 9:
     {
       // REAR_WIPER_LINK true
-      CommandCanVector(0x745, 0x765, {"3B5880"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5880"}, false, false);
       res = Success;
       break;
     }
     case 10:
     {
       // RKE_Backdoor_open false
-      CommandCanVector(0x745, 0x765, {"3B7800"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7800"}, false, false);
       res = Success;
       break;
     }
     case 11:
     {
       // RKE_Backdoor_open true
-      CommandCanVector(0x745, 0x765, {"3B7880"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7880"}, false, false);
       res = Success;
       break;
     }
     case 12:
     {
       // Precond_by_key 00
-      CommandCanVector(0x745, 0x765, {"3B7700"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7700"}, false, false);
       res = Success;
       break;
     }
     case 13:
     {
       // Precond_by_key 03
-      CommandCanVector(0x745, 0x765, {"3B7703"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7703"}, false, false);
       res = Success;
       break;
     }
     case 14:
     {
       // ECOMODE_PRE_Restart false
-      CommandCanVector(0x745, 0x765, {"3B7600"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7600"}, false, false);
       res = Success;
       break;
     }
     case 15:
     {
       // ECOMODE_PRE_Restart true
-      CommandCanVector(0x745, 0x765, {"3B7680"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7680"}, false, false);
       res = Success;
       break;
     }
@@ -232,42 +232,42 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 18:
     {
       // ONLY_DRL_OFF_CF false
-      CommandCanVector(0x74d, 0x76d, {"2E045F00"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E045F00"}, false, false);
       res = Success;
       break;
     }
     case 19:
     {
       // ONLY_DRL_OFF_CF true
-      CommandCanVector(0x74d, 0x76d, {"2E045F80"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E045F80"}, false, false);
       res = Success;
       break;
     }
     case 20:
     {
       // Welcome_Goodbye_CF false
-      CommandCanVector(0x74d, 0x76d, {"2E033400"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033400"}, false, false);
       res = Success;
       break;
     }
     case 21:
     {
       // Welcome_Goodbye_CF true
-      CommandCanVector(0x74d, 0x76d, {"2E033480"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033480"}, false, false);
       res = Success;
       break;
     }    
     case 22:
     {      
       // Default variant, tailgate open true, Precond_by_key 00
-      CommandCanVector(0x745, 0x765, {"3B7880","3B7700"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7880","3B7700"}, false, false);
       res = Success;
       break;
     }
     case 23:
     {      
       // Default variant, tailgate open false, Precond_by_key 03
-      CommandCanVector(0x745, 0x765, {"3B7800","3B7703"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7800","3B7703"}, false, false);
       res = Success;
       break;
     }
@@ -303,28 +303,28 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 32:
     {
       // key reminder false
-      CommandCanVector(0x745, 0x765, {"3B5E00"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5E00"}, false, false);
       res = Success;
       break;
     }
     case 33:
     {
       // key reminder true
-      CommandCanVector(0x745, 0x765, {"3B5E80"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5E80"}, false, false);
       res = Success;
       break;
     }
     case 34:
     {
       // long tempo display false
-      CommandCanVector(0x745, 0x765, {"3B5700"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5700"}, false, false);
       res = Success;
       break;
     }
     case 35:
     {
       // long tempo display true
-      CommandCanVector(0x745, 0x765, {"3B5780"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5780"}, false, false);
       res = Success;
       break;
     }
@@ -387,28 +387,28 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 46:
     {
       // Auto Light false
-      CommandCanVector(0x745, 0x765, {"2E104200"}, false, true);
+      CommandCanVector(0x745, 0x765, {"2E104200"}, false, false);
       res = Success;
       break;
     }
     case 47:
     {
       // Auto Light true
-      CommandCanVector(0x745, 0x765, {"2E104201"}, false, true);
+      CommandCanVector(0x745, 0x765, {"2E104201"}, false, false);
       res = Success;
       break;
     }
     case 48:
     {
       // Light by EMM false
-      CommandCanVector(0x745, 0x765, {"3B4F00"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B4F00"}, false, false);
       res = Success;
       break;
     }
     case 49:
     {
       // Light by EMM true
-      CommandCanVector(0x745, 0x765, {"3B4F80"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B4F80"}, false, false);
       res = Success;
       break;
     }
@@ -572,7 +572,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 745:
     {
       std::string hexbytes = mt_canbyte->AsString();
-      CommandCanVector(0x745, 0x765, {hexbytes}, false, true);
+      CommandCanVector(0x745, 0x765, {hexbytes}, false, false);
       res = Success;
       break;
     }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -37,98 +37,105 @@
 
 static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,298,33,33 }, 0, ISOTP_STD },   // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,294,294,94 }, 0, ISOTP_STD },  // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,0,298,298 }, 0, ISOTP_STD },   // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,0,0,98 }, 0, ISOTP_STD },      // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,0,6665,0 }, 0, ISOTP_STD },    // Battery Health (SOH)
+  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different sleep times before start polling for each pollstate
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },   // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD },  // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,298,298 }, { 0,0,10,10 } }}, 0, ISOTP_STD },   // SOC
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,98 }, { 0,0,0,155 } }}, 0, ISOTP_STD },      // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,0,6665,0 }, { 0,0,155,0 } }}, 0, ISOTP_STD },    // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P2      (Cells 49-96)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,304,304,104 }, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,304,304,104 }, { 0,30,30,30 } }}, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,8,8,8 }, 0, ISOTP_STD },         // Doorlock EEPROM
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, { 0,0,152,0 }, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, { 0,0,154,0 }, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,152,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,154,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,9,0,9 }, 0, ISOTP_STD },       // Charging plug detected (B_PlugConnected_bcb_status_S)  
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,598,119,59 }, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,122,122,0 }, 0, ISOTP_STD },   // Cabin blower command
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },       // Charging plug detected (B_PlugConnected_bcb_status_S)  
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,598,119,59 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,122,122,122 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,294,59,59 }, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,12,12,12 }, 0, ISOTP_STD },  // DCDC activation request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,294,37,37 }, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,291,31,31 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,291,31,31 }, 0, ISOTP_STD }, // 14V DCDC current measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,294,31,31 }, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,58,17,17 }, 0, ISOTP_STD },  // USM 14V voltage (CAN) - needed for ADC calculation
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,291,29,29 }, 0, ISOTP_STD }, // Battery voltage 14V
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,294,59,59 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },  // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,294,37,37 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,291,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,294,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },  // USM 14V voltage (CAN) - needed for ADC calculation
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,906,906,906 }, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance level
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,906,906,906 }, { 0,17,17,17 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
 static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, { 0,0,0,10 }, 0, ISOTP_STD },  // rqChargerAC
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, {.ts={ { 0,0,0,10 }, { 0,0,0,0 } }}, 0, ISOTP_STD },  // rqChargerAC
 };
 
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, { 0,0,0,11 }, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, { 0,0,0,303 }, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, { 0,0,0,72 }, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, { 0,0,0,304 }, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, { 0,0,0,305 }, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, { 0,0,0,306 }, 0, ISOTP_STD }, // rqJB2AC_DC Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, { 0,0,0,307 }, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, { 0,0,0,308 }, 0, ISOTP_STD }, // rqJB2AC_HF Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, { 0,0,0,309 }, 0, ISOTP_STD }, // rqJB2AC_LF Current
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,303 }, { 0,0,0,51 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,72 }, { 0,0,0,31 } }}, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,304 }, { 0,0,0,52 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, {.ts={ { 0,0,0,305 }, { 0,0,0,53 } }}, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, {.ts={ { 0,0,0,306 }, { 0,0,0,54 } }}, 0, ISOTP_STD }, // rqJB2AC_DC Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, {.ts={ { 0,0,0,307 }, { 0,0,0,55 } }}, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, {.ts={ { 0,0,0,308 }, { 0,0,0,56 } }}, 0, ISOTP_STD }, // rqJB2AC_HF Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, {.ts={ { 0,0,0,309 }, { 0,0,0,57 } }}, 0, ISOTP_STD }, // rqJB2AC_LF Current
 };
 //   -> HandleOBDpolling() will add the following PIDs once m_static_ids_read is false and IsOnEQ() is true
 static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, { 0,6666,6666,0 }, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,6667,6667,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,6668,6668,0 }, 0, ISOTP_STD },    // Frame Traceability Information
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,6669,6669,0 }, 0, ISOTP_STD },    // req.VIN
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6667,6667,0 }, { 0,13,13,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6668,6668,0 }, { 0,14,14,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6669,6669,0 }, { 0,11,11,0 } }}, 0, ISOTP_STD },    // req.VIN
 };

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -38,104 +38,106 @@
 static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different sleep times before start polling for each pollstate
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },     // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,298,298 }, { 0,0,10,10 } }}, 0, ISOTP_STD },   // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,98 }, { 0,0,0,155 } }}, 0, ISOTP_STD },      // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,0,6665,0 }, { 0,0,155,0 } }}, 0, ISOTP_STD },    // Battery Health (SOH)
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different delay time before start polling for each pollstate
+  // e.g. interval 60 with shift 10 is polled at n*60 + 10.
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,300,30,30 }, { 0,8,8,8 } }}, 0, ISOTP_STD },     // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,300,300,60 }, { 0,10,10,10 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,300,300 }, { 0,0,27,27 } }}, 0, ISOTP_STD },   // SOC
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,100 }, { 0,0,0,155 } }}, 0, ISOTP_STD },     // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,3600,3600,0 }, { 0,60,60,0 } }}, 0, ISOTP_STD }, // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,304,304,104 }, { 0,30,30,30 } }}, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,300,300,100 }, { 0,25,25,25 } }}, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,300,300,100 }, { 0,25,25,25 } }}, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,600,600,600 }, { 0,40,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,600,600,600 }, { 0,40,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,300,300,100 }, { 0,30,30,30 } }}, 0, ISOTP_STD },    // Battery Temperatures (27 sensors)    
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,152,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,154,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,150,0 }, { 0,0,34,0 } }}, 0, ISOTP_STD },        // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,150,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Charging plug detected (B_PlugConnected_bcb_status_S)  
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,598,119,59 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,122,122,122 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,600,120,60 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,120,120,120 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,294,59,59 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },     // DCDC activation request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,294,37,37 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // 14V DCDC voltage measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,291,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,294,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },     // USM 14V voltage (CAN) - needed for ADC calculation
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // Battery voltage 14V
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  // AWAKE short interval needed for trickle charging (HVAC on)
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,10,10,10 }, { 0,5,5,5 } }}, 0, ISOTP_STD },    // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,30,30,30 }, { 0,19,19,19 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,20,20,20 }, { 0,8,8,14 } }}, 0, ISOTP_STD },   // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,30,30,30 }, { 0,20,20,20 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,30,30,30 }, { 0,21,21,21 } }}, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,30,30,30 }, { 0,22,22,22 } }}, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,20,20,20 }, { 0,6,6,11 } }}, 0, ISOTP_STD },   // USM 14V voltage (CAN) - needed for ADC calculation
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,20,20,20 }, { 0,7,7,13 } }}, 0, ISOTP_STD },   // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,906,906,906 }, { 0,17,17,17 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance level
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,600,600,600 }, { 0,31,31,31 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,600,300,0 }, { 0,32,32,0 } }}, 0, ISOTP_STD },    // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,600,300,0 }, { 0,33,33,0 } }}, 0, ISOTP_STD },    // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,600,300,0 }, { 0,34,34,0 } }}, 0, ISOTP_STD },    // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,6661,6661,0 }, { 0,63,63,0 } }}, 0, ISOTP_STD },  // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,6661,6661,0 }, { 0,64,64,0 } }}, 0, ISOTP_STD },  // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,6661,6661,0 }, { 0,65,65,0 } }}, 0, ISOTP_STD },  // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
 static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, {.ts={ { 0,0,0,10 }, { 0,0,0,0 } }}, 0, ISOTP_STD },  // rqChargerAC
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqChargerAC
 };
 
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph31_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph1_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph2_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },   // rqJB2AC Mains active power consumed
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,303 }, { 0,0,0,51 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,72 }, { 0,0,0,31 } }}, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,304 }, { 0,0,0,52 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, {.ts={ { 0,0,0,305 }, { 0,0,0,53 } }}, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, {.ts={ { 0,0,0,306 }, { 0,0,0,54 } }}, 0, ISOTP_STD }, // rqJB2AC_DC Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, {.ts={ { 0,0,0,307 }, { 0,0,0,55 } }}, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, {.ts={ { 0,0,0,308 }, { 0,0,0,56 } }}, 0, ISOTP_STD }, // rqJB2AC_HF Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, {.ts={ { 0,0,0,309 }, { 0,0,0,57 } }}, 0, ISOTP_STD }, // rqJB2AC_LF Current
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph1_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph2_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph3_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,13 }, { 0,0,0,13 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,601 }, { 0,0,0,58 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,601 }, { 0,0,0,59 } }}, 0, ISOTP_STD }, // rqJB2AC_Max Current limitation
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,601 }, { 0,0,0,61 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, {.ts={ { 0,0,0,601 }, { 0,0,0,62 } }}, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, {.ts={ { 0,0,0,601 }, { 0,0,0,63 } }}, 0, ISOTP_STD }, // rqJB2AC_DC Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, {.ts={ { 0,0,0,601 }, { 0,0,0,64 } }}, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, {.ts={ { 0,0,0,601 }, { 0,0,0,65 } }}, 0, ISOTP_STD }, // rqJB2AC_HF Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, {.ts={ { 0,0,0,601 }, { 0,0,0,66 } }}, 0, ISOTP_STD }, // rqJB2AC_LF Current
 };
 //   -> HandleOBDpolling() will add the following PIDs once m_static_ids_read is false and IsOnEQ() is true
 static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },   // DataRead.Identification.RenaultR2
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6667,6667,0 }, { 0,13,13,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6668,6668,0 }, { 0,14,14,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6669,6669,0 }, { 0,11,11,0 } }}, 0, ISOTP_STD },    // req.VIN
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ { 0,6662,6662,0 }, { 0,66,66,0 } }}, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6662,6662,0 }, { 0,67,67,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6662,6662,0 }, { 0,68,68,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6662,6662,0 }, { 0,69,69,0 } }}, 0, ISOTP_STD },    // req.VIN
 };

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -84,7 +84,7 @@ static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   // AWAKE short interval needed for trickle charging (HVAC on)
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,10,10,10 }, { 0,5,5,5 } }}, 0, ISOTP_STD },    // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,10,10,10 }, { 0,5,5,9 } }}, 0, ISOTP_STD },    // DCDC activation request
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,30,30,30 }, { 0,19,19,19 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,20,20,20 }, { 0,8,8,14 } }}, 0, ISOTP_STD },   // 14V DCDC voltage measure
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,30,30,30 }, { 0,20,20,20 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
@@ -122,7 +122,7 @@ static const OvmsPoller::poll_pid_t fast_charger_polls[] =
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph1_RMS_A
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph2_RMS_A
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,13 }, { 0,0,0,13 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,5 }, { 0,0,0,8 } }}, 0, ISOTP_STD },    // rqJB2AC Mains active power consumed
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,601 }, { 0,0,0,58 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,601 }, { 0,0,0,59 } }}, 0, ISOTP_STD }, // rqJB2AC_Max Current limitation
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,601 }, { 0,0,0,61 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -49,7 +49,7 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,0,303,103 }, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,0,303,102 }, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P1      (Cells 1-48)   
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,0,3603,603 }, 0, ISOTP_STD },  // Cell Resistance P2      (Cells 49-96)
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,304,304,104 }, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -49,9 +49,9 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,0,303,102 }, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,0,3603,603 }, 0, ISOTP_STD },  // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P2      (Cells 49-96)
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,304,304,104 }, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
 };
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -40,11 +40,11 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different delay time before start polling for each pollstate
   // e.g. interval 60 with shift 10 is polled at n*60 + 10.
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,300,30,30 }, { 0,8,8,8 } }}, 0, ISOTP_STD },     // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,300,300,60 }, { 0,10,10,10 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,300,300 }, { 0,0,27,27 } }}, 0, ISOTP_STD },   // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,100 }, { 0,0,0,155 } }}, 0, ISOTP_STD },     // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,3600,3600,0 }, { 0,60,60,0 } }}, 0, ISOTP_STD }, // Battery Health (SOH)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,300,30,30 }, { 0,8,8,8 } }}, 0, ISOTP_STD },         // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,300,300,60 }, { 0,10,10,10 } }}, 0, ISOTP_STD },     // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,300,300,300 }, { 0,27,27,27 } }}, 0, ISOTP_STD },    // SOC more detailed
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,100 }, { 0,0,0,155 } }}, 0, ISOTP_STD },         // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,3600,3600,0 }, { 0,60,60,0 } }}, 0, ISOTP_STD },     // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
@@ -61,14 +61,14 @@ static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] =
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Doorlock EEPROM
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },             // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,150,0 }, { 0,0,34,0 } }}, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,150,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,150,0 }, { 0,0,34,0 } }}, 0, ISOTP_STD },          // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,150,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },          // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -39,8 +39,8 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different sleep times before start polling for each pollstate
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },   // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD },  // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },     // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,298,298 }, { 0,0,10,10 } }}, 0, ISOTP_STD },   // SOC
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,98 }, { 0,0,0,155 } }}, 0, ISOTP_STD },      // SOC Recalibration
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,0,6665,0 }, { 0,0,155,0 } }}, 0, ISOTP_STD },    // Battery Health (SOH)
@@ -50,10 +50,10 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,304,304,104 }, { 0,30,30,30 } }}, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
 };
 
@@ -73,7 +73,7 @@ static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },       // Charging plug detected (B_PlugConnected_bcb_status_S)  
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Charging plug detected (B_PlugConnected_bcb_status_S)  
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,598,119,59 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,122,122,122 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
 };
@@ -83,25 +83,25 @@ static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,294,59,59 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },  // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },     // DCDC activation request
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,294,37,37 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // 14V DCDC voltage measure
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,291,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,294,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },  // USM 14V voltage (CAN) - needed for ADC calculation
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // Battery voltage 14V
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },     // USM 14V voltage (CAN) - needed for ADC calculation
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,906,906,906 }, { 0,17,17,17 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance level
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
@@ -114,13 +114,13 @@ static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph1_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph2_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph3_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },   // rqJB2AC Mains active power consumed
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,303 }, { 0,0,0,51 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,72 }, { 0,0,0,31 } }}, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,304 }, { 0,0,0,52 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
@@ -134,7 +134,7 @@ static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },   // DataRead.Identification.RenaultR2
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6667,6667,0 }, { 0,13,13,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6668,6668,0 }, { 0,14,14,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
   { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6669,6669,0 }, { 0,11,11,0 } }}, 0, ISOTP_STD },    // req.VIN

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -39,19 +39,19 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
   float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;   // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
-  float usm12v = mt_evc_dcdc->GetElemValue(3);              // 12V USM voltage
+  float bms12v = mt_bms_voltages->GetElemValue(6);          // 12V BMS clamp 30
+  float voltcan = mt_evc_dcdc->GetElemValue(4);             // 12V voltage can
   bool  ref12V_valid = m_ref12V > 11.0f;                    // evaluate reference once per tick
 
   if (ref12V_valid && (
       (volt > 6.0f && m_ref12V - volt > m_alert12V) ||
       (m_can_active && bms12v > 6.0f && m_ref12V - bms12v > m_alert12V) ||
-      (m_can_active && usm12v > 6.0f && m_ref12V - usm12v > m_alert12V)))
+      (m_can_active && voltcan > 6.0f && m_ref12V - voltcan > m_alert12V)))
     {
     if (m_poll_state != POLLSTATE_OFF) // if not already in sleep mode, then switch to sleep mode immediately
       {
       smartCoolDownPolling(60);
-      ESP_LOGW(TAG, "12V undervoltage detected:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      ESP_LOGW(TAG, "12V undervoltage detected:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, voltcan, m_ref12V);
       mt_poll_state->SetValue("Off (12V undervoltage)");
       }
     else if (m_cooldown_ticker <= 10) // cooldown expired or nearly expired - restart to maintain sleep mode
@@ -63,7 +63,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       {
       m_12v_alerted = true;
       m_12v_alerted_ticker = 150; // 150 ticks debounce before alert can reset
-      ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, voltcan, m_ref12V);
       smart12VHistory();          // log undervoltage event in history metric and send data log
       }
     }
@@ -74,7 +74,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       {
       m_12v_alerted = false;
       m_12v_alerted_ticker = -1;
-      ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, voltcan, m_ref12V);
       smart12VHistory();          // log undervoltage event in history metric and send data log
       }
     }
@@ -178,9 +178,9 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
     }
 
   #ifdef CONFIG_OVMS_COMP_ADC
-  if((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ())
+  if(!m_poll_cooldown && ((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ()))
     {
-    float can12V = StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f);   // DCDC voltage = mt_evc_dcdc->GetElemValue(1)
+    float can12V = mt_bms_voltages->GetElemValue(6);   // BMS 12V clamp 30 voltage
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
     if(m_check12vadc && can12V >= 13.1f)
       {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -39,7 +39,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
   float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  float bms12v = mt_bms_voltages->GetElemValue(6);          // 12V BMS clamp 30
+  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.25f;  // 12V BMS clamp 30 + 0.25V offset
   float voltcan = mt_evc_dcdc->GetElemValue(4);             // 12V voltage can
   bool  ref12V_valid = m_ref12V > 11.0f;                    // evaluate reference once per tick
 
@@ -180,7 +180,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
   #ifdef CONFIG_OVMS_COMP_ADC
   if(!m_poll_cooldown && ((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ()))
     {
-    float can12V = mt_bms_voltages->GetElemValue(6);   // BMS 12V clamp 30 voltage
+    float can12V = (mt_evc_dcdc->GetElemValue(1) + mt_evc_dcdc->GetElemValue(3) + mt_evc_dcdc->GetElemValue(4)) / 3;   // DCDC 12V
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
     if(m_check12vadc && can12V >= 13.1f)
       {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -58,13 +58,16 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       }
     else if (!m_12v_alerted) // alert only once when undervoltage is detected, to prevent log flooding
       {
-      m_12v_alerted = true;  
-      smart12VHistory();     // log undervoltage event in history metric and send data log
+      m_12v_alerted = true;
+      m_12v_alerted_ticker = 120; // alert reset cooldown for 120 seconds
+      ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      smart12VHistory();         // log undervoltage event in history metric and send data log
       }
     }
-  else if (m_12v_alerted && (volt > 6.0f  && m_ref12V-volt <= m_alert12V))
+  else if (m_12v_alerted && m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0 && (volt > 6.0f && m_ref12V-volt <= m_alert12V))
     {
-    m_12v_alerted = false; // reset alert flag when voltage is back to normal
+    m_12v_alerted = false;     // reset alert flag when voltage is back to normal
+    m_12v_alerted_ticker = -1; // reset alert ticker
     ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
     }
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -41,7 +41,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
   float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;   // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
   float usm12v = mt_evc_dcdc->GetElemValue(3);              // 12V USM voltage
-  bool  ref12V_valid = m_ref12V > 6.0f;                     // evaluate reference once per tick
+  bool  ref12V_valid = m_ref12V > 11.0f;                    // evaluate reference once per tick
 
   if (ref12V_valid && (
       (volt > 6.0f && m_ref12V - volt > m_alert12V) ||
@@ -59,21 +59,24 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       m_poll_cooldown = true;
       m_cooldown_ticker = 60;
       }
-    else if (!m_12v_alerted)     // alert once per undervoltage event to prevent log flooding
+    if (!m_12v_alerted)           // alert once per undervoltage event to prevent log flooding
       {
       m_12v_alerted = true;
-      m_12v_alerted_ticker = 60; // 60 ticks debounce before alert can reset
+      m_12v_alerted_ticker = 150; // 150 ticks debounce before alert can reset
       ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
-      smart12VHistory();         // log undervoltage event in history metric and send data log
+      smart12VHistory();          // log undervoltage event in history metric and send data log
       }
     }
-  else if (m_12v_alerted && volt > 6.0f && m_ref12V - volt <= m_alert12V &&
-           m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0)
+  else if (m_12v_alerted && ref12V_valid && 
+          volt > 6.0f && m_ref12V - volt <= m_alert12V)
     {
-    m_12v_alerted = false;
-    m_12v_alerted_ticker = -1;
-    ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
-    smart12VHistory();          // log undervoltage event in history metric and send data log
+    if (m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0)
+      {
+      m_12v_alerted = false;
+      m_12v_alerted_ticker = -1;
+      ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      smart12VHistory();          // log undervoltage event in history metric and send data log
+      }
     }
 
   if (m_ddt4all_exec >= 1)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -62,7 +62,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       smart12VHistory();     // log undervoltage event in history metric and send data log
       }
     }
-  else if (m_12v_alerted)
+  else if (m_12v_alerted && (volt > 6.0f  && m_ref12V-volt <= m_alert12V))
     {
     m_12v_alerted = false; // reset alert flag when voltage is back to normal
     ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -89,6 +89,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     can_awake = false;
     can_env_on = false;
     can_battery_on = false;
+    m_cmd_wakeup = false;
     smartCAN2Metrics();
     }
 
@@ -109,6 +110,8 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
 
 void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker) 
   {
+  if (m_cmd_wakeup)
+    m_cmd_wakeup = false;   // reset wakeup command after ~10s
   // if awake state has changed, then update metric to prevent desync
   if (IsAwakeEQ() != StdMetrics.ms_v_env_awake->AsBool(false))
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -38,37 +38,42 @@ static const char *TAG = "v-smarteq";
 void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker) 
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
-  float volt = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;      // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
-  float usm12v = mt_evc_dcdc->GetElemValue(3);                 // 12V USM voltage
-  if((volt > 6.0f && m_ref12V > 6.0f && m_ref12V-volt > m_alert12V) ||
-     (m_can_active && bms12v > 6.0f && m_ref12V > 6.0f && m_ref12V-bms12v > m_alert12V) ||
-     (m_can_active && usm12v > 6.0f && m_ref12V > 6.0f && m_ref12V-usm12v > m_alert12V))
+  float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
+  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;   // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
+  float usm12v = mt_evc_dcdc->GetElemValue(3);              // 12V USM voltage
+  bool  ref12V_valid = m_ref12V > 6.0f;                     // evaluate reference once per tick
+
+  if (ref12V_valid && (
+      (volt > 6.0f && m_ref12V - volt > m_alert12V) ||
+      (m_can_active && bms12v > 6.0f && m_ref12V - bms12v > m_alert12V) ||
+      (m_can_active && usm12v > 6.0f && m_ref12V - usm12v > m_alert12V)))
     {
-    if(m_poll_state != POLLSTATE_OFF) // if not already in sleep mode, then switch to sleep mode immediately
-      {      
+    if (m_poll_state != POLLSTATE_OFF) // if not already in sleep mode, then switch to sleep mode immediately
+      {
       smartCoolDownPolling(60);
       ESP_LOGW(TAG, "12V undervoltage detected:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
       mt_poll_state->SetValue("Off (12V undervoltage)");
       }
-    else if(m_cooldown_ticker <= 10) // if not already in cooldown, then restart 60sec. cooldown
+    else if (m_cooldown_ticker <= 10) // cooldown expired or nearly expired - restart to maintain sleep mode
       {
       m_poll_cooldown = true;
       m_cooldown_ticker = 60;
       }
-    else if (!m_12v_alerted) // alert only once when undervoltage is detected, to prevent log flooding
+    else if (!m_12v_alerted)     // alert once per undervoltage event to prevent log flooding
       {
       m_12v_alerted = true;
-      m_12v_alerted_ticker = 120; // alert reset cooldown for 120 seconds
+      m_12v_alerted_ticker = 60; // 60 ticks debounce before alert can reset
       ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
       smart12VHistory();         // log undervoltage event in history metric and send data log
       }
     }
-  else if (m_12v_alerted && m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0 && (volt > 6.0f && m_ref12V-volt <= m_alert12V))
+  else if (m_12v_alerted && volt > 6.0f && m_ref12V - volt <= m_alert12V &&
+           m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0)
     {
-    m_12v_alerted = false;     // reset alert flag when voltage is back to normal
-    m_12v_alerted_ticker = -1; // reset alert ticker
+    m_12v_alerted = false;
+    m_12v_alerted_ticker = -1;
     ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+    smart12VHistory();          // log undervoltage event in history metric and send data log
     }
 
   if (m_ddt4all_exec >= 1)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -257,8 +257,8 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   if (param && param->GetName() == "vehicle")
     {
     setTPMSValue();   // update TPMS metrics
-    m_ref12V = MyConfig.GetParamValueFloat("vehicle", "12v.ref", 12.6f);
-    m_alert12V = MyConfig.GetParamValueFloat("vehicle", "12v.alert", 0.8f);
+    m_ref12V = MyConfig.GetParamValueFloat("vehicle", "12v.ref", 12.5f);
+    m_alert12V = MyConfig.GetParamValueFloat("vehicle", "12v.alert", 0.9f);
     }
   if (param && param->GetName() != "xsq")
     return;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -218,7 +218,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   StdMetrics.ms_v_bat_12v_voltage_alert->SetValue(false);      // set 12V alert to false
   StdMetrics.ms_v_env_charging12v->SetValue(false);            // set 12V charging state to false
   StdMetrics.ms_v_env_aux12v->SetValue(false);
-  StdMetrics.ms_v_env_hvac->SetValue(false);  
+  StdMetrics.ms_v_env_hvac->SetValue(false);
 
   if (mt_pos_odometer_trip_total->AsFloat(0) < 1.0f)           // reset at boot
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -546,7 +546,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     float can_speed = 0.0f;
     float can_odometer = 0.0f;
     float can_odometer_trip = 0.0f;
-    float can_soc = 0.0f;
+    float can_soc = StdMetrics.ms_v_bat_soc->AsFloat(0.0f);
     float can_range_est = 0.0f;
     float can_range_full = 0.0f;
     float can_range_ideal = 0.0f;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -227,14 +227,14 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // --- Inline state helpers ---
     bool UsesTpmsSensorMapping() override { return true; } // using m_tpms_index[]
     bool IsOffEQ() { return m_poll_state == POLLSTATE_OFF; }
-    bool IsAwakeEQ() { return can_awake || can_charge_inprogress || can_env_on || can_hvac; }
+    bool IsAwakeEQ() { return can_awake || can_charge_inprogress || can_env_on || can_hvac || m_cmd_wakeup; }
     bool IsHVonEQ() { return can_battery_on && IsAwakeEQ(); }
     bool IsOnEQ() { return can_env_on; }
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
     bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
     bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) >= 13.1f || 
-                                  (StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f ) || 
+                                  (m_can_active && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f ) || 
                                   (m_can_active && can_charging12v); }
 
   // =========================================================================
@@ -449,6 +449,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_12v_charge_state = false;        // 12V charge state
     bool m_extendedStats = false;           // extended stats for trip and maintenance data
     bool m_enable_calcADCfactor = false;    // enable calculation of ADC factor
+    bool m_cmd_wakeup = false;              // wakeup command issued
     int m_reboot_ticker = 0;                // ticker for network restart
     int m_reboot_time = 30;                 // Restart Network time
     int m_TPMS_FL = 0;                      // TPMS Sensor Front Left

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -470,6 +470,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     float m_ref12V = 12.6f;                 // reference 12V (12.6V)
     float m_alert12V = 0.8f;                // alert threshold 12V (0.8V)
     bool m_12v_alerted = false;             // 12V undervolt alert triggered
+    int m_12v_alerted_ticker = -1;          // cooldown ticker for 12V undervolt alert reset
 
     // --- Internal state variables ---
     bool m_indicator = false;               // activate indicator e.g. 7 times or whatever

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -33,14 +33,14 @@
 #ifndef __VEHICLE_SMARTEQ_H__
 #define __VEHICLE_SMARTEQ_H__
 
-
 // --- Constants ---
 #define VERSION "2.2.0"
-#define PRESET_VERSION 20260623 // Configuration preset version
+#define PRESET_VERSION 20260706        // Configuration preset version
+#define PRESET_VERSION_12VREF 20260706 // Configuration preset version for 12V reference migration, defined separately to allow setting 12V reference migration
 #define DEFAULT_BATTERY_CAPACITY 16700 // <- net 16700 Wh, gross 17600 Wh
 #define MAX_POLL_DATA_LEN 126
 #define CELLCOUNT 96
-#define SQ_CANDATA_TIMEOUT 10   // seconds until car goes to sleep without CAN activity
+#define SQ_CANDATA_TIMEOUT 10          // seconds until car goes to sleep without CAN activity
 
 #include "ovms_log.h"
 
@@ -468,8 +468,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     std::string m_hl_canbyte = "";          // canbyte variable for unv
     std::deque<float> m_adc_factor_history;     // ring buffer (max 10) for ADC factors
     std::deque<float> m_12v_undervolt_history;  // ring buffer (max 10) for 12V undervoltage measurements
-    float m_ref12V = 12.6f;                 // reference 12V (12.6V)
-    float m_alert12V = 0.8f;                // alert threshold 12V (0.8V)
+    float m_ref12V = 12.5f;                 // reference 12V (12.5V)
+    float m_alert12V = 0.9f;                // alert threshold 12V (0.9V)
     bool m_12v_alerted = false;             // 12V undervolt alert triggered
     int m_12v_alerted_ticker = -1;          // cooldown ticker for 12V undervolt alert reset
 


### PR DESCRIPTION
Brings the fork up to date with `openvehicles/master` @ `2fe84eeb` — we were **34 commits behind**.

**Clean auto-merge, zero conflicts.** 15 files, +272/−171.

### What's in it

Mostly smartEQ (charge metrics, 12V alert/ref defaults, poll rates, BMS part info, TPMS/ADC/LED refactor), plus README and a scripting doc line.

One framework change worth attention:

### `poll_pid_t` gains poll-time shifts (upstream 3.3.006)

`OvmsPoller::poll_pid_t` is now `__attribute__((__packed__))`, and `polltime[]` becomes a union:

```cpp
union {
  uint16_t polltime[VEHICLE_POLL_NSTATES];
  struct {
    uint16_t cycle[VEHICLE_POLL_NSTATES];
    uint8_t  shift[VEHICLE_POLL_NSTATES];   // NEW: shift poll times by N seconds
  } ts;
};
```

and `StandardPollSeries::NextPollEntry` becomes:

```cpp
uint16_t polltime = m_poll_plcur->polltime[pollstate];
uint8_t  pollshift = m_poll_plcur->ts.shift[pollstate];
if ( ((polltime > 0) && (pollticker >= pollshift) && (((pollticker - pollshift) % polltime) == 0))
  || ((polltime == 0) && (pollshift > 0) && (pollticker == pollshift)) )
```

**Why this is safe for us:** existing tables brace-initialize the interval array, which targets the union's first member `polltime[]`. e-TNGA's `obdii_polls_base[]` and `obdii_polls_charge[]` are `static const` at namespace scope, so the new `ts.shift[]` bytes zero-initialize. With `shift == 0` the condition collapses to the previous `(pollticker % polltime) == 0`, and the `polltime == 0 && pollshift > 0` arm never fires. **Poll cadence is unchanged.**

`VEHICLE_POLL_NSTATES` stays at the fork's `4` (our offset-block split, #106) — upstream did not touch it.

The packing is also why upstream had to introduce local temporaries in `DukOvmsPollerPollAdd` (you can't bind a reference into a packed struct member).

### Caveat for future work, not a blocker

Any `poll_pid_t` constructed on the **stack** now has uninitialized `ts.shift[]` bytes, which the standard poll loop would read. e-TNGA has no such construction — both its tables are `static const` — so nothing here is affected. Worth remembering if we ever build a poll list dynamically.

### Validation

- CI `Firmware build` — see checks below.
- Not flashed. Poll-cadence reasoning above is static analysis; the module is currently running `047f53c` (PR #144) and this merge does not change e-TNGA behavior.
