### PR TITLE
etnga: derive v.e.charging12v from the 12V rail voltage (fixes #147)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-etnga-12v-charging12v-rail.md
+++ b/docs/superpowers/plans/2026-07-11-etnga-12v-charging12v-rail.md
@@ -1,0 +1,295 @@
+# e-TNGA 12V Reference Fix (#147) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Derive e-TNGA's `v.e.charging12v` from the module's 12V rail voltage instead of the CAN-sourced DC-DC current, so the base class can never latch a DC-DC float voltage (~14.1 V) as the aux battery's *resting* reference.
+
+**Architecture:** A single new `UpdateCharging12v()` runs every second from `OvmsVehicleToyotaETNGA::Ticker1()`, reading `v.b.12v.voltage` (the module's own ADC, `ovms_housekeeping.cpp:90` — the one signal that does not travel over CAN) and applying hysteresis. It becomes the flag's **only** writer; the three existing writers are removed. `OvmsVehicle::VehicleTicker1()` calls the vehicle's `Ticker1()` at `vehicle.cpp:875` and then runs the base 12V monitor at `vehicle.cpp:947`, so the base sees the fresh value in the same tick — no new hook required.
+
+**Tech Stack:** C++ (ESP-IDF 3.3, legacy `make`). Component `vehicle/OVMS.V3/components/vehicle_toyota_etnga`.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-etnga-12v-ref-design.md`
+**Branch:** `fix/etnga-12v-charging12v-rail` (worktree `/home/devuser/wt-etnga-12v-ref`, off `origin/master`)
+
+## Global Constraints
+
+- **No framework changes.** `components/vehicle/vehicle.cpp`, `components/can/`, and `components/powermgmt/` are **not** touched. Every other vehicle keeps today's behaviour. Fork-local, e-TNGA only.
+- **No host test suite exists.** Per CLAUDE.md, firmware compiles only in CI (GitHub Actions) or the devcontainer, and "tests" run on-device. There is no red/green TDD cycle available for this change. The verification gates are (1) the CI `Firmware build` workflow and (2) an on-vehicle drive-and-park cycle. **Do not invent or add host unit tests** — there is no harness to run them.
+- **No `changes.txt` entry.** Per CLAUDE.md, `changes.txt` is for changes users must act on or notice — new features, config changes. This is a plain bug fix requiring no user action and adds no config keys, so per maintainer guidance it is deliberately omitted.
+- **Match the surrounding file style exactly** (4-space indent, brace placement, comment density as found in each file).
+- Thresholds are hardcoded `static const float` file-locals — **not** config keys (YAGNI, and matches the existing `AUX_12V_WAKE_SET_V` pattern).
+
+---
+
+### Task 1: Make the 12V rail voltage the single source of `v.e.charging12v`
+
+This is one atomic change. Splitting "add the new writer" from "remove the old writers" would leave an intermediate commit where both rules fight each other, which is worse than either.
+
+**Files:**
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h:406`
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp:552-559`
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp:235-237`
+- Modify: `vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp:384` and `:414`
+
+**Interfaces:**
+- Produces: `void OvmsVehicleToyotaETNGA::UpdateCharging12v()` — no args, no return. Reads `StandardMetrics.ms_v_bat_12v_voltage`, writes `StandardMetrics.ms_v_env_charging12v`. Called once per second from `Ticker1()`.
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1: Declare the new method in the header**
+
+In `src/vehicle_toyota_etnga.h`, the aux-12V setters are declared together at lines 403-406. Add the new method directly after `SetAux12vFullCharge`:
+
+```cpp
+    void SetAux12vCurrent(float v);
+    void SetAux12vVoltage(float v);
+    void SetAux12vTemperature(float v);
+    void SetAux12vFullCharge(float v);
+    void UpdateCharging12v();
+```
+
+- [ ] **Step 2: Add the constants and the new method, and strip `charging12v` out of `SetAux12vCurrent`**
+
+In `src/etnga_metrics.cpp`, replace this exact block (currently at lines 552-559):
+
+```cpp
+void OvmsVehicleToyotaETNGA::SetAux12vCurrent(float v)
+{
+    StandardMetrics.ms_v_bat_12v_current->SetValue(v);
+    // Positive current = HV->12V DC-DC pushing charge into the aux battery.
+    StandardMetrics.ms_v_env_charging12v->SetValue(v > 0.5f);
+    // Any valid EV-ECU 12V reply means the aux system is energized.
+    StandardMetrics.ms_v_env_aux12v->SetValue(true);
+}
+```
+
+with:
+
+```cpp
+// Aux-12V charge detection comes from the rail voltage (v.b.12v.voltage — the module's own ADC),
+// NOT from the CAN-sourced DC-DC current: the current tapers below any sane threshold while the car
+// is still running and the rail is still held at float, and it is unavailable entirely if the bus
+// drops. A resting lead-acid aux never exceeds ~13V, so a rail above that means the DC-DC is holding
+// it up. Hysteresis stops the flag chattering as the rail decays after shutdown.
+static const float AUX_12V_CHARGING_ON_V  = 13.2f;  // rail above resting -> DC-DC is charging
+static const float AUX_12V_CHARGING_OFF_V = 12.9f;  // rail back at rest  -> not charging
+
+void OvmsVehicleToyotaETNGA::UpdateCharging12v()
+{
+    float v = StandardMetrics.ms_v_bat_12v_voltage->AsFloat();
+    if (v <= 0.0f)  // ADC not ready yet
+        return;
+
+    bool charging = StandardMetrics.ms_v_env_charging12v->AsBool();
+    if (!charging && v > AUX_12V_CHARGING_ON_V)
+        charging = true;
+    else if (charging && v < AUX_12V_CHARGING_OFF_V)
+        charging = false;
+
+    StandardMetrics.ms_v_env_charging12v->SetValue(charging);
+}
+
+void OvmsVehicleToyotaETNGA::SetAux12vCurrent(float v)
+{
+    StandardMetrics.ms_v_bat_12v_current->SetValue(v);
+    // Any valid EV-ECU 12V reply means the aux system is energized.
+    StandardMetrics.ms_v_env_aux12v->SetValue(true);
+}
+```
+
+Note the `v > 0.0f` guard: `HousekeepingUpdate12V()` (`main/ovms_housekeeping.cpp:96`) writes `0` when the ADC reads below 1.0 V, so a zero means "no reading", not "flat battery". Returning early leaves the flag at its last value rather than forcing it false.
+
+- [ ] **Step 3: Call it from `Ticker1()`**
+
+In `src/vehicle_toyota_etnga.cpp`, `Ticker1()` begins at line 235. Insert the call as the first statement:
+
+```cpp
+void OvmsVehicleToyotaETNGA::Ticker1(uint32_t ticker)
+{
+    // Aux-12V charge state is derived from the rail voltage every tick, independent of CAN and poll
+    // state. The base 12V monitor in VehicleTicker1() samples v.b.12v.voltage.ref from this flag
+    // later in the same tick, so it must be fresh before that runs.
+    UpdateCharging12v();
+
+    if (StandardMetrics.ms_v_charge_inprogress->AsBool()) {
+```
+
+(The existing `if (StandardMetrics.ms_v_charge_inprogress->AsBool())` block and everything after it is unchanged.)
+
+- [ ] **Step 4: Remove the two poll-state writers**
+
+In `src/etnga_poll_states.cpp`, this exact three-line sequence appears **twice** — once in the transition to SLEEP (line ~384) and once in the transition to AWAKE (line ~414):
+
+```cpp
+    StandardMetrics.ms_v_bat_12v_current->Clear();
+    StandardMetrics.ms_v_env_charging12v->SetValue(false);
+    StandardMetrics.ms_v_env_aux12v->SetValue(false);
+```
+
+Replace **both** occurrences with:
+
+```cpp
+    StandardMetrics.ms_v_bat_12v_current->Clear();
+    StandardMetrics.ms_v_env_aux12v->SetValue(false);
+```
+
+Use `replace_all` — the blocks are byte-identical. Leave the preceding comment ("12V aux metrics come only from the EV ECU…") and every other line in both blocks untouched; it still correctly describes the remaining PID-sourced metrics.
+
+These two writes are not merely redundant under the new rule, they are **actively wrong**: entering AWAKE while the car is running at 14 V would force the flag false and re-open the bug.
+
+- [ ] **Step 5: Verify no `charging12v` writers remain outside `UpdateCharging12v()`**
+
+Run:
+
+```bash
+cd /home/devuser/wt-etnga-12v-ref
+grep -rn "ms_v_env_charging12v" vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/
+```
+
+Expected: exactly **two** hits, both inside `UpdateCharging12v()` in `etnga_metrics.cpp` (one `AsBool()` read, one `SetValue()` write). Any hit in `etnga_poll_states.cpp`, or inside `SetAux12vCurrent`, means a step was missed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/devuser/wt-etnga-12v-ref
+git add vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h \
+        vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp \
+        vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp \
+        vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+git commit -m "etnga: derive v.e.charging12v from the 12V rail voltage, not DC-DC current
+
+The base class samples v.b.12v.voltage.ref when its calmdown ticker
+expires, assuming charging12v==false means the rail is at rest. e-TNGA
+set charging12v from the CAN-sourced DC-DC current (>0.5A), which goes
+false while the car is still running and the rail is still held at ~14.1V
+float — and cannot be true at all if the CAN bus drops. Either way the
+'resting' reference latched at float voltage, so a healthy 12.27V battery
+read as critical and powermgmt armed a 30-minute auto-DeepSleep.
+
+Derive the flag from v.b.12v.voltage (the module's own ADC) with
+hysteresis instead. It stays truthful through both a current taper and a
+CAN outage, and makes UpdateCharging12v() the flag's single writer.
+
+Fixes #147"
+```
+
+---
+
+### Task 2: Prove it compiles (CI is the only build gate)
+
+Firmware does not build on this host. CI is the build.
+
+**Files:** none (CI only).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/devuser/wt-etnga-12v-ref
+git push -u origin fix/etnga-12v-charging12v-rail
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --repo kezarjg/Open-Vehicle-Monitoring-System-3 \
+  --base master --head fix/etnga-12v-charging12v-rail \
+  --title "etnga: derive v.e.charging12v from the 12V rail voltage (fixes #147)" \
+  --body "Fixes #147. Design: \`docs/superpowers/specs/2026-07-11-etnga-12v-ref-design.md\`
+
+The base class samples \`v.b.12v.voltage.ref\` when its calmdown ticker expires, assuming \`charging12v == false\` implies the rail is at rest (\`vehicle.cpp:947-961\`). e-TNGA derived that flag from the CAN-sourced DC-DC current (\`> 0.5A\`, \`etnga_metrics.cpp:556\`), which:
+
+1. goes false mid-drive as the current tapers, while the rail is still held at ~14.1V float; and
+2. cannot be true at all if the CAN bus drops (which is what happened on 2026-07-11 — see #148).
+
+Either route latches the reference at float voltage (14.09V observed), so a healthy 12.27V resting battery trips \`12V Battery critical\` and powermgmt arms a 30-minute auto-DeepSleep.
+
+This derives the flag from \`v.b.12v.voltage\` — the module's own ADC, the one signal that doesn't travel over CAN — with 13.2V/12.9V hysteresis, and makes \`UpdateCharging12v()\` its single writer. No framework changes; e-TNGA only.
+
+The corrupted persisted reference self-heals on the first drive-and-park cycle after this ships.
+
+On-vehicle validation pending."
+```
+
+- [ ] **Step 3: Wait for CI and confirm the firmware build passed**
+
+```bash
+gh run list --repo kezarjg/Open-Vehicle-Monitoring-System-3 \
+  --branch fix/etnga-12v-charging12v-rail --limit 5 \
+  --json workflowName,status,conclusion,headSha
+```
+
+Expected: `Firmware build` with `"conclusion": "success"`.
+
+Note per CLAUDE.md: `Docs build` runs here too (this branch touches `docs/**`), and its Pages `deploy` job is **skipped on PRs** by design — that is not a failure. Only `Firmware build` gates this change. If `Firmware build` fails, read the log (`gh run view <run-id> --log-failed`), fix, and re-push — do not proceed to Task 3 on a red build.
+
+---
+
+### Task 3: On-vehicle validation (the real gate)
+
+This is the only test that can actually prove the fix. It requires a drive-and-park cycle on the physical car.
+
+**Files:** none.
+
+- [ ] **Step 1: Flash the CI build to the module**
+
+Follow `CLAUDE.local.md`. The CI binary lands in MinIO at `ci-artifacts/<run_id>/ovms3/ovms3.bin` (**not** GitHub artifacts). Serve it from `os-k3s` and flash with `ota flash http`, minding the slot-stick rule (`ota flash http` writes the **inactive** slot; the launcher autostarts `default_slot` = `ota_1`).
+
+- [ ] **Step 2: Record the pre-drive baseline**
+
+```bash
+ssh solterra-ovms 'metrics list v.b.12v.voltage'
+```
+
+Record `v.b.12v.voltage`, `.ref`, and `.alert`. (The reference was manually set to 12.6 V on 2026-07-11; the point of this test is that it stays sane on its own.)
+
+- [ ] **Step 3: Drive, then park**
+
+During the drive, `v.e.charging12v` must be **`yes` continuously**:
+
+```bash
+ssh solterra-ovms 'metrics list v.e.charging12v'
+```
+
+- [ ] **Step 4: Check the log for the flapping signature**
+
+Pull the log (use the `ovms-log-pull` skill) and grep:
+
+```bash
+grep -cE "Charging 12V battery|No longer charging 12V battery" ~/ovms-logs/log.txt
+```
+
+Expected: **no rapid alternating pairs during the drive.** Before the fix these appeared every 11–22 seconds. One transition on power-up and one on shutdown is correct and expected; a burst of them is the bug.
+
+- [ ] **Step 5: Confirm the reference lands at resting voltage**
+
+After parking, wait for the calmdown to expire (up to 15 minutes), then:
+
+```bash
+ssh solterra-ovms 'metrics list v.b.12v.voltage'
+```
+
+Expected:
+- `v.b.12v.voltage.ref` ≈ **12.3–12.7 V** (resting) — **not** ~14 V.
+- `v.b.12v.voltage.alert` = **no**.
+- No `12V Battery critical` notification, and no `powermgmt: 12V battery alert detected` in the log.
+
+- [ ] **Step 6: Regression check — the 12V wake trigger still works**
+
+The wake trigger fires on `v12 > ref + 0.2` (`etnga_poll_states.cpp:76`), so a sane reference should restore it. On the next power-on, the log should show:
+
+```
+v-toyota-etnga: Aux 12V has exceeded the threshold
+```
+
+- [ ] **Step 7: Record the result on #147 and merge**
+
+Post the observed `ref`, `alert`, and the flapping-grep count as a comment on #147. **Only merge once the on-vehicle numbers are in** — per CLAUDE.md, do not claim behaviour that hasn't been verified on real hardware.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every section of the spec maps to a task. The rule and hysteresis constants → Task 1 Step 2. Ordering (Ticker1 before the base monitor) → Task 1 Step 3. Single-owner table (all three writers) → Task 1 Steps 2, 4, verified in Step 5. Verification (CI + on-vehicle drive-and-park, plus the wake-trigger regression check) → Tasks 2 and 3. Out-of-scope items (base class, wake trigger, #148) → Global Constraints. Self-healing reference → asserted in the PR body and measured in Task 3 Step 5.
+
+**Placeholder scan:** No TBDs. Every code step contains the complete literal code. No "add error handling" hand-waving — the only guard (`v <= 0.0f`) is spelled out with its reason.
+
+**Type consistency:** `UpdateCharging12v()` is declared `void`, no args, in Task 1 Step 1 and defined identically in Step 2; called with no args in Step 3. Constants `AUX_12V_CHARGING_ON_V` / `AUX_12V_CHARGING_OFF_V` are named identically in the definition and both uses.

--- a/docs/superpowers/specs/2026-07-11-etnga-12v-ref-design.md
+++ b/docs/superpowers/specs/2026-07-11-etnga-12v-ref-design.md
@@ -1,0 +1,162 @@
+# e-TNGA: derive `v.e.charging12v` from the 12V rail voltage
+
+**Issue:** [#147](https://github.com/kezarjg/Open-Vehicle-Monitoring-System-3/issues/147)
+**Date:** 2026-07-11
+**Scope:** `components/vehicle_toyota_etnga` only — fork-local, no framework changes.
+
+## Problem
+
+A healthy 12V aux battery raises a false `12V Battery critical` alert, and because the alert cannot
+self-clear, `powermgmt` deep-sleeps the module 30 minutes later. Observed on the live Solterra
+2026-07-11; the module was ~10 minutes from going dark.
+
+The battery is fine. The *reference* it is measured against is wrong:
+
+| metric | value |
+|---|---|
+| `v.b.12v.voltage` | 12.27 V — a normal resting aux battery |
+| `v.b.12v.voltage.ref` | **14.09 V** — a DC-DC *float* voltage, not a resting one |
+| `v.b.12v.voltage.alert` | yes (latched) |
+
+`vehicle.cpp:975` alerts when `max(ref, 12.6) − volt > 1.6`. With the bogus reference,
+`14.09 − 12.27 = 1.82` → fires. Against a correct 12.6 V reference it would be `0.33` — nowhere near.
+
+### Root cause
+
+The base class samples the reference when its "calmdown" ticker expires (`vehicle.cpp:947-961`). The
+ticker accumulates while `v.e.charging12v` is true and drains when it is false; on reaching zero it
+takes `ref = current 12V voltage`. **The design assumes `charging12v == false` implies the rail is at
+rest.**
+
+e-TNGA breaks that assumption (`etnga_metrics.cpp:556`):
+
+```cpp
+StandardMetrics.ms_v_env_charging12v->SetValue(v > 0.5f);   // v = DC-DC current, from CAN
+```
+
+Two independent routes to a bad reference follow:
+
+1. **Current taper.** Once the aux battery tops up mid-drive, DC-DC current falls below 0.5 A *while
+   the rail is still held at ~14.1 V*. The flag flaps false/true every 11–22 s (visible in the log as
+   rapid `Charging 12V battery..` / `No longer charging..` pairs), which can drain the ticker to zero
+   mid-drive → the reference is sampled at float voltage.
+
+2. **CAN outage (what actually happened).** `charging12v` is CAN-derived. On 2026-07-11 the MCP2515 was
+   left deaf for an entire drive (#148), so the flag could never become true while the car ran at
+   14.1 V. The ticker sat at zero and the reference was sampled at float voltage.
+
+The corruption is self-reinforcing: the 12V wake trigger (`etnga_poll_states.cpp:76`) fires on
+`v12 > ref + 0.2`. With `ref = 14.09` that needs >14.29 V — essentially never — so a bad reference also
+disables the fallback that is supposed to wake the module and reset CAN when the bus is dead.
+
+## Key insight
+
+`v.b.12v.voltage` is read from the **module's own ADC** (`ovms_housekeeping.cpp:90`,
+`MyPeripherals->m_esp32adc->read()`). It is the one signal in this system that does **not** come over
+CAN, so it stays truthful when the bus dies. `v.e.charging12v` and `v.e.on` are both CAN-derived and go
+silently false in exactly the situation we must survive.
+
+Therefore the flag should be derived from the rail voltage, not from a CAN-sourced current.
+
+## Design
+
+### The rule
+
+A resting lead-acid aux battery never exceeds ~13 V. Anything higher means something — the DC-DC — is
+holding it up. So: *the rail being above resting **is** the definition of "charging".*
+
+New method, called at the top of `OvmsVehicleToyotaETNGA::Ticker1()`:
+
+```cpp
+static const float AUX_12V_CHARGING_ON_V  = 13.2f;  // rail above resting -> DC-DC is charging
+static const float AUX_12V_CHARGING_OFF_V = 12.9f;  // rail back at rest  -> not charging
+
+void OvmsVehicleToyotaETNGA::UpdateCharging12v()
+{
+    float v = StandardMetrics.ms_v_bat_12v_voltage->AsFloat();
+    if (v <= 0.0f)  // ADC not ready yet
+        return;
+    bool charging = StandardMetrics.ms_v_env_charging12v->AsBool();
+    if (!charging && v > AUX_12V_CHARGING_ON_V)
+        charging = true;
+    else if (charging && v < AUX_12V_CHARGING_OFF_V)
+        charging = false;
+    StandardMetrics.ms_v_env_charging12v->SetValue(charging);
+}
+```
+
+It runs every second regardless of poll state, CAN health, or whether the vehicle is awake — which is
+the entire point.
+
+### Ordering
+
+`OvmsVehicle::VehicleTicker1()` calls the virtual `Ticker1()` at `vehicle.cpp:875` and then runs the
+base 12V monitor at `vehicle.cpp:947`, in the same tick. Updating the flag inside e-TNGA's `Ticker1()`
+means the base monitor sees the fresh value immediately. No new hook is required.
+
+### Single owner
+
+`charging12v` currently has three writers. After this change the `Ticker1` rule is its only owner:
+
+| Site | Change |
+|---|---|
+| `etnga_metrics.cpp:556` (`SetAux12vCurrent`) | Stop setting `charging12v`. Keep setting `v.b.12v.current` and `v.e.aux12v`. |
+| `etnga_poll_states.cpp:384` (→ SLEEP) | Stop setting `charging12v` false. Keep clearing the PID-sourced metrics (`v.b.12v.current`, `v.e.aux12v`, PID voltage/temp). |
+| `etnga_poll_states.cpp:414` (→ AWAKE) | Same as above. |
+
+The two transition-handler writes are not merely redundant under the new rule, they are **actively
+wrong**: entering AWAKE while the car is running at 14 V would force the flag false and re-open the bug.
+
+### Thresholds
+
+Hardcoded constants next to the existing `AUX_12V_WAKE_SET_V` / `AUX_12V_WAKE_CLEAR_V`, matching the
+file's style. Not configuration — YAGNI. 13.2 / 12.9 V sits comfortably between a fully-charged resting
+lead-acid (~12.6–12.8 V) and DC-DC float (~14.0–14.4 V); the 0.3 V hysteresis prevents chatter as the
+rail decays after shutdown.
+
+## Behaviour after the fix
+
+| Situation | Rail (ADC) | `charging12v` | Reference sampled? |
+|---|---|---|---|
+| Driving, DC-DC current tapered below 0.5 A | ~14.1 V | **true** | No — ticker stays charged |
+| Driving, **CAN bus dead** | ~14.1 V | **true** | No — ADC is unaffected by CAN |
+| AC/DC HV charging (DC-DC also charges aux) | ~14 V | true | No |
+| Parked, car off | ~12.3 V | false | Yes — at genuine resting voltage ✅ |
+
+The currently-corrupted persisted reference **self-heals** on the first drive-and-park cycle after this
+ships: `charging12v` goes true during the drive, charging the calmdown ticker; on parking it drains and
+the base re-samples `ref` at true resting voltage, overwriting 14.09 V.
+
+Fixing `ref` also restores the 12V wake trigger, which the bad reference had disabled.
+
+## Out of scope (deliberate)
+
+- **Base-class `vehicle.cpp` reference logic is untouched.** Every other vehicle keeps its current
+  behaviour. Hardening the base so *no* vehicle can latch a charging voltage as a resting reference is a
+  real and separate improvement, but it is a framework change and belongs in its own upstream PR.
+- **The 12V wake trigger's dependence on `ref`** (`etnga_poll_states.cpp:76`) is left as-is. It works
+  correctly once `ref` is sane; decoupling it is a separate change.
+- **#148** (the MCP2515 failure that caused the CAN outage) is tracked separately. This fix makes the
+  12V reference survive such an outage; it does not prevent one.
+
+## Verification
+
+There is no host test suite; firmware compiles in CI and behaviour is validated on the vehicle.
+
+1. **CI:** `Firmware build` green on the PR.
+2. **On-vehicle, one drive-and-park cycle:**
+   - During the drive: `v.e.charging12v` is `yes` continuously, and the log shows **no**
+     `Charging 12V battery..` / `No longer charging 12V battery..` flapping.
+   - After parking and the calmdown expiry: `v.b.12v.voltage.ref` lands at resting voltage
+     (~12.3–12.7 V), **not** ~14 V.
+   - `v.b.12v.voltage.alert` remains `no`.
+   - No `12V Battery critical` notification; no `powermgmt: 12V battery alert detected` in the log.
+3. **Regression check:** the module still wakes on the 12V trigger
+   (`Aux 12V has exceeded the threshold`) when the car powers on.
+
+## Note on the interim workaround
+
+The live module's reference was manually corrected to 12.6 V on 2026-07-11
+(`metrics set v.b.12v.voltage.ref 12.6`), which cleared the latched alert and cancelled the pending
+deep-sleep. That is a one-off repair of the *value*, not the bug; without this fix the reference can
+re-corrupt on any drive.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -564,7 +564,14 @@ void OvmsVehicleToyotaETNGA::UpdateCharging12v()
         return;
 
     bool charging = StandardMetrics.ms_v_env_charging12v->AsBool();
-    if (!charging && v > AUX_12V_CHARGING_ON_V)
+    if (!m_charging12v_seeded) {
+        // The metric is persistent (survives a warm reboot), and the hysteresis below uses its
+        // previous value as the latch. A stale 'true' would stick while the rail sits in the
+        // 12.9-13.2V band, so seed the latch from the rail itself rather than trusting it.
+        charging = (v > AUX_12V_CHARGING_ON_V);
+        m_charging12v_seeded = true;
+    }
+    else if (!charging && v > AUX_12V_CHARGING_ON_V)
         charging = true;
     else if (charging && v < AUX_12V_CHARGING_OFF_V)
         charging = false;

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -549,11 +549,32 @@ void OvmsVehicleToyotaETNGA::DecodeAux12vIntegrators(const std::string& data)
     m_v_bat_12v_readyon_h->SetValue(static_cast<float>(GetRxBUint16(data, 10)));
 }
 
+// Aux-12V charge detection comes from the rail voltage (v.b.12v.voltage — the module's own ADC),
+// NOT from the CAN-sourced DC-DC current: the current tapers below any sane threshold while the car
+// is still running and the rail is still held at float, and it is unavailable entirely if the bus
+// drops. A resting lead-acid aux never exceeds ~13V, so a rail above that means the DC-DC is holding
+// it up. Hysteresis stops the flag chattering as the rail decays after shutdown.
+static const float AUX_12V_CHARGING_ON_V  = 13.2f;  // rail above resting -> DC-DC is charging
+static const float AUX_12V_CHARGING_OFF_V = 12.9f;  // rail back at rest  -> not charging
+
+void OvmsVehicleToyotaETNGA::UpdateCharging12v()
+{
+    float v = StandardMetrics.ms_v_bat_12v_voltage->AsFloat();
+    if (v <= 0.0f)  // ADC not ready yet
+        return;
+
+    bool charging = StandardMetrics.ms_v_env_charging12v->AsBool();
+    if (!charging && v > AUX_12V_CHARGING_ON_V)
+        charging = true;
+    else if (charging && v < AUX_12V_CHARGING_OFF_V)
+        charging = false;
+
+    StandardMetrics.ms_v_env_charging12v->SetValue(charging);
+}
+
 void OvmsVehicleToyotaETNGA::SetAux12vCurrent(float v)
 {
     StandardMetrics.ms_v_bat_12v_current->SetValue(v);
-    // Positive current = HV->12V DC-DC pushing charge into the aux battery.
-    StandardMetrics.ms_v_env_charging12v->SetValue(v > 0.5f);
     // Any valid EV-ECU 12V reply means the aux system is energized.
     StandardMetrics.ms_v_env_aux12v->SetValue(true);
 }

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -381,7 +381,6 @@ void OvmsVehicleToyotaETNGA::TransitionToSleepState()
     // 12V aux metrics come only from the EV ECU (answers in READY/charging); clear the
     // PID-sourced values when leaving those states so stale readings aren't shown while off.
     StandardMetrics.ms_v_bat_12v_current->Clear();
-    StandardMetrics.ms_v_env_charging12v->SetValue(false);
     StandardMetrics.ms_v_env_aux12v->SetValue(false);
     m_v_bat_12v_voltage_pid->Clear();
     m_v_bat_12v_temp->Clear();
@@ -411,7 +410,6 @@ void OvmsVehicleToyotaETNGA::TransitionToAwakeState()
     // 12V aux metrics come only from the EV ECU (answers in READY/charging); clear the
     // PID-sourced values when leaving those states so stale readings aren't shown while off.
     StandardMetrics.ms_v_bat_12v_current->Clear();
-    StandardMetrics.ms_v_env_charging12v->SetValue(false);
     StandardMetrics.ms_v_env_aux12v->SetValue(false);
     m_v_bat_12v_voltage_pid->Clear();
     m_v_bat_12v_temp->Clear();

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -234,6 +234,10 @@ void OvmsVehicleToyotaETNGA::NotifyVehicleOn()
 
 void OvmsVehicleToyotaETNGA::Ticker1(uint32_t ticker)
 {
+    // Aux-12V charge state is derived from the rail voltage every tick, independent of CAN and poll
+    // state. The base 12V monitor in VehicleTicker1() samples v.b.12v.voltage.ref from this flag
+    // later in the same tick, so it must be fresh before that runs.
+    UpdateCharging12v();
 
     if (StandardMetrics.ms_v_charge_inprogress->AsBool()) {
         ESP_LOGV(CHARGING_TAG, "%.0f, %.2f, %.4f, %.0f, %.2f, %.2f, %.2f, %.2f, %.0f, %.2f, %.4f",

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -78,6 +78,7 @@ protected:
     int m_sleep_backoff_idx = 0;     // Index into SLEEP_COOLDOWN_SECS; escalates on consecutive no-activity sleeps
     bool m_12v_was_high = false;     // 12V-above-threshold latch: the SLEEP 12V wake fires on the rising edge only
                                      // (level-triggering oscillated; seeded on each sleep entry in TransitionToSleepState)
+    bool m_charging12v_seeded = false;  // v.e.charging12v persists across warm reboots: seed the latch from the rail on the first tick
 
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
     int  m_cable_watch_start = 0;      // monotonic s when armed (15-min cable watch)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -404,6 +404,7 @@ private:
     void SetAux12vVoltage(float v);
     void SetAux12vTemperature(float v);
     void SetAux12vFullCharge(float v);
+    void UpdateCharging12v();
     void DecodeAux12vIntegrators(const std::string& data);
 
     // const char* throughout: these run on every poll reply, and std::string


### PR DESCRIPTION
Fixes #147. Design: `docs/superpowers/specs/2026-07-11-etnga-12v-ref-design.md`

The base class samples `v.b.12v.voltage.ref` when its calmdown ticker expires, assuming `charging12v == false` implies the rail is at rest (`vehicle.cpp:947-961`). e-TNGA derived that flag from the CAN-sourced DC-DC current (`> 0.5A`, `etnga_metrics.cpp:556`), which:

1. goes false mid-drive as the current tapers, while the rail is still held at ~14.1V float; and
2. cannot be true at all if the CAN bus drops (which is what happened on 2026-07-11 — see #148).

Either route latches the reference at float voltage (14.09V observed), so a healthy 12.27V resting battery trips `12V Battery critical` and powermgmt arms a 30-minute auto-DeepSleep.

This derives the flag from `v.b.12v.voltage` — the module's own ADC, the one signal that doesn't travel over CAN — with 13.2V/12.9V hysteresis, and makes `UpdateCharging12v()` its single writer. No framework changes; e-TNGA only.

The corrupted persisted reference self-heals on the first drive-and-park cycle after this ships.

On-vehicle validation pending.