### PR TITLE
etnga: make v.e.charging12v a union, not a voltage-only rule (fixes #153)

### DIFF
--- a/docs/superpowers/specs/2026-07-11-etnga-12v-ref-design.md
+++ b/docs/superpowers/specs/2026-07-11-etnga-12v-ref-design.md
@@ -120,8 +120,25 @@ rail decays after shutdown.
 |---|---|---|---|
 | Driving, DC-DC current tapered below 0.5 A | ~14.1 V | **true** | No — ticker stays charged |
 | Driving, **CAN bus dead** | ~14.1 V | **true** | No — ADC is unaffected by CAN |
-| AC/DC HV charging (DC-DC also charges aux) | ~14 V | true | No |
+| AC/DC HV charging (DC-DC also charges aux) | ~14 V | true | No | ← **WRONG, see below** |
 | Parked, car off | ~12.3 V | false | Yes — at genuine resting voltage ✅ |
+
+> **Correction (2026-07-12, measured on the car — issue #153).** Two rows of the table above are wrong,
+> and the error is the same in both: this design assumed the rail cleanly separates "charging" from
+> "resting". It does not.
+>
+> - **HV charging is NOT ~14 V.** The DC-DC floats the aux battery at only **~12.85 V** (current
+>   +2.64 A tapering to +0.64 A, positive throughout a 3 h charge) — *below* `AUX_12V_CHARGING_OFF_V`.
+>   So `charging12v` reads **false** for an entire charge while the battery is demonstrably being charged.
+> - **Driving is not a steady float either.** The DC-DC modulates; the rail was measured at **12.86 V**
+>   mid-drive, which makes the flag flap.
+>
+> Note 12.86 V occurs while HV-charging *and* while driving, and both sit inside a healthy battery's
+> resting band (12.6–12.8 V) — so **no pair of voltage thresholds can separate these states.**
+> The fix is a union (rail ∥ `v.e.on` ∥ CHARGE_AC/CHARGE_DC), not a retune.
+>
+> The safety invariant this spec relies on is unaffected: `ref` is still only ever sampled while
+> `charging12v` is false, so it can never latch a charging voltage.
 
 The currently-corrupted persisted reference **self-heals** on the first drive-and-park cycle after this
 ships: `charging12v` goes true during the drive, charging the calmdown ticker; on parking it drains and

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -548,29 +548,33 @@ void OvmsVehicleToyotaETNGA::DecodeAux12vIntegrators(const std::string& data)
 // is still running and the rail is still held at float, and it is unavailable entirely if the bus
 // drops. A resting lead-acid aux never exceeds ~13V, so a rail above that means the DC-DC is holding
 // it up. Hysteresis stops the flag chattering as the rail decays after shutdown.
+// The rail voltage alone cannot tell "charging" from "resting" on this vehicle, so it is only one
+// term of a union (see issue #153). Measured on the car: the DC-DC floats the aux battery at just
+// ~12.85V during an HV charge (below OFF), it dips to ~12.86V mid-drive, and a healthy resting
+// battery sits at 12.6-12.8V -- the bands overlap, so no pair of thresholds separates them.
+// The rail term is kept because it is the only CAN-independent one: it alone must carry a CAN
+// outage, which is exactly what the old CAN-derived rule failed to do (#147).
 static const float AUX_12V_CHARGING_ON_V  = 13.2f;  // rail above resting -> DC-DC is charging
 static const float AUX_12V_CHARGING_OFF_V = 12.9f;  // rail back at rest  -> not charging
 
 void OvmsVehicleToyotaETNGA::UpdateCharging12v()
 {
     float v = StandardMetrics.ms_v_bat_12v_voltage->AsFloat();
-    if (v <= 0.0f)  // ADC not ready yet
-        return;
-
-    bool charging = StandardMetrics.ms_v_env_charging12v->AsBool();
-    if (!m_charging12v_seeded) {
-        // The metric is persistent (survives a warm reboot), and the hysteresis below uses its
-        // previous value as the latch. A stale 'true' would stick while the rail sits in the
-        // 12.9-13.2V band, so seed the latch from the rail itself rather than trusting it.
-        charging = (v > AUX_12V_CHARGING_ON_V);
-        m_charging12v_seeded = true;
+    if (v > 0.0f) {  // 0 = ADC not ready yet: hold the latch rather than clearing it
+        if (v > AUX_12V_CHARGING_ON_V)
+            m_rail_charging12v = true;
+        else if (v < AUX_12V_CHARGING_OFF_V)
+            m_rail_charging12v = false;
     }
-    else if (!charging && v > AUX_12V_CHARGING_ON_V)
-        charging = true;
-    else if (charging && v < AUX_12V_CHARGING_OFF_V)
-        charging = false;
 
-    StandardMetrics.ms_v_env_charging12v->SetValue(charging);
+    // CHARGE_WAIT and CHARGE_HANDSHAKE are deliberately excluded: the DC-DC is off in those states
+    // and the module drains the aux battery (the rail measurably declines from plug-in until the
+    // charge actually starts), so calling them "charging" would mask that.
+    bool hv_charging = (static_cast<PollState>(m_poll_state) == PollState::CHARGE_AC ||
+                        static_cast<PollState>(m_poll_state) == PollState::CHARGE_DC);
+
+    StandardMetrics.ms_v_env_charging12v->SetValue(
+        m_rail_charging12v || StandardMetrics.ms_v_env_on->AsBool() || hv_charging);
 }
 
 void OvmsVehicleToyotaETNGA::SetAux12vCurrent(float v)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -79,7 +79,7 @@ protected:
     uint32_t m_last_can2_time = 0;   // monotonic secs of last accepted CAN2 frame; drives SLEEP<->AWAKE bus-liveness
     bool m_12v_was_high = false;     // 12V-above-threshold latch: the SLEEP 12V wake fires on the rising edge only
                                      // (level-triggering oscillated; seeded on each sleep entry in TransitionToSleepState)
-    bool m_charging12v_seeded = false;  // v.e.charging12v persists across warm reboots: seed the latch from the rail on the first tick
+    bool m_rail_charging12v = false;    // rail-voltage term of v.e.charging12v; own (non-persistent) latch, so the union's other terms cannot pollute the hysteresis
 
     bool m_armed_for_charge = false;   // charge lid seen open since entering AWAKE
     int  m_cable_watch_start = 0;      // monotonic s when armed (15-min cable watch)


### PR DESCRIPTION
Fixes #153. Follow-up to #152 (which fixed #147).

## The problem: voltage cannot separate the states

Recovered a 24 h / 1-min trace of the 12V rail and current from the **auxbatmon** plugin
(`/store/usr/auxbatmon.cbor`, fetched via `GET /api/file`, decoded offline). Alignment validated
against known events (the drive, and the `ref` 12.37→12.26 flip at 18:04:50).

| condition | rail (module ADC) | `v.b.12v.current` (0x15F7) |
|---|---|---|
| parked, resting | 12.16–12.24 V | not polled |
| **HV charging (CHARGE_AC)** | **12.82–12.86 V** | **+2.64 A → +0.64 A, positive in all 178 samples** |
| driving, DC-DC hard | 14.09 V | +23.7 A |
| **driving, DC-DC dip** | **12.86 V** | −0.80 A |

Two bugs, one root cause:

1. **The DC-DC floats the aux battery at only ~12.85 V during an HV charge** — *below* the 12.9 V OFF
   threshold. `v.e.charging12v` read **false for an entire 3-hour charge** while the battery was
   demonstrably being charged (rail steps 12.16 → 12.82 V the instant CHARGE_AC begins).
2. **The rail dips to 12.86 V mid-drive** (the DC-DC modulates), which made the flag flap — the
   original report on #153.

**12.86 V therefore means both "charging" and "driving"**, and both sit inside a healthy lead-acid's
resting band (12.6–12.8 V). This battery only rests at 12.2 V because it is weak, so a lower threshold
would work here and then fail on a good battery by latching `charging12v` true while parked — blocking
reference sampling entirely, which is *worse* than the bug. **No pair of voltage thresholds separates
these states; retuning is not a fix.**

## The fix

```cpp
charging = rail_hysteresis(13.2 / 12.9)          // CAN-independent -- alone must survive a bus outage
        || StdMetrics.ms_v_env_on->AsBool()       // driving (covers the dips)
        || (state == CHARGE_AC || state == CHARGE_DC);  // HV charging -- the ~12.85 V float
```

The added terms are CAN-derived, so they are **additive only**: the rail term alone still carries a CAN
outage. That is the property the old `current > 0.5 A` rule lacked, and it is why #147 happened.

- `CHARGE_WAIT` / `CHARGE_HANDSHAKE` are **excluded** — the rail measurably *declines* (12.24 → 12.16 V)
  from plug-in until the charge starts, i.e. the DC-DC is off and the module is draining the aux
  battery. Marking those "charging" would mask #118.
- A current-based term (`v.b.12v.current > 0.2 A`) was rejected: the taper (2.64 → 0.64 A and still
  falling) would eventually cross any fixed threshold and re-introduce flapping — exactly how the
  original rule failed.
- The rail term gets its **own non-persistent latch** so the union's other terms cannot pollute its
  hysteresis. That also removes the persistent-metric seeding: a `bool` starting `false` only becomes
  true when the rail exceeds ON, which *is* the seed rule.

## Safety

The invariant from #152 is preserved and **tightened**: `ref` is sampled only while `charging12v` is
false, which now *additionally* requires the car to be off and not HV-charging. The ~14 V latch that
caused #147 remains structurally impossible. The flag also cannot stick `true` while parked (rail falls
below 12.9 V, `v.e.on` false, state not CHARGE_*), so the reference still refreshes.

## Validation

- [ ] CI green
- [ ] On-vehicle: during an AC charge, `v.e.charging12v` = `yes` (was `no`); no `12V Battery critical`;
      `v.b.12v.voltage.ref` still lands at resting voltage after a drive-and-park.
- [ ] On-vehicle: no `Charging 12V battery..` / `No longer charging..` flapping during a drive.