### PR TITLE
etnga: batch the TPMS threshold config writes under one lock

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -144,10 +144,17 @@ void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
             error += "<li>Temperature alert should be at or above the warning threshold (higher temperature is worse).</li>";
 
         if (error == "") {
-            MyConfig.SetParamValueFloat("xte", "tpms.pressure.warn",  p_warn);
-            MyConfig.SetParamValueFloat("xte", "tpms.pressure.alert", p_alert);
-            MyConfig.SetParamValueFloat("xte", "tpms.temp.warn",      t_warn);
-            MyConfig.SetParamValueFloat("xte", "tpms.temp.alert",     t_alert);
+            // Hold the config lock across all four writes. OvmsConfig::Transaction is a
+            // recursive lock that commits only as the OUTERMOST lock is released, so the
+            // four Save() operations coalesce into a single config-store write instead of
+            // one per setter. Scoped so the lock is released before the response is built.
+            {
+                auto lock = MyConfig.Lock();
+                MyConfig.SetParamValueFloat("xte", "tpms.pressure.warn",  p_warn);
+                MyConfig.SetParamValueFloat("xte", "tpms.pressure.alert", p_alert);
+                MyConfig.SetParamValueFloat("xte", "tpms.temp.warn",      t_warn);
+                MyConfig.SetParamValueFloat("xte", "tpms.temp.alert",     t_alert);
+            }
 
             c.head(200);
             std::string saved = "<p class=\"lead\">" + etnga_vehicle_name() + " configuration saved.</p>";


### PR DESCRIPTION
Audit item 4 from the upstream review-convention pass.

`WebCfgFeatures` wrote four config instances in a row. Tracing what that actually
costs:

    SetParamValueFloat -> OvmsConfigParam::SetValueFloat -> if (changed) Save()
    Save()             -> MyConfig.TransactionAdd(this, TransOp::Save)
    Transaction::Unlock() -> commits when GetCount() == 1

`OvmsConfig::Transaction` is a **recursive** lock and commits only as the *outermost*
lock is released. Each setter takes and releases its own lock, so each one commits:
a form submit changing all four values performed **four separate config-store writes**.

`TransactionAdd()` keys pending operations by `OvmsConfigParam*`, so holding a single
outer lock across the four setters collapses them into **one** write — no change to
the setters themselves. Same idiom as `ovms_plugins.cpp:325` and
`ovms_location.cpp:864`, and what openvehicles#1472 asks for directly: *"Please move
all config changes into the block below applying the config lock."*

### Why not `SetParamMap()`

That is the usual batching advice (openvehicles#1229), and it would be **wrong here**.
`OvmsConfigParam::SetMap()` *replaces* every instance in the param — it clears
`m_instances` and moves the supplied map in. Applied to a form that knows about only
its own four keys, it would silently delete any other `xte` instance a user had set
from the shell.

That is the same shape as the partial `/cfg/wifi` POST that wipes saved WiFi networks.
The lock achieves the identical single-write result with none of that risk.

### Notes

- The setters already no-op when a value is unchanged, so submitting the form with no
  edits still writes nothing.
- The lock is scoped to the writes and released before the response is built, so it is
  not held across the HTTP reply.
- Behavioural check is a real form submit — the values must persist across a reboot,
  as before.