### PR TITLE
etnga: shorten log tags to v-etnga / v-subsol

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,12 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the log tags have been shortened for
+    consistency with other vehicles. If you set log levels for diagnostics, use the new names:
+    "v-etnga" (was "v-toyota-etnga") and "v-subsol" (was "v-subaru-solterra"). Almost all
+    messages come from the shared platform, so "log level verbose v-etnga" is the one to set
+    on any of these cars. The separate "v-toyota-etnga-charging" telemetry tag is gone — the
+    same per-second charging data is recorded in the charge-session report CSV.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): v.e.awake now reflects the vehicle being
     switched on (AWAKE/DRIVING) rather than raw CAN2 bus activity, so it no longer reads true
     during a charge — the module no longer sends the periodic "Vehicle is idling / stopped

--- a/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
@@ -13,7 +13,9 @@ Vehicle identity
 
 :Short type code: SUBSOL
 :Vehicle name: Subaru Solterra
-:Log tag: ``v-subaru-solterra``
+:Log tag: ``v-subsol`` (wrapper only). Nearly all logging comes from the shared
+   e-TNGA platform under ``v-etnga`` — set that one to collect diagnostics, e.g.
+   ``log level verbose v-etnga``.
 
 -------------
 Battery / BMS

--- a/vehicle/OVMS.V3/components/vehicle_subaru_solterra/src/vehicle_subaru_solterra.h
+++ b/vehicle/OVMS.V3/components/vehicle_subaru_solterra/src/vehicle_subaru_solterra.h
@@ -18,7 +18,7 @@ class OvmsVehicleSubaruSolterra : public OvmsVehicleToyotaETNGA
 public:
   OvmsVehicleSubaruSolterra();  // Constructor for the Subaru Solterra vehicle module
   ~OvmsVehicleSubaruSolterra(); // Destructor for the Subaru Solterra vehicle module
-  static constexpr const char* TAG = "v-subaru-solterra";
+  static constexpr const char* TAG = "v-subsol";
 
 };
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_io.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_io.cpp
@@ -18,7 +18,7 @@
 #include "ovms_log.h"
 #include "vehicle_toyota_etnga.h"
 
-static const char* TAG = "v-toyota-etnga";
+static const char* TAG = "v-etnga";
 
 static const int CHARGE_REPORT_MAX = 50;   // retain at most this many reports (moved from etnga_charge_report.cpp)
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -239,21 +239,6 @@ void OvmsVehicleToyotaETNGA::Ticker1(uint32_t ticker)
     // later in the same tick, so it must be fresh before that runs.
     UpdateCharging12v();
 
-    if (StandardMetrics.ms_v_charge_inprogress->AsBool()) {
-        ESP_LOGV(CHARGING_TAG, "%.0f, %.2f, %.4f, %.0f, %.2f, %.2f, %.2f, %.2f, %.0f, %.2f, %.4f",
-                StandardMetrics.ms_v_bat_voltage->AsFloat(),
-                StandardMetrics.ms_v_bat_current->AsFloat(),
-                StandardMetrics.ms_v_bat_power->AsFloat(),
-                StandardMetrics.ms_v_env_temp->AsFloat(),
-                StandardMetrics.ms_v_bat_pack_tavg->AsFloat(),
-                StandardMetrics.ms_v_bat_pack_tmax->AsFloat(),
-                StandardMetrics.ms_v_bat_pack_tmin->AsFloat(),
-                StandardMetrics.ms_v_bat_pack_tstddev->AsFloat(),
-                StandardMetrics.ms_v_bat_soc->AsFloat(),
-                m_v_bat_soc_bms->AsFloat(),
-                StandardMetrics.ms_v_charge_power->AsFloat());
-    }
-
     //ESP_LOGI(TAG, "Entering Ticker1: %d", ticker);
     ResetStaleMetrics();
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -222,8 +222,7 @@ protected:
     // session counters reset at session open in TransitionToChargeHandshakeState.
 
 private:
-    static constexpr const char* TAG = "v-toyota-etnga";
-    static constexpr const char* CHARGING_TAG = "v-toyota-etnga-charging";
+    static constexpr const char* TAG = "v-etnga";
     // Energy-integrator timestamps (esp_log_timestamp ms; 0 = interval not started).
     // Must be zero-initialized: the first poll reply can arrive before NotifyVehicleOn /
     // NotifyChargeStart reset them, and a garbage dt would corrupt the persistent *_total metrics.


### PR DESCRIPTION
Pre-upstream cleanup, from the review-convention audit.

Upstream expects one word for the vehicle type in a log tag, with additional
dashes reserved for functional subsystems (openvehicles#1472: *"The vehicle type
shall be one word, additional dashes shall only be introduced for specific
functional subsystems"*). Ours used dashes as word separators.

    v-toyota-etnga     -> v-etnga
    v-subaru-solterra  -> v-subsol   (matches the SUBSOL type code)

Also removes `CHARGING_TAG` and the `Ticker1` block behind it — a once-per-second
`ESP_LOGV` row of pack voltage/current/power, temperatures and SOC during charging.
The charge-session report already records the same fields per sample in its CSV, so
the log row was redundant, and upstream prefers few tags precisely so a user can
enable one and get everything (openvehicles#1327). Verified nothing is orphaned:
`m_v_bat_soc_bms` is still written by the BMS decode and read by the report.

**Fixes a real documentation error found while checking this.** The Solterra page
listed only its own tag — but the wrapper has 3 `ESP_LOG` call sites against 108 in
the shared platform, so a user following the docs and setting `v-subsol` would have
collected almost nothing and concluded logging was broken. It now points at `v-etnga`.

`changes.txt` entry included: this renames something users type, and retires a tag
some may have configured.

Docs build passes locally with the CI flags (`-W --keep-going`). Firmware not compiled
locally — this PR's build is the check.