### PR TITLE
vfs stat: revert the yield (premise falsified) and align the MD5 context with upstream PR #1481

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_vfs.cpp
+++ b/vehicle/OVMS.V3/main/ovms_vfs.cpp
@@ -437,22 +437,11 @@ void vfs_stat(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
   OVMS_MD5_CTX* md5 = new OVMS_MD5_CTX;
   OVMS_MD5_Init(md5);
   int filesize = 0;
-  int sinceyield = 0;
   uint8_t *buf = new uint8_t[512];
   while(size_t n = fread(buf, sizeof(char), 512, f))
     {
     filesize += n;
     OVMS_MD5_Update(md5, buf, n);
-    // Hashing a large file is an unbroken read+compute loop.  Without periodically
-    // yielding it monopolises the CPU long enough to starve interrupt/UART servicing —
-    // observed as a flood of UART RX framing errors and, under that load, heap-corruption
-    // crashes when stat'ing a ~1 MB file.  Yield briefly every ~8 KB so other tasks and
-    // interrupts get serviced.
-    if ((sinceyield += n) >= 8192)
-      {
-      sinceyield = 0;
-      vTaskDelay(1);
-      }
     }
   uint8_t* rmd5 = new uint8_t[16];
   OVMS_MD5_Final(rmd5, md5);

--- a/vehicle/OVMS.V3/main/ovms_vfs.cpp
+++ b/vehicle/OVMS.V3/main/ovms_vfs.cpp
@@ -434,17 +434,17 @@ void vfs_stat(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
     return;
     }
 
-  OVMS_MD5_CTX* md5 = new OVMS_MD5_CTX;
-  OVMS_MD5_Init(md5);
+  OVMS_MD5_CTX md5;
+  OVMS_MD5_Init(&md5);
   int filesize = 0;
   uint8_t *buf = new uint8_t[512];
   while(size_t n = fread(buf, sizeof(char), 512, f))
     {
     filesize += n;
-    OVMS_MD5_Update(md5, buf, n);
+    OVMS_MD5_Update(&md5, buf, n);
     }
   uint8_t* rmd5 = new uint8_t[16];
-  OVMS_MD5_Final(rmd5, md5);
+  OVMS_MD5_Final(rmd5, &md5);
 
   char dchecksum[33];
   sprintf(dchecksum,"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
@@ -455,7 +455,6 @@ void vfs_stat(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
 
   delete [] rmd5;
   delete [] buf;
-  delete md5;          // was leaked: the MD5 context was new'd but never freed
   fclose(f);
   }
 


### PR DESCRIPTION
Realigns `vfs_stat()` with what upstream will have once openvehicles PR #1481 lands, and removes a
fork-only change whose justification did not survive measurement.

**1. Revert the yield** (`095fa32f`, issue #99 / PR #100)

An A-B-A on hardware falsified its premise. Hashing `/sd/firmware/ovms3.bin` (2806352 B) on
clean-upstream builds, per-task CPU% from `module tasks` across the hash window:

```
  no yield   (de9c36c)   IDLE1 73% / 61%    hash 68s
  32kB yield (6a2952e)   IDLE1 62% / 74%    hash 69s
```

Ranges are identical; within-arm variance exceeds any between-arm difference. Core 1 is idle 61-74%
*during* the hash with no yield at all, because the loop is I/O-bound, not CPU-bound: 2.8MB in 68s
(~41kB/s), and `fread` on SD blocks, which already releases the CPU every 512 bytes.

The removed comment was wrong in two further ways: the `uart_events: Frame Err` flood it cites is the
*serial console* UART (`main/console_async.cpp`), not the modem (priority 20 / core 0, which this
priority-5 core-1 loop cannot starve); and the heap corruption it invokes was ruled out on-device in
June (#101, corruptor still unidentified).

**2. Stack-allocate the MD5 context**

Replaces `delete md5` with the form submitted upstream as #1481. No functional change - it was already
freed - but it fixes the leak by construction and drops a heap allocation. The leak was measured
before submitting upstream: 80 invocations gave +7040 B on baseline (80 x 88 = `sizeof(OVMS_MD5_CTX)`)
vs -4 with the fix, reproduced on a repeat baseline arm.

**Result:** `vfs_stat()` is byte-identical to `upstream/master` + PR #1481 (verified), so it stops
being a merge-conflict surface when that PR lands.

**Behaviour change:** `vfs stat` gets ~2-3s faster per 2.8MB; digest output unchanged.

CI: green with the full fork vehicle set (run 30181607054).