### PR TITLE
webserver: stream file-sized bodies instead of buffering them whole

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.cpp
@@ -839,58 +839,6 @@ int HttpDataSender::HandleEvent(int ev, void* p)
 
 
 /**
- * HttpStringSender: chunked transfer of a memory region (needs to be const during xfer)
- */
-HttpStringSender::HttpStringSender(mg_connection* nc, std::string* msg, bool keepalive /*=true*/)
-  : MgHandler(nc)
-{
-  m_msg = msg;
-  m_sent = 0;
-  m_keepalive = keepalive;
-  ESP_EARLY_LOGV(TAG, "HttpStringSender[%p]: init msg=%p, %d bytes", nc, m_msg, m_msg->size());
-}
-
-HttpStringSender::~HttpStringSender()
-{
-  if (m_sent < m_msg->size()) {
-    ESP_EARLY_LOGV(TAG, "HttpStringSender[%p]: abort msg=%p, %d bytes sent", m_nc, m_msg, m_sent);
-  }
-  delete m_msg;
-}
-
-int HttpStringSender::HandleEvent(int ev, void* p)
-{
-  switch (ev)
-  {
-    case MG_EV_SEND:          // last transmission has finished
-    {
-      if (m_sent < m_msg->size()) {
-        // send next chunk:
-        size_t len = MIN(m_msg->size() - m_sent, XFER_CHUNK_SIZE);
-        mg_send_http_chunk(m_nc, (const char*) m_msg->data() + m_sent, len);
-        m_sent += len;
-        ESP_EARLY_LOGV(TAG, "HttpStringSender[%p] msg=%p sent %d/%d", m_nc, m_msg, m_sent, m_msg->size());
-      }
-      else {
-        // done:
-        if (!m_keepalive)
-          m_nc->flags |= MG_F_SEND_AND_CLOSE;
-        mg_send_http_chunk(m_nc, "", 0);
-        ESP_EARLY_LOGV(TAG, "HttpStringSender[%p]: done msg=%p, %d bytes sent", m_nc, m_msg, m_sent);
-        delete this;
-      }
-    }
-    break;
-
-    default:
-      break;
-  }
-
-  return ev;
-}
-
-
-/**
  * CheckLogin: check username & password
  *
  * We use "admin" as a fixed username for now to be able to extend users later on

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.h
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.h
@@ -155,8 +155,8 @@ struct PageContext : public ExternalRamAllocated
   // output:
   void error(int code, const char* text);
   void head(int code, const char* headers=NULL);
-  void print(const std::string text);
-  void print(const extram::string text);
+  void print(const std::string& text);
+  void print(const extram::string& text);
   void print(const char* text);
   void printf(const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
   void done();
@@ -337,20 +337,62 @@ class HttpDataSender : public MgHandler
  * HttpStringSender transmits a std::string in HTTP chunks of XFER_CHUNK_SIZE size.
  * Note: the string is deleted after transmission.
  */
-class HttpStringSender : public MgHandler
+/**
+ * HttpStringSenderT: chunked transfer of a string the sender takes ownership of.
+ *  The string must not be modified during the transfer; the sender deletes both the
+ *  string and itself once the last chunk has gone out, and emits the terminating
+ *  zero-length chunk, so the caller must NOT also call PageContext::done().
+ *
+ *  Two instantiations are provided. Prefer HttpExtRamStringSender for file-sized
+ *  bodies so the payload sits in SPIRAM instead of internal 8-bit RAM.
+ */
+template <class StringType>
+class HttpStringSenderT : public MgHandler
 {
   public:
-    HttpStringSender(mg_connection* nc, std::string* msg, bool keepalive=true);
-    ~HttpStringSender();
+    HttpStringSenderT(mg_connection* nc, StringType* msg, bool keepalive=true)
+      : MgHandler(nc)
+    {
+      m_msg = msg;
+      m_sent = 0;
+      m_keepalive = keepalive;
+    }
+    ~HttpStringSenderT()
+    {
+      delete m_msg;
+    }
 
   public:
-    int HandleEvent(int ev, void* p);
+    int HandleEvent(int ev, void* p)
+    {
+      if (ev == MG_EV_SEND)                 // last transmission has finished
+      {
+        if (m_sent < m_msg->size()) {
+          // send next chunk:
+          size_t remain = m_msg->size() - m_sent;
+          size_t len = (remain < XFER_CHUNK_SIZE) ? remain : (size_t) XFER_CHUNK_SIZE;
+          mg_send_http_chunk(m_nc, (const char*) m_msg->data() + m_sent, len);
+          m_sent += len;
+        }
+        else {
+          // done:
+          if (!m_keepalive)
+            m_nc->flags |= MG_F_SEND_AND_CLOSE;
+          mg_send_http_chunk(m_nc, "", 0);
+          delete this;
+        }
+      }
+      return ev;
+    }
 
   public:
-    std::string*              m_msg = NULL;           // pointer to data
+    StringType*               m_msg = NULL;           // owned payload
     size_t                    m_sent = 0;             // size sent up to now
     bool                      m_keepalive = false;    // false = close connection when done
 };
+
+typedef HttpStringSenderT<std::string>      HttpStringSender;
+typedef HttpStringSenderT<extram::string>   HttpExtRamStringSender;
 
 
 /**

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_framework.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_framework.cpp
@@ -179,11 +179,11 @@ void PageContext::head(int code, const char* headers /*=NULL*/) {
   mg_send_head(nc, code, -1, headers);
 }
 
-void PageContext::print(const std::string text) {
+void PageContext::print(const std::string& text) {
   mg_send_http_chunk(nc, text.data(), text.size());
 }
 
-void PageContext::print(const extram::string text) {
+void PageContext::print(const extram::string& text) {
   mg_send_http_chunk(nc, text.data(), text.size());
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -568,8 +568,15 @@ void OvmsVehicleToyotaETNGA::WebChargeReport(PageEntry_t& p, PageContext_t& c)
         c.head(200, "Content-Type: text/csv; charset=utf-8\r\nContent-Disposition: attachment");
     else
         c.head(200, "Content-Type: text/html; charset=utf-8\r\nCache-Control: no-cache");
-    c.print(content);
-    c.done();
+
+    // Stream the body in XFER_CHUNK_SIZE pieces rather than appending the whole file to the
+    // connection send buffer. A session CSV can reach several MB, and buffering it whole held
+    // three concurrent copies (the load_file target, the print() argument, and the mbuf).
+    // Ownership passes to the sender, which frees the body and itself when the transfer ends
+    // and emits the terminating chunk — so there is deliberately no c.done() here.
+    extram::string* body = new extram::string();
+    body->swap(content);
+    new HttpExtRamStringSender(c.nc, body);
 }
 
 #endif // CONFIG_OVMS_COMP_WEBSERVER


### PR DESCRIPTION
Fixes #170.

### 1. `PageContext::print()` took its argument by value

Both the `std::string` and `extram::string` overloads copied the entire body before
sending it. Now `const&`. No behaviour change — 226 call sites benefit, most
trivially, the file-backed ones substantially.

### 2. `HttpStringSender` had zero callers

The chunked sender built for exactly this — `XFER_CHUNK_SIZE` pieces driven by
`MG_EV_SEND` — was dead code. Everything went through `print()`, which appends the
whole body to the connection mbuf in a single call.

It is now a template, `HttpStringSenderT<>`, with:
- `HttpStringSender` preserved as a typedef for `std::string`, so the existing public
  API is unchanged, and
- `HttpExtRamStringSender` added for `extram::string`, so a file-sized payload stays
  in SPIRAM rather than internal 8-bit RAM.

Moving the implementation into the header costs the three `ESP_EARLY_LOGV` traces it
carried — verbose-level only, on a class with no users to trace.

### The first caller

Serving one charge report held **three concurrent copies** of the file: the
`load_file` target, the by-value `print()` argument, and the mbuf. For the 2.8 MB CSV
in this fork's report directory that is roughly 8 MB of transient allocation. It now
streams, bounded by `XFER_CHUNK_SIZE`.

### What this does and does not fix

It does **not** fix the heap corruption in #101 — a path that allocates less simply
trips over pre-existing damage less often.

It does make the report browser usable. Measured today: 23 sequential fetches through
this handler reliably crashed the module, while the same 36 reports (20 MB, largest
file 2.79 MB) came off cleanly through mongoose's static handler in the same session.

### Notes for review

- Core and vehicle changes are in one commit because they depend on each other: the
  handler cannot stream without the new sender.
- `mg_send_http_chunk` is now called from a template body in the header, so it must be
  declared at that point. It is — `ovms_webserver.h` includes `ovms_netmanager.h`,
  which includes `mongoose_client.h`; `web_framework.cpp` already relies on the same
  transitive path.
- The handler deliberately no longer calls `c.done()`: the sender emits the
  terminating zero-length chunk itself, matching the existing `HttpDataSender` usage.
- **Not yet exercised on the module.** Firmware does not compile on this box, so this
  PR's build is the first compile. The behavioural check is a bulk report fetch, which
  is also the #101 reproducer — worth doing deliberately rather than casually.