### PR TITLE
etnga: decouple CAN2 bus-liveness from v.e.awake (stop idle alerts during charge)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-etnga-awake-decouple.md
+++ b/docs/superpowers/plans/2026-07-10-etnga-awake-decouple.md
@@ -1,0 +1,296 @@
+# e-TNGA awake/bus-liveness decouple — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the e-TNGA's `v.e.awake` metric to the standard "switched on by the user" meaning by moving CAN2 bus-liveness into an internal `m_last_can2_time` member, so framework consumers stop reporting the car as on/idle during a charge.
+
+**Architecture:** Split the two concepts currently both living in `v.e.awake`. (1) An internal `m_last_can2_time` timestamp, stamped per accepted CAN2 frame and read via `IsBusAlive()`, drives `SLEEP ↔ AWAKE`. (2) `v.e.awake` is set centrally in `SetPollState()` as a pure function of poll state (`AWAKE || DRIVING`), so it is false in SLEEP and all four CHARGE_* states.
+
+**Tech Stack:** C++ (ESP-IDF 3.3, older GCC), OVMS metrics framework. Component: `vehicle/OVMS.V3/components/vehicle_toyota_etnga`.
+
+## Global Constraints
+
+- **No host test suite.** Firmware is not built or unit-tested on the host. Compile verification = GitHub Actions `build.yml` (see CLAUDE.md); behavior verification = on-vehicle. Do NOT claim a local build verified anything.
+- **Feature-branch CI must be triggered explicitly:** `gh workflow run build.yml --ref feature/etnga-awake-decouple` (push trigger fires for master only). Artifacts land in MinIO `ci-artifacts/<run_id>/ovms3/ovms3.bin`.
+- **Match existing file style** (the project asks contributors to match each module's style exactly).
+- **Behavior-preserving for the state machine:** `SLEEP↔AWAKE` timing must stay identical — same 120 s window (`SM_STALE_MID`), same monotonic-seconds clock (`ms_m_monotonic`), same rising-edge-on-forced-sleep behavior. The only intended behavior change is the value of the `v.e.awake` metric during charge.
+- **Single-purpose fork PR:** e-TNGA only; no base-class / framework edits.
+- **Spec:** `docs/superpowers/specs/2026-07-10-etnga-awake-decouple-design.md`.
+
+---
+
+### Task 1: Decouple bus-liveness from `v.e.awake` (all code edits)
+
+This is one atomic code change: the edits are interdependent (repointing a reader before the helper exists would not compile; setting the metric per-state while still setting it per-frame would be incoherent). Land them together in one commit.
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h` (member + method decl)
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp` (`IsBusAlive()` + constant, `SetPollState` awake set, delete stale-reset block)
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_can_processor.cpp` (stamp member)
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp` (3 reads → `IsBusAlive()`, forced-sleep reset)
+- Test: none on host (see Global Constraints). Static self-check + CI build.
+
+**Interfaces:**
+- Produces: `bool OvmsVehicleToyotaETNGA::IsBusAlive() const;` — true iff a CAN2 frame was accepted within `BUS_STALE_SECS` (120) seconds. `uint32_t m_last_can2_time` — monotonic seconds of the last accepted CAN2 frame, `0` when never/after forced sleep.
+- Consumes: `StandardMetrics.ms_m_monotonic->AsInt()` (monotonic seconds), `enum PollState` (SLEEP/AWAKE/DRIVING/CHARGE_*), existing `SetAwake(bool)` and `m_allow_wake`.
+
+- [ ] **Step 1: Declare the member and helper in the header**
+
+In `src/vehicle_toyota_etnga.h`, add the member alongside the sleep/cooldown state (after line 78, `int m_sleep_backoff_idx = 0; ...`):
+
+```cpp
+    uint32_t m_last_can2_time = 0;   // monotonic secs of last accepted CAN2 frame; drives SLEEP<->AWAKE bus-liveness
+```
+
+And add the method declaration immediately after `void SetAwake(bool awake);` (line 351):
+
+```cpp
+    bool IsBusAlive() const;   // true if a CAN2 frame arrived within BUS_STALE_SECS
+```
+
+- [ ] **Step 2: Define `IsBusAlive()` and the stale constant**
+
+In `src/etnga_metrics.cpp`, immediately after the `SetAwake` definition:
+
+```cpp
+void OvmsVehicleToyotaETNGA::SetAwake(bool awake)
+{
+    StandardMetrics.ms_v_env_awake->SetValue(awake);
+}
+```
+
+append:
+
+```cpp
+// CAN2 bus-liveness. Mirrors the old v.e.awake ~120s auto-stale window (SM_STALE_MID)
+// but is kept internal, so v.e.awake can carry the standard "switched on" meaning.
+// Uses the ms_m_monotonic seconds clock (same clock as the CHARGE_WAIT drain timer).
+static const uint32_t BUS_STALE_SECS = 120;
+
+bool OvmsVehicleToyotaETNGA::IsBusAlive() const
+{
+    if (m_last_can2_time == 0)
+        return false;
+    uint32_t now = (uint32_t) StandardMetrics.ms_m_monotonic->AsInt();
+    return (now - m_last_can2_time) <= BUS_STALE_SECS;
+}
+```
+
+- [ ] **Step 3: Set `v.e.awake` centrally from poll state in `SetPollState`**
+
+In `src/etnga_metrics.cpp`, in `SetPollState`, insert the awake set between the transition log and `PollSetState`:
+
+```cpp
+    ESP_LOGI(TAG, "Transitioning from the %s to the %s state", CurrentPollStateText, NextPollStateText);
+
+    // v.e.awake reflects the standard "switched on" meaning: true only while actively
+    // awake for a non-charge reason. Charge states poll with the car off -> awake stays false.
+    SetAwake(state == PollState::AWAKE || state == PollState::DRIVING);
+
+    PollSetState(state);
+}
+```
+
+- [ ] **Step 4: Stamp `m_last_can2_time` instead of `SetAwake(true)` per frame**
+
+In `src/etnga_can_processor.cpp`, `IncomingFrameCan2`, replace the `else` body (keep the `m_allow_wake` gate exactly — stamping only when wake is allowed is what preserves the cooldown semantics):
+
+```cpp
+    if (!m_allow_wake) {
+        // Verbose: this fires for EVERY frame received during a cooldown window — at
+        // parked-bus broadcast rates an INFO message here flooded the log.
+        ESP_LOGV(TAG, "OBD message ignored during cooldown");
+    } else {
+        // Bus-liveness only; v.e.awake is now driven by poll state in SetPollState().
+        m_last_can2_time = (uint32_t) StandardMetrics.ms_m_monotonic->AsInt();
+    }
+```
+
+- [ ] **Step 5: Repoint the three SLEEP/AWAKE/CHARGE_WAIT reads to `IsBusAlive()`**
+
+In `src/etnga_poll_states.cpp`:
+
+Line ~65 (SLEEP handler, wake if there is life):
+```cpp
+    if (IsBusAlive()) {
+```
+(was `if (StandardMetrics.ms_v_env_awake->AsBool()) {`)
+
+Line ~168 (AWAKE handler, sleep if bus dead):
+```cpp
+    if (!IsBusAlive()) {
+```
+(was `if (!StandardMetrics.ms_v_env_awake->AsBool()) {`)
+
+Line ~283 (CHARGE_WAIT handler, sleep if bus dead):
+```cpp
+    if (!IsBusAlive()) {
+```
+(was `if (!StandardMetrics.ms_v_env_awake->AsBool()) {`)
+
+Leave the surrounding comments unchanged.
+
+- [ ] **Step 6: Reset liveness on forced sleep**
+
+In `src/etnga_poll_states.cpp`, `TransitionToSleepState` (line ~379-380), replace the `SetAwake(false)` after `SetPollState(PollState::SLEEP)`:
+
+```cpp
+    SetPollState(PollState::SLEEP);   // also sets v.e.awake = false
+    m_last_can2_time = 0;             // force rising-edge: next wake needs a fresh CAN2 frame
+```
+
+Rationale: `SetPollState(SLEEP)` now sets `v.e.awake` false (Step 3), and the cooldowns `{10,30,60,120,300}` include values ≤120 s, so without zeroing the timestamp a forced sleep taken while the bus is alive would satisfy `IsBusAlive()` again the instant the cooldown lifts and re-wake without a fresh frame.
+
+- [ ] **Step 7: Delete the awake stale-reset block**
+
+In `src/etnga_metrics.cpp`, `ResetStaleMetrics`, delete this block entirely (lines ~87-91):
+
+```cpp
+    // Check to make sure the 'awake' signal has been updated recently
+    if (StandardMetrics.ms_v_env_awake->IsStale() && StandardMetrics.ms_v_env_awake->AsBool()) {
+        ESP_LOGD(TAG, "Awake is stale. Manually setting to off");
+        SetAwake(false);
+    }
+```
+
+`v.e.awake` is now poll-state-driven (never needs a stale reset); bus staleness lives in `IsBusAlive()`. Leave the `controlstate` stale check above it and the chargeport-door stale logic below it untouched.
+
+- [ ] **Step 8: Static self-check — no stray `v.e.awake` bus-liveness references remain**
+
+Run:
+```bash
+cd vehicle/OVMS.V3/components/vehicle_toyota_etnga
+grep -rn "ms_v_env_awake" src/
+grep -rn "SetAwake" src/
+```
+Expected `ms_v_env_awake`: exactly **one** hit — the setter body in `etnga_metrics.cpp` (`SetValue(awake)`).
+Expected `SetAwake`: the header decl, the definition, the new `SetPollState` call, and the two init calls (`etnga_metrics.cpp` init, `vehicle_toyota_etnga.cpp:165`). No `SetAwake(true)`, no `SetAwake` in `can_processor` or in `TransitionToSleepState`.
+
+If anything else appears, reconcile before committing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/devuser/wt-etnga-awake-decouple
+git add vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h \
+        vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp \
+        vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_can_processor.cpp \
+        vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+git commit -m "etnga: decouple CAN2 bus-liveness from v.e.awake
+
+Move bus-liveness to an internal m_last_can2_time member (IsBusAlive(),
+120s window) that drives SLEEP<->AWAKE. Set v.e.awake centrally in
+SetPollState() as (AWAKE || DRIVING), so it is false during all CHARGE_*
+states. Fixes the hourly 'Vehicle is idling' notifications that fired all
+through a charge because v.e.awake was held true to keep the poller running."
+```
+
+---
+
+### Task 2: Docs — `changes.txt` and state-machine notes
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/changes.txt`
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst`
+
+**Interfaces:** none (documentation only).
+
+- [ ] **Step 1: Add the `changes.txt` entry**
+
+Add a new dated entry at the top of `vehicle/OVMS.V3/changes.txt` following the existing format (date/author header, `-` bullets). It is a user-noticeable behavior change, so it belongs here:
+
+```
+2026-07-10 (Jerry Kezar)
+	Toyota e-TNGA / Subaru Solterra:
+	- v.e.awake now reflects "vehicle switched on" (AWAKE/DRIVING) rather than raw
+	  CAN2 bus activity. It no longer reads true during a charge, so the module no
+	  longer emits the periodic "Vehicle is idling / stopped turned on" notification
+	  while parked and charging. Internal CAN2 bus-liveness (sleep/wake timing) is
+	  unchanged.
+```
+
+(Match the surrounding entries' exact leading-tab/indent style.)
+
+- [ ] **Step 2: Update the state-machine doc**
+
+In `components/vehicle_toyota_etnga/docs/state_machine.rst`, update the "Two views of 'vehicle on'" note and the "`env_awake` is never explicitly cleared" note so they describe the new split: internal `m_last_can2_time` / `IsBusAlive()` (120 s window) drives `SLEEP↔AWAKE`; the `v.e.awake` metric is set in `SetPollState()` as `AWAKE || DRIVING` and is false in SLEEP and all CHARGE_* states. Keep the surrounding prose/format; adjust only the two notes that referenced `env_awake` as the bus-liveness signal.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/devuser/wt-etnga-awake-decouple
+git add vehicle/OVMS.V3/changes.txt \
+        vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+git commit -m "docs: etnga — record v.e.awake semantic change and bus-liveness split"
+```
+
+---
+
+### Task 3: CI build verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/devuser/wt-etnga-awake-decouple
+git push -u origin feature/etnga-awake-decouple
+```
+
+- [ ] **Step 2: Trigger the firmware build (feature branches don't auto-build on push)**
+
+```bash
+gh workflow run build.yml --ref feature/etnga-awake-decouple
+```
+
+- [ ] **Step 3: Watch it to green**
+
+```bash
+gh run list --workflow=build.yml --branch feature/etnga-awake-decouple --limit 3 \
+  --json databaseId,status,conclusion,headSha
+# then: gh run watch <databaseId>   (or re-list until status=completed)
+```
+Expected: `conclusion = success`. Note the `run_id` — the bench build is at MinIO `ci-artifacts/<run_id>/ovms3/ovms3.bin`. If the build fails to compile, fix in Task 1 and re-run.
+
+---
+
+### Task 4: On-vehicle validation (run on the module; cannot be done in this environment)
+
+**Files:** none. This is the behavior gate. Flash the Task 3 build to the bench/vehicle module (see CLAUDE.local.md slot-stick flashing) and confirm each item. Capture via `metrics list v.e.` / `stat` over SSH and by pulling `log.txt` after each window.
+
+- [ ] **Step 1: Sleep/wake timing unchanged (parked, no charge)**
+  - Park with bus quiet → module enters SLEEP ~120 s after the last CAN2 frame (watch for `CAN bus idle (env_awake cleared) — sleeping` is now `... (bus idle) ...` per any log wording you kept; confirm the ~120 s latency).
+  - Passive CAN wake (open a door) → `Transitioning from the SLEEP to the AWAKE state`; confirm `v.e.awake` becomes `yes` only on that transition.
+  - Confirm 12 V rising-edge wake still works (unchanged path).
+
+- [ ] **Step 2: AC charge — the fix**
+  - Start an AC charge. Confirm `v.e.awake == no` for the whole `CHARGE_AC` window.
+  - Confirm **no** `notify/alert/vehicle/idle` ("Vehicle is idling / stopped turned on") is emitted during the charge (grep the pulled log).
+  - Confirm charge metrics / charge report still populate normally and there is no spurious SLEEP↔AWAKE oscillation.
+
+- [ ] **Step 3: CHARGE_WAIT 12 V-drain path (validates the forced-sleep reset)**
+  - Plug in with a delayed/scheduled charge (car in CHARGE_WAIT, not yet charging).
+  - Confirm the tiered slow-poll → forced sleep → passive resume cycle still works and does **not** immediately bounce back to AWAKE after the cooldown lifts (this exercises `m_last_can2_time = 0`).
+
+- [ ] **Step 4: Driving**
+  - Drive briefly; confirm `v.e.awake == yes` and `v.e.on == yes` in DRIVING, and both return to `no` after power-off + sleep.
+
+- [ ] **Step 5: Open the PR** once Steps 1–4 pass, targeting the fork master, single-purpose, referencing the spec and the observed 2026-07-09→10 idle-notification logs.
+
+## Self-Review
+
+**Spec coverage:**
+- Internal bus-liveness member + `IsBusAlive()` + 120 s constant → Task 1 Steps 1-2. ✔
+- `v.e.awake` set centrally in `SetPollState` as `AWAKE||DRIVING` → Task 1 Step 3. ✔
+- Per-frame stamp replacing `SetAwake(true)`, preserving `m_allow_wake` gate → Task 1 Step 4. ✔
+- Three reads → `IsBusAlive()` → Task 1 Step 5. ✔
+- Forced-sleep `m_last_can2_time = 0` reset → Task 1 Step 6. ✔
+- Delete stale-reset block → Task 1 Step 7. ✔
+- Init `SetAwake(false)` calls kept (no step needed; explicitly not touched) → covered by Step 8 self-check expectation. ✔
+- Behavior-preserving validation (sleep timing, 12 V wake, charge, drain path) → Task 4. ✔
+- `changes.txt` + `state_machine.rst` → Task 2. ✔
+- CI build gate → Task 3. ✔
+
+**Placeholder scan:** No TBD/TODO; every code step shows exact before/after; commands have expected output. ✔
+
+**Type consistency:** `IsBusAlive()` (const, returns bool) and `m_last_can2_time` (`uint32_t`, seconds) named identically in the header decl (Step 1), definition (Step 2), and all readers (Steps 5-6). `BUS_STALE_SECS` defined once (Step 2). `SetAwake(bool)` reused unchanged. ✔

--- a/docs/superpowers/specs/2026-07-10-etnga-awake-decouple-design.md
+++ b/docs/superpowers/specs/2026-07-10-etnga-awake-decouple-design.md
@@ -1,0 +1,186 @@
+# e-TNGA: decouple CAN2 bus-liveness from `v.e.awake`
+
+**Date:** 2026-07-10
+**Branch:** `feature/etnga-awake-decouple`
+**Scope:** `components/vehicle_toyota_etnga` only. No framework/base-class change. Single-purpose fork PR.
+
+## Problem
+
+The e-TNGA overloads the standard metric `v.e.awake` (documented as "Vehicle is fully
+awake (switched on by the user)", `metrics_standard.h:478`) to mean "the CAN2 bus has
+recent traffic." `IncomingFrameCan2` calls `SetAwake(true)` on every CAN2 frame
+(`etnga_can_processor.cpp:29`), and the metric's built-in ~120 s auto-stale is used to
+detect "bus went dead → sleep" (`etnga_metrics.cpp:88-90`). Because the module stays awake
+to poll throughout an AC/DC charge, `v.e.awake` stays **true for the whole charge**.
+
+Every framework consumer of `v.e.awake` then reports "on" during a charge:
+
+- `vehicle.cpp:1096-1105` — the idle detector fires `NotifyVehicleIdling()`
+  ("Vehicle is idling / stopped turned on") 15 min into the charge, then hourly. This is
+  the user-visible symptom: Home Assistant showed the parked, charging car as on/idle.
+- `ovms_server_v2.cpp:1597` / `ovms_server_v3.cpp:1370` — the `CarAwake` bit sent to the
+  server/app is set true during charge.
+- `vehicle.cpp:2019-2024` — the `vehicle.awake` event + `NotifiedVehicleAwake()` fire on
+  every charge wake.
+
+**Observed** (logs, night of 2026-07-09→10): AC charge ran 23:00:43 → 06:49:01
+(SOC 25%→100%). "Vehicle is idling" alerts fired at 23:15, 00:18, 01:15, 02:17, 03:16,
+04:16, 05:18, 06:18 — entirely inside the charge window.
+
+The closest analogue vehicle, Hyundai Ioniq5, sets `ms_v_env_awake = isOn` (car on, false
+during charge) and drives charge polling from a dedicated poll state
+(`vehicle_hyundai_ioniq5.cpp:661, 850`). That is the fleet norm: `awake` = the user
+switched the car on; charging is a separate poll-state concern with the car off.
+
+## Goal
+
+Separate the two concepts currently conflated in `v.e.awake`:
+
+1. **CAN2 bus-liveness** — an internal signal that drives the `SLEEP ↔ AWAKE` state
+   transitions. Stays exactly as capable as today.
+2. **`v.e.awake` metric** — restored to the standard "switched on" semantic, so framework
+   consumers stop reporting on/idle during a charge.
+
+Non-goals: no base-class idle-alert change; no change to the 12 V wake path; no change to
+charge polling, sleep cooldown/backoff, or the chargeport-latch logic.
+
+## Design
+
+### 1. Internal bus-liveness (drives `SLEEP ↔ AWAKE`)
+
+Replace the metric-staleness mechanism with an explicit member timestamp.
+
+- New member: `uint32_t m_last_can2_time = 0;` — monotonic **seconds** (from
+  `StandardMetrics.ms_m_monotonic->AsInt()`, the same clock the CHARGE_WAIT 12 V-drain
+  timer already uses in `etnga_poll_states.cpp`).
+- New constant: `static constexpr uint32_t BUS_STALE_SECS = 120;` — equals `SM_STALE_MID`
+  (`metrics_standard.h:38`), the auto-stale period `v.e.awake` uses today.
+- New helper:
+  ```cpp
+  bool OvmsVehicleToyotaETNGA::IsBusAlive() const
+  {
+      if (m_last_can2_time == 0)
+          return false;
+      uint32_t now = StandardMetrics.ms_m_monotonic->AsInt();
+      return (now - m_last_can2_time) <= BUS_STALE_SECS;
+  }
+  ```
+
+**Faithful-port justification.** `OvmsMetric::IsStale()` is
+`m_lastmodified + m_autostale < monotonictime` → *not* stale while
+`now - m_lastmodified <= 120`. Every CAN2 frame refreshed `m_lastmodified` because
+`OvmsMetricBool::SetValue` calls `SetModified` in **both** the changed and unchanged
+branches (`ovms_metrics.cpp`), so today's "alive" means "a frame within the last 120 s."
+`IsBusAlive()` reproduces that comparison on the same monotonic-seconds clock.
+
+### 2. `v.e.awake` metric (standard "switched on" semantic)
+
+Make the metric a pure function of poll state, set in the single transition choke point.
+
+- `SetPollState(int state)` is the sole path for every transition (each `TransitionTo*`
+  calls it; it is where the "Transitioning from the X to the Y state" log is emitted).
+  Add there:
+  ```cpp
+  SetAwake(state == PollState::AWAKE || state == PollState::DRIVING);
+  ```
+- Result: `v.e.awake` is **true in AWAKE and DRIVING**, **false in SLEEP and all four
+  CHARGE_\* states** (HANDSHAKE / WAIT / AC / DC). This keeps `awake` distinct from and a
+  superset of `v.e.on` (Ready), and excludes charging.
+
+`SetAwake(bool)` (`etnga_metrics.cpp:645`) keeps its one-line body; it is now called only
+from `SetPollState` and from explicit initialization, never per-frame.
+
+### 3. The forced-sleep liveness reset (critical subtlety)
+
+`TransitionToSleepState` currently ends with `SetAwake(false)` (`etnga_poll_states.cpp:380`).
+This is **not** redundant: when sleep is *forced while the bus is still alive* — the
+CHARGE_WAIT 12 V-drain protection, and the sleep-cooldown path — forcing awake false makes
+the next wake require a **fresh** CAN2 frame (rising-edge), preventing an immediate bounce
+back to AWAKE.
+
+To preserve this under the member-based liveness, `TransitionToSleepState` must **reset the
+liveness timestamp**: replace `SetAwake(false)` with
+```cpp
+m_last_can2_time = 0;   // force rising-edge: wake requires a fresh CAN2 frame
+```
+The `v.e.awake` metric is set false anyway by `SetPollState(PollState::SLEEP)` inside the
+same transition, so no separate metric write is needed here.
+
+Without this reset, a forced sleep taken while `m_last_can2_time` is recent would leave
+`IsBusAlive()` true, and after the cooldown window the SLEEP handler would wake immediately
+instead of waiting for a fresh frame — a behavior change we explicitly avoid.
+
+## Complete change list
+
+| # | Site | Today | Change |
+|---|------|-------|--------|
+| 1 | `etnga_can_processor.cpp:29` | `SetAwake(true)` per CAN2 frame | `m_last_can2_time = StandardMetrics.ms_m_monotonic->AsInt();` |
+| 2 | `etnga_poll_states.cpp:65` (SLEEP: wake if alive) | `ms_v_env_awake->AsBool()` | `IsBusAlive()` |
+| 3 | `etnga_poll_states.cpp:168` (AWAKE→sleep if dead) | `!ms_v_env_awake->AsBool()` | `!IsBusAlive()` |
+| 4 | `etnga_poll_states.cpp:283` (CHARGE_WAIT→sleep if dead) | `!ms_v_env_awake->AsBool()` | `!IsBusAlive()` |
+| 5 | `etnga_poll_states.cpp:380` (`TransitionToSleepState`) | `SetAwake(false)` | `m_last_can2_time = 0;` |
+| 6 | `etnga_metrics.cpp:88-90` (awake stale-reset block) | force awake false on stale | **delete** |
+| 7 | `SetPollState(...)` (`etnga_metrics.cpp`) | — | add `SetAwake(state == AWAKE \|\| state == DRIVING)` |
+| 8 | `vehicle_toyota_etnga.h` | — | declare `uint32_t m_last_can2_time`, `BUS_STALE_SECS`, `bool IsBusAlive() const` |
+
+Unchanged and intentionally kept:
+- `SetAwake(false)` at init (`etnga_metrics.cpp:54`, `vehicle_toyota_etnga.cpp:165`) — a
+  harmless explicit initial value; `SetPollState(PollState::SLEEP)` at boot also sets it.
+- `SetAwake` helper body (`etnga_metrics.cpp:645`).
+- The 12 V rising-edge wake path in the SLEEP handler (separate from bus-liveness).
+- Charge-state polling, sleep cooldown/backoff, chargeport-latch / `in_session` logic.
+
+## Why it's behavior-preserving for the state machine
+
+- `SLEEP ↔ AWAKE` timing is identical: same 120 s window, same clock, same
+  rising-edge-on-forced-sleep behavior (via the `m_last_can2_time = 0` reset).
+- Charge polling is unaffected: the charge states never used `awake` to *stay* in charge;
+  they only used it (now `IsBusAlive()`) for the bus-dead → sleep guard, and the OBC keeps
+  CAN2 alive during a real charge.
+- The only intended behavior change is the value of the `v.e.awake` **metric** during
+  charge (now false), which is the fix.
+
+## Consequences (the payoff)
+
+- Base idle detector no longer fires during a charge → no more "Vehicle is idling"
+  notifications while parked and charging (the reported HA symptom).
+- v2/v3 `CarAwake` bit and `vehicle.awake` event now reflect genuine on-state, not charge.
+- `v.e.awake` becomes informative (distinct from `v.e.on`) rather than a duplicate of
+  bus-liveness.
+
+## Testing / validation
+
+No host unit-test suite exists; firmware is validated by CI build + on-vehicle runtime
+(per CLAUDE.md). Validation plan:
+
+1. **CI build** green (firmware `build.yml`) with the e-TNGA selected.
+2. **On-vehicle, static checks via `metrics`/logs:**
+   - Parked, bus quiet → module enters SLEEP ~120 s after last CAN2 frame (unchanged).
+   - Passive CAN wake (open door) → SLEEP→AWAKE; `v.e.awake` becomes true only on the
+     transition to AWAKE.
+   - 12 V rising-edge wake still works (uncalibrated-ref fallback path unaffected).
+3. **On-vehicle, AC charge session:** confirm `v.e.awake == false` throughout; confirm the
+   "Vehicle is idling" notification does **not** fire; confirm charge metrics/report still
+   populate; confirm no spurious SLEEP↔AWAKE oscillation.
+4. **CHARGE_WAIT 12 V-drain path:** plug in with delayed/scheduled charge; confirm the
+   tiered slow-poll → forced sleep → passive resume still works and does not immediately
+   bounce (validates the `m_last_can2_time = 0` reset).
+
+Items 3–4 require a real vehicle and cannot be verified in this environment.
+
+## Documentation & housekeeping
+
+- `changes.txt`: add an entry — user-noticeable behavior change (no idle alerts while
+  charging; `v.e.awake` now excludes charging). No new config keys.
+- `components/vehicle_toyota_etnga/docs/state_machine.rst`: update the "Two views of
+  'vehicle on'" note and the `env_awake` auto-stale note to describe the new split
+  (internal `m_last_can2_time` drives SLEEP↔AWAKE; `v.e.awake` reflects poll state).
+
+## Risks
+
+- **Subtle timing drift** if `ms_m_monotonic` and the metric's `monotonictime` differ by a
+  tick. Both advance once per second from the same source; the 120 s window is tolerant of
+  a ±1 s difference. Low risk.
+- **A missed `awake` reader.** Audit confirmed exactly five `ms_v_env_awake` references and
+  seven `SetAwake` references in the component (all in the change list). Re-grep during
+  implementation to guard against drift.

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,11 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): v.e.awake now reflects the vehicle being
+    switched on (AWAKE/DRIVING) rather than raw CAN2 bus activity, so it no longer reads true
+    during a charge — the module no longer sends the periodic "Vehicle is idling / stopped
+    turned on" notification while parked and charging. Internal CAN2 bus-liveness (sleep/wake
+    timing) is unchanged.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): if the CAN bus goes quiet mid-charge (e.g. the
     car is locked, isolating the diagnostic gateway from the OBC), the charge report no longer
     records frozen/stale telemetry — the per-sample log, energy accounting and chart pause until

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -56,10 +56,10 @@ Tick loop
 ``Ticker1()`` runs once per second and does three things:
 
 1. ``ResetStaleMetrics()`` manually clears ``controlstate``,
-   ``ms_v_env_awake``, ``ms_v_door_chargeport``, ``ms_v_charge_pilot``,
-   and ``ms_v_bat_power`` if they have gone stale but still hold a
-   non-default value.  This is the only way ``ms_v_env_awake`` ever drops
-   back to ``false``.
+   ``ms_v_door_chargeport``, ``ms_v_charge_pilot``, and ``ms_v_bat_power``
+   if they have gone stale but still hold a non-default value.
+   ``ms_v_env_awake`` is no longer cleared here — it is now set directly
+   by ``SetPollState()`` (see "Two views of 'vehicle on'" below).
 2. While in the ``DRIVING`` state, computes ``v.b.consumption``
    (trip-average Wh/km) from net trip energy divided by trip distance.
 3. Dispatches to the appropriate handler —
@@ -86,7 +86,7 @@ Transition diagram
    start →│      SLEEP      │◄─────────────────────┐       │
           └─────────────────┘                      │       │
               │     ▲                              │       │
-   CAN traffic│     │ env_awake stale (~120 s)      │       │
+   CAN traffic│     │ bus idle (~120 s)             │       │
    OR 12V >   │     │ OR 5-min / 15-min watchdog    │       │
    ref+0.2 V  │     │ (arms escalating cooldown)    │       │
               ▼     │                              │       │
@@ -138,16 +138,18 @@ The polling feedback loop
 =========================
 
 The ``SLEEP → AWAKE`` edge is driven by external CAN traffic (any frame
-on CAN2 sets ``ms_v_env_awake``).  Once in ``AWAKE``, however, the
-poller is actively transmitting OBD-II requests on the same bus.  The
-ECUs reply, and those replies are themselves CAN traffic — so the
-driver's own polling refreshes ``ms_v_env_awake`` on every tick and
-prevents the auto-stale that would otherwise bring it back to ``SLEEP``.
+on CAN2 updates the internal ``m_last_can2_time`` bus-liveness timestamp,
+checked via ``IsBusAlive()``).  Once in ``AWAKE``, however, the poller
+is actively transmitting OBD-II requests on the same bus.  The ECUs
+reply, and those replies are themselves CAN traffic — so the driver's
+own polling refreshes ``m_last_can2_time`` on every tick and prevents
+the bus-liveness window (120 s) from expiring, which would otherwise
+bring it back to ``SLEEP``.
 
 Practical consequences:
 
-* ``AWAKE`` will not exit on its own via the ``env_awake`` stale path
-  while the poller is running.  The 5-minute forced-sleep watchdog in
+* ``AWAKE`` will not exit on its own via the ``IsBusAlive()`` stale
+  path while the poller is running.  The 5-minute forced-sleep watchdog in
   ``HandleAwakeState`` exists precisely to break this loop when the
   vehicle never reports a clear ``DRIVING`` state and no cable is
   inserted.
@@ -187,17 +189,18 @@ All edges live in ``etnga_poll_states.cpp``.
      - Condition
      - Notes
    * - ``SLEEP → AWAKE``
-     - ``ms_v_env_awake == true``
-     - Set by ``IncomingFrameCan2()`` on any CAN2 frame, gated by the
-       cooldown latch (see below).
+     - ``IsBusAlive() == true``
+     - ``m_last_can2_time`` updated by ``IncomingFrameCan2()`` on any
+       CAN2 frame, gated by the cooldown latch (see below).
    * - ``SLEEP → AWAKE``
      - 12 V > 12 V-ref + 0.2 V
      - Issues ``m_can2->Reset()`` first to recover from a stuck bus.
        **Not** gated by the cooldown latch.
    * - ``AWAKE → SLEEP``
-     - ``ms_v_env_awake == false``
-     - Triggered when ``env_awake`` auto-stales (~120 s of no CAN
-       frames) and ``ResetStaleMetrics`` flips it false.
+     - ``IsBusAlive() == false``
+     - Triggered when ``m_last_can2_time`` goes stale (~120 s of no
+       CAN2 frames); checked directly in ``HandleAwakeState``, not via
+       a metric auto-stale.
    * - ``AWAKE → DRIVING``
      - ``controlstate == CS_DRIVING``
      - Invalidates the internal trip-start odometer baseline on entry so it
@@ -249,7 +252,7 @@ All edges live in ``etnga_poll_states.cpp``.
      - HLC in range ``0x0A–0x12``
      - DC engaged from wait.  Sets ``ms_v_charge_state = "charging"``.
    * - ``CHARGE_WAIT → SLEEP``
-     - ``ms_v_env_awake == false``
+     - ``IsBusAlive() == false``
      - Bus went dead during scheduled wait (OBC slept or gateway isolated
        OBD).  Arms the escalating cooldown latch.
    * - ``CHARGE_AC → CHARGE_WAIT``
@@ -588,9 +591,9 @@ To prevent flapping after the forced-sleep watchdogs,
 ``m_sleep_entry_time`` before calling ``SetPollState(SLEEP)``.  While
 the latch is held:
 
-* ``IncomingFrameCan2`` does **not** call ``SetAwake(true)``, so trailing
-  post-shutdown CAN traffic cannot bounce the driver straight back to
-  ``AWAKE``.
+* ``IncomingFrameCan2`` does **not** update ``m_last_can2_time``, so
+  trailing post-shutdown CAN traffic cannot bounce the driver straight
+  back to ``AWAKE`` via ``IsBusAlive()``.
 * After the current cooldown window elapses, ``HandleSleepState`` clears
   the latch and CAN frames can wake the driver again.
 
@@ -627,18 +630,26 @@ The driver always starts in ``SLEEP`` and waits for CAN activity or a
 Notes and quirks
 ================
 
-* **Two views of "vehicle on".** ``ms_v_env_awake`` (anything on the bus)
-  drives ``SLEEP ↔ AWAKE``; ``controlstate`` (vehicle-reported mode)
-  drives ``AWAKE ↔ DRIVING``; PISW (cable-seated signal) drives
-  ``AWAKE → CHARGE_HANDSHAKE``.  Future wake/sleep tweaks should preserve
-  this split.
+* **Two views of "vehicle on".** Bus-liveness and the "switched on"
+  metric are separate.  The internal ``m_last_can2_time`` timestamp
+  (checked via ``IsBusAlive()``, a 120 s window) drives ``SLEEP ↔
+  AWAKE``; ``controlstate`` (vehicle-reported mode) drives ``AWAKE ↔
+  DRIVING``; PISW (cable-seated signal) drives ``AWAKE →
+  CHARGE_HANDSHAKE``.  ``ms_v_env_awake`` no longer drives any
+  transition — ``SetPollState()`` sets it directly to ``(state ==
+  AWAKE || state == DRIVING)``, so it reads ``false`` in ``SLEEP`` and
+  all four ``CHARGE_*`` states (this is what stops the periodic
+  "Vehicle is idling" notification from firing mid-charge).  Future
+  wake/sleep tweaks should preserve this split.
 * **Charge entry no longer uses CS_CHARGING.** The old
   ``controlstate == CS_CHARGING`` trigger is gone; PISW ``≥ 0x02`` fires
   earlier (plug-in detected before HV mode flips).
-* **``env_awake`` is never explicitly cleared.** It falls to ``false``
-  only via auto-stale plus the manual reset in ``ResetStaleMetrics``.
-  Anything that changes its auto-stale period changes the ``SLEEP``
-  detection latency.
+* **``ms_v_env_awake`` is set explicitly, not auto-staled.**
+  ``SetPollState()`` sets it on every state transition (``true`` for
+  ``AWAKE``/``DRIVING``, ``false`` otherwise); it is no longer cleared
+  via metric auto-stale in ``ResetStaleMetrics``.  Bus-liveness
+  detection latency is governed separately by the internal
+  ``BUS_STALE_SECS`` (120 s) window used by ``IsBusAlive()``.
 * **Direct ``DRIVING ↔ charge-state`` is impossible.** A vehicle that
   flips control mode from drive to charge spends at least one tick in
   ``AWAKE`` in between, which clears trip metrics.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_can_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_can_processor.cpp
@@ -26,6 +26,7 @@ void OvmsVehicleToyotaETNGA::IncomingFrameCan2(CAN_frame_t* p_frame)
         // parked-bus broadcast rates an INFO message here flooded the log.
         ESP_LOGV(TAG, "OBD message ignored during cooldown");
     } else {
-        SetAwake(true);
+        // Bus-liveness only; v.e.awake is now driven by poll state in SetPollState().
+        m_last_can2_time = (uint32_t) StandardMetrics.ms_m_monotonic->AsInt();
     }
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -84,12 +84,6 @@ void OvmsVehicleToyotaETNGA::ResetStaleMetrics() // Reset stale variables
         SetControlMode(0);
     }
 
-    // Check to make sure the 'awake' signal has been updated recently
-    if (StandardMetrics.ms_v_env_awake->IsStale() && StandardMetrics.ms_v_env_awake->AsBool()) {
-        ESP_LOGD(TAG, "Awake is stale. Manually setting to off");
-        SetAwake(false);
-    }
-
     // Check to make sure the 'charging door' signal has been updated recently.
     // The lid (0x1625) is only polled in AWAKE+DRIVING, so in the charge states it
     // reads stale even though the cable is physically holding the door open — don't
@@ -645,6 +639,19 @@ void OvmsVehicleToyotaETNGA::SetAwake(bool awake)
     StandardMetrics.ms_v_env_awake->SetValue(awake);
 }
 
+// CAN2 bus-liveness. Mirrors the old v.e.awake ~120s auto-stale window (SM_STALE_MID)
+// but is kept internal, so v.e.awake can carry the standard "switched on" meaning.
+// Uses the ms_m_monotonic seconds clock (same clock as the CHARGE_WAIT drain timer).
+static const uint32_t BUS_STALE_SECS = 120;
+
+bool OvmsVehicleToyotaETNGA::IsBusAlive() const
+{
+    if (m_last_can2_time == 0)
+        return false;
+    uint32_t now = (uint32_t) StandardMetrics.ms_m_monotonic->AsInt();
+    return (now - m_last_can2_time) <= BUS_STALE_SECS;
+}
+
 // Hours elapsed since the last sample on an energy-integrator channel; updates the
 // channel timestamp. The first sample of an interval (lastSampleTime == 0) counts as
 // 1 s. Gaps over 60 s (charge pause, OBC lock-isolation, sleep) also count as 1 s —
@@ -1038,6 +1045,10 @@ void OvmsVehicleToyotaETNGA::SetPollState(int state)
     const char* NextPollStateText = ConvertPollStateToString(state);
 
     ESP_LOGI(TAG, "Transitioning from the %s to the %s state", CurrentPollStateText, NextPollStateText);
+
+    // v.e.awake reflects the standard "switched on" meaning: true only while actively
+    // awake for a non-charge reason. Charge states poll with the car off -> awake stays false.
+    SetAwake(state == PollState::AWAKE || state == PollState::DRIVING);
 
     PollSetState(state);
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -62,7 +62,7 @@ void OvmsVehicleToyotaETNGA::HandleSleepState()
         }
     }
 
-    if (StandardMetrics.ms_v_env_awake->AsBool()) {
+    if (IsBusAlive()) {
         // There is life.
         TransitionToAwakeState();
     } else {
@@ -165,7 +165,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
         // fall through to normal AWAKE handling (finalize path only)
     }
 
-    if (!StandardMetrics.ms_v_env_awake->AsBool()) {
+    if (!IsBusAlive()) {
         // No CAN communication - bus is dead, go to sleep
         ESP_LOGI(TAG, "CAN bus idle (env_awake cleared) — sleeping");
         TransitionToSleepState();
@@ -280,7 +280,7 @@ void OvmsVehicleToyotaETNGA::HandleChargeWaitState()
         TransitionToChargeDcState();
         return;
     }
-    if (!StandardMetrics.ms_v_env_awake->AsBool()) {
+    if (!IsBusAlive()) {
         // Bus went dead during scheduled wait (OBC slept or gateway isolated OBD)
         TransitionToSleepState();
         return;
@@ -376,8 +376,8 @@ void OvmsVehicleToyotaETNGA::TransitionToSleepState()
                      > (StandardMetrics.ms_v_bat_12v_voltage_ref->AsFloat() + AUX_12V_WAKE_SET_V);
     if (m_sleep_backoff_idx < SLEEP_COOLDOWN_STEPS - 1)
         m_sleep_backoff_idx++;
-    SetPollState(PollState::SLEEP);
-    SetAwake(false);
+    SetPollState(PollState::SLEEP);   // also sets v.e.awake = false
+    m_last_can2_time = 0;             // force rising-edge: next wake needs a fresh CAN2 frame
     // 12V aux metrics come only from the EV ECU (answers in READY/charging); clear the
     // PID-sourced values when leaving those states so stale readings aren't shown while off.
     StandardMetrics.ms_v_bat_12v_current->Clear();

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -167,7 +167,7 @@ void OvmsVehicleToyotaETNGA::HandleAwakeState()
 
     if (!IsBusAlive()) {
         // No CAN communication - bus is dead, go to sleep
-        ESP_LOGI(TAG, "CAN bus idle (env_awake cleared) — sleeping");
+        ESP_LOGI(TAG, "CAN bus idle (no recent CAN2 frames) — sleeping");
         TransitionToSleepState();
         return;
     }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -76,6 +76,7 @@ protected:
     int m_sleep_entry_time = 0;  // Used to track the time that cooldown timer started
     int m_sleep_cooldown_secs = 10;  // Cooldown window (s) for the current sleep; default must equal SLEEP_COOLDOWN_SECS[0]
     int m_sleep_backoff_idx = 0;     // Index into SLEEP_COOLDOWN_SECS; escalates on consecutive no-activity sleeps
+    uint32_t m_last_can2_time = 0;   // monotonic secs of last accepted CAN2 frame; drives SLEEP<->AWAKE bus-liveness
     bool m_12v_was_high = false;     // 12V-above-threshold latch: the SLEEP 12V wake fires on the rising edge only
                                      // (level-triggering oscillated; seeded on each sleep entry in TransitionToSleepState)
 
@@ -349,6 +350,7 @@ private:
     void SetAcOpStatus(int v);
     void SetAmbientTemperature(float temperature);
     void SetAwake(bool awake);
+    bool IsBusAlive() const;   // true if a CAN2 frame arrived within BUS_STALE_SECS
     void SetBatteryChargingPower(float power);
     void SetBatteryCurrent(float current);
     void SetBatteryPower(float power);


### PR DESCRIPTION
## Problem

The e-TNGA overloads the standard `v.e.awake` metric ("Vehicle is fully awake
(switched on by the user)") to mean "CAN2 bus has recent traffic": every CAN2 frame
called `SetAwake(true)`, and the metric's ~120 s auto-stale detected "bus dead → sleep".
Because the module stays awake to poll throughout a charge, `v.e.awake` stayed **true for
the entire charge**, so the base framework's idle detector (`vehicle.cpp:1096`) fired
`"Vehicle is idling / stopped turned on"` 15 min in, then hourly — surfaced in Home
Assistant as the car being on/idle while it was just parked and charging.

Observed (logs, night of 2026-07-09→10): AC charge ran 23:00:43 → 06:49:01
(SOC 25%→100%); idle alerts fired at 23:15, 00:18, 01:15, 02:17, 03:16, 04:16, 05:18,
06:18 — entirely inside the charge window. The v2/v3 `CarAwake` bit and `vehicle.awake`
events were likewise asserted throughout the charge.

## Change

Split the two concepts that both lived in `v.e.awake`:

- **CAN2 bus-liveness** (drives `SLEEP↔AWAKE`) moves to an internal `m_last_can2_time`
  member, stamped per accepted CAN2 frame and read via `IsBusAlive()` (`≤120 s` window,
  `ms_m_monotonic` seconds — a faithful port of the old `SM_STALE_MID` auto-stale).
- **`v.e.awake`** is now set centrally in `SetPollState()` as
  `(state == AWAKE || state == DRIVING)`, so it is **false in SLEEP and all four CHARGE_\***
  states — matching the standard "switched on" semantic (and the Ioniq5 pattern of
  `awake = isOn`, charge polled with the car off).

The `SLEEP↔AWAKE` timing is unchanged (same 120 s window and clock; forced-sleep resets
`m_last_can2_time = 0` to preserve the rising-edge-on-forced-sleep behavior that the
`{10,30,60,120,300} s` cooldowns depend on). The only intended runtime change is the value
of `v.e.awake` during a charge.

## Result

No more "Vehicle is idling" notifications while parked and charging; the `CarAwake` bit and
`vehicle.awake` events reflect genuine on-state; `v.e.awake` is no longer redundant with
`v.e.on`. No base-class/framework change.

## Validation

- ✅ Firmware CI build (`build.yml`) green.
- ⏳ **On-vehicle validation pending** (the real behavior gate, cannot be done off-vehicle):
  - Normal parked sleep still enters ~120 s after the bus quiets; passive-CAN and 12 V
    rising-edge wake both still work.
  - A full AC charge shows `v.e.awake == no` throughout, **no** idle notification, and no
    SLEEP↔AWAKE oscillation.
  - CHARGE_WAIT 12 V-drain forced-sleep → resume does not immediately bounce.
  - Driving shows `v.e.awake == yes`.

Design spec and implementation plan included under `docs/superpowers/`.
