### PR TITLE
[CI] console: Mongoose console base-class refactor (upstream #1424)

### DIFF
--- a/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
+++ b/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
@@ -96,15 +96,7 @@ void OvmsSSH::EventHandler(struct mg_connection *nc, int ev, void *p)
 
     case MG_EV_POLL:
       {
-      // Reap consoles whose follow task has exited (GetFollowModeTask() now NULL).
-      for (auto it = m_reaping.begin(); it != m_reaping.end(); )
-        {
-        ConsoleSSH* z = *it;
-        if (z->GetFollowModeTask() == NULL)
-          { delete z; it = m_reaping.erase(it); }
-        else
-          ++it;
-        }
+      ReapConsoles();
       //ESP_EARLY_LOGV(tag, "Event MG_EV_ACCEPT conn %p, data %p", nc, p);
       ConsoleSSH* child = (ConsoleSSH*)nc->user_data;
       if (child)
@@ -154,20 +146,7 @@ void OvmsSSH::EventHandler(struct mg_connection *nc, int ev, void *p)
       ESP_EARLY_LOGV(tag, "Event MG_EV_CLOSE conn %p, data %p", nc, p);
       ConsoleSSH* child = (ConsoleSSH*)nc->user_data;
       if (child)
-        {
-        OvmsCommandTask* ft = child->GetFollowModeTask();
-        if (ft)
-          {
-          // Follow task still running: we cannot join here (we hold the Mongoose
-          // lock its write() needs). Mark closing so its in-flight write bails,
-          // ask it to stop, and defer delete until it has left the write path.
-          child->SetClosing();
-          ft->RequestStop();
-          m_reaping.push_back(child);
-          }
-        else
-          delete child;   // no follow task: synchronous termination + free (unchanged)
-        }
+        CloseConsole(child);
       nc->user_data = NULL;
       }
       break;
@@ -331,14 +310,13 @@ int RecvCallback(WOLFSSH* ssh, void* data, word32 size, void* ctx);
 int SendCallback(WOLFSSH* ssh, void* data, word32 size, void* ctx);
 
 ConsoleSSH::ConsoleSSH(OvmsSSH* server, struct mg_connection* nc)
+  : ConsoleMongoose(nc)
   {
   m_server = server;
-  m_connection = nc;
   m_queue = xQueueCreate(100, sizeof(Event));
   m_ssh = NULL;
   m_state = ACCEPT;
   m_drain = 0;
-  m_closing = false;
   m_sent = true;
   m_rekey = false;
   m_needDir = false;

--- a/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.h
+++ b/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.h
@@ -30,19 +30,19 @@
 #ifndef __CONSOLE_SSH_H__
 #define __CONSOLE_SSH_H__
 
-#include <list>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "ovms_console.h"
 #include "task_base.h"
 #include "mongoose_client.h"
+#include "console_mongoose.h"
 
 #define BUFFER_SIZE 512
 
 class ConsoleSSH;
 struct mg_connection;
 
-class OvmsSSH : public MongooseClient
+class OvmsSSH : public MongooseClient, public ConsoleMongooseServer
   {
   public:
     OvmsSSH();
@@ -58,10 +58,9 @@ class OvmsSSH : public MongooseClient
   protected:
     WOLFSSH_CTX* m_ctx;
     bool m_keyed;
-    std::list<ConsoleSSH*> m_reaping;   // consoles awaiting follow-task exit before delete
   };
 
-class ConsoleSSH : public OvmsConsole, public MongooseClient
+class ConsoleSSH : public ConsoleMongoose
   {
   public:
     ConsoleSSH(OvmsSSH* server, struct mg_connection* nc);
@@ -82,9 +81,6 @@ class ConsoleSSH : public OvmsConsole, public MongooseClient
     ssize_t write(const void *buf, size_t nbyte);
     int RecvCallback(char* buf, uint32_t size);
     bool IsDraining() { return m_drain > 0; }
-    void SetClosing() { m_closing = true; }
-    bool IsClosing() { return m_closing; }
-    mg_connection* GetConnection() { return m_connection; }
 
   private:
     typedef struct {DIR* dir; size_t size;} Level;
@@ -105,13 +101,11 @@ class ConsoleSSH : public OvmsConsole, public MongooseClient
       CLOSING
       } m_state;
     OvmsSSH* m_server;
-    mg_connection* m_connection;
     WOLFSSH* m_ssh;
     char m_buffer[BUFFER_SIZE];
     int m_index;                // Index into m_buffer of data remaining to send
     int m_size;                 // Size of data remaining to send
     int m_drain;                // Bytes discarded waiting for socket to drain
-    volatile bool m_closing;    // true once the connection is closing; read cross-task
     bool m_sent;
     bool m_rekey;
     bool m_needDir;

--- a/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.cpp
+++ b/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.cpp
@@ -75,6 +75,7 @@ void OvmsTelnet::EventHandler(struct mg_connection *nc, int ev, void *p)
 
     case MG_EV_POLL:
       {
+      ReapConsoles();
       ConsoleTelnet* child = (ConsoleTelnet*)nc->user_data;
       if (child)
         child->Poll(0);
@@ -93,7 +94,8 @@ void OvmsTelnet::EventHandler(struct mg_connection *nc, int ev, void *p)
       {
       ConsoleTelnet* child = (ConsoleTelnet*)nc->user_data;
       if (child)
-        delete child;
+        CloseConsole(child);
+      nc->user_data = NULL;
       }
       break;
 
@@ -156,8 +158,8 @@ void OvmsTelnet::NetManStop(std::string event, void* data)
 //-----------------------------------------------------------------------------
 
 ConsoleTelnet::ConsoleTelnet(struct mg_connection* nc)
+  : ConsoleMongoose(nc)
   {
-  m_connection = nc;
   m_queue = xQueueCreate(100, sizeof(Event));
 
   static const telnet_telopt_t options[] =
@@ -287,7 +289,10 @@ int ConsoleTelnet::printf(const char* fmt, ...)
 
 ssize_t ConsoleTelnet::write(const void *buf, size_t nbyte)
   {
-  if (!m_telnet || (m_connection->flags & MG_F_SEND_AND_CLOSE))
+  // m_closing is checked first on purpose: once the connection is closing the
+  // mongoose nc (m_connection) may already be freed, so short-circuit before
+  // dereferencing it — telnet_send_text() would otherwise reach mg_send() on it.
+  if (m_closing || !m_telnet || (m_connection->flags & MG_F_SEND_AND_CLOSE))
     return 0;
   telnet_send_text(m_telnet, (const char*)buf, nbyte);
   return nbyte;

--- a/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.h
+++ b/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.h
@@ -32,10 +32,11 @@
 
 #include "libtelnet.h"
 #include "ovms_console.h"
+#include "console_mongoose.h"
 
 struct mg_connection;
 
-class OvmsTelnet : public MongooseClient
+class OvmsTelnet : public MongooseClient, public ConsoleMongooseServer
   {
   public:
     OvmsTelnet();
@@ -49,7 +50,7 @@ class OvmsTelnet : public MongooseClient
     bool m_running;
   };
 
-class ConsoleTelnet : public OvmsConsole, public MongooseClient
+class ConsoleTelnet : public ConsoleMongoose
   {
   public:
     ConsoleTelnet(struct mg_connection* nc);
@@ -68,7 +69,6 @@ class ConsoleTelnet : public OvmsConsole, public MongooseClient
     ssize_t write(const void *buf, size_t nbyte);
 
   protected:
-    mg_connection* m_connection;
     telnet_t *m_telnet;
   };
 

--- a/vehicle/OVMS.V3/components/mongoose/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/mongoose/CMakeLists.txt
@@ -3,7 +3,7 @@ set(include_dirs)
 set(priv_includedirs)
 
 if (CONFIG_OVMS_SC_GPL_MONGOOSE)
-  list(APPEND srcs "mongoose/mongoose.c" "src/mongoose_client.cpp")
+  list(APPEND srcs "mongoose/mongoose.c" "src/mongoose_client.cpp" "src/console_mongoose.cpp")
   list(APPEND include_dirs "include" "mongoose" "src")
 
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${srcs}" "mongoose/mongoose.h")

--- a/vehicle/OVMS.V3/components/mongoose/src/console_mongoose.cpp
+++ b/vehicle/OVMS.V3/components/mongoose/src/console_mongoose.cpp
@@ -1,0 +1,98 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          20th July 2026
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2026  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#include "console_mongoose.h"
+#include "ovms_command.h"
+
+//-----------------------------------------------------------------------------
+//    Class ConsoleMongoose
+//-----------------------------------------------------------------------------
+
+ConsoleMongoose::ConsoleMongoose(struct mg_connection* nc)
+  {
+  m_connection = nc;
+  m_closing = false;
+  }
+
+ConsoleMongoose::~ConsoleMongoose()
+  {
+  // Note: RunTerminationCallback() is deliberately NOT called here. It must run
+  // before the derived console frees the transport its writer feeds, and a base
+  // destructor runs after the derived one. Each console therefore calls it as
+  // the first statement of its own destructor.
+  }
+
+//-----------------------------------------------------------------------------
+//    Class ConsoleMongooseServer
+//-----------------------------------------------------------------------------
+
+ConsoleMongooseServer::~ConsoleMongooseServer()
+  {
+  // The console servers are global singletons living for the lifetime of the
+  // firmware, so this is not reached in practice. Any still-deferred console is
+  // deliberately leaked rather than freed: its follow-mode task may not have
+  // exited yet, and freeing it would be a use-after-free.
+  }
+
+void ConsoleMongooseServer::CloseConsole(ConsoleMongoose* child)
+  {
+  OvmsCommandTask* ft = child->GetFollowModeTask();
+  if (!ft)
+    {
+    delete child;   // no follow task: synchronous termination + free
+    return;
+    }
+
+  // A follow-mode task is still bound to this console. We must not join it
+  // here: we are on the Mongoose task with the lock held, and the connection is
+  // being freed underneath us. Mark closing so the task's in-flight write()
+  // bails out without touching the connection, ask it to stop, and defer the
+  // delete to a later poll.
+  child->SetClosing();
+  ft->RequestStop();
+  m_reaping.push_back(child);
+  }
+
+void ConsoleMongooseServer::ReapConsoles()
+  {
+  for (auto it = m_reaping.begin(); it != m_reaping.end(); )
+    {
+    ConsoleMongoose* z = *it;
+    // GetFollowModeTask() turns NULL once the task has deregistered itself,
+    // which ~OvmsCommandTask does as its last access to the writer.
+    if (z->GetFollowModeTask() == NULL)
+      {
+      delete z;
+      it = m_reaping.erase(it);
+      }
+    else
+      ++it;
+    }
+  }

--- a/vehicle/OVMS.V3/components/mongoose/src/console_mongoose.h
+++ b/vehicle/OVMS.V3/components/mongoose/src/console_mongoose.h
@@ -1,0 +1,109 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          20th July 2026
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2026  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#ifndef __CONSOLE_MONGOOSE_H__
+#define __CONSOLE_MONGOOSE_H__
+
+#include <list>
+#include "ovms_console.h"
+#include "mongoose_client.h"
+
+/**
+ * ConsoleMongoose / ConsoleMongooseServer: shared teardown support for the
+ * Mongoose based consoles (SSH, Telnet).
+ *
+ * The problem
+ * -----------
+ * An interactive command may run its own task that writes to the console that
+ * launched it — "vfs tail" in follow mode is the current example. That task
+ * holds a raw OvmsWriter pointer, so the console must not be freed while the
+ * task can still write to it.
+ *
+ * OvmsWriter's termination handler registry solves that for consoles that can
+ * simply join the task during teardown. A Mongoose based console cannot always
+ * do that, because it is deleted from the MG_EV_CLOSE event, i.e. on the
+ * Mongoose task, while the connection is being freed:
+ *
+ *  - On SSH the join deadlocks outright: MG_EV_CLOSE is dispatched with the
+ *    Mongoose lock held for the whole mg_mgr_poll(), and the follow task's
+ *    write() path needs that same lock, so neither side can proceed.
+ *  - On Telnet the join does complete (its write() path calls mg_send()
+ *    without taking the lock), but the follow task can still be inside
+ *    mg_send() on the very connection Mongoose is about to free.
+ *
+ * The scheme
+ * ----------
+ * "Signal and reap" instead of "stop and wait". When a connection closes with
+ * a follow-mode task still bound, the server marks the console closing (so the
+ * task's in-flight write() bails out without touching the connection), asks the
+ * task to stop without waiting for it, and defers the delete. A reap pass on a
+ * later MG_EV_POLL frees the console once the task has actually exited.
+ *
+ * Consoles with no follow-mode task are deleted synchronously as before.
+ */
+
+class ConsoleMongoose : public OvmsConsole, public MongooseClient
+  {
+  public:
+    ConsoleMongoose(struct mg_connection* nc);
+    virtual ~ConsoleMongoose();
+
+  public:
+    // Set once the connection is closing. A write() from a follow-mode task
+    // must check this FIRST and bail out: m_connection may already be freed,
+    // so it must not be dereferenced afterwards.
+    void SetClosing() { m_closing = true; }
+    bool IsClosing() { return m_closing; }
+    struct mg_connection* GetConnection() { return m_connection; }
+
+  protected:
+    struct mg_connection* m_connection;
+    volatile bool m_closing;    // true once the connection is closing; read cross-task
+  };
+
+class ConsoleMongooseServer
+  {
+  public:
+    virtual ~ConsoleMongooseServer();
+
+  protected:
+    // Call from the MG_EV_CLOSE handler in place of "delete child": deletes the
+    // console immediately, or defers it if a follow-mode task is still bound.
+    void CloseConsole(ConsoleMongoose* child);
+
+    // Call from the MG_EV_POLL handler: frees any deferred console whose
+    // follow-mode task has since exited.
+    void ReapConsoles();
+
+  private:
+    std::list<ConsoleMongoose*> m_reaping;   // consoles awaiting follow-task exit before delete
+  };
+
+#endif //#ifndef __CONSOLE_MONGOOSE_H__


### PR DESCRIPTION
Draft / do-not-merge. Fork-master-based branch that exists only to run the fork Firmware build + produce a flashable artifact for the base-class refactor requested by dexterbg on openvehicles#1424. The real PR is the upstream-based branch `console-vfs-tail-uaf`; this cherry-picks that refactor onto fork master (clean apply).