### PR TITLE
etnga: log min/max pack temperature in the charge CSV

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,12 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge-session CSV now also records the
+    coolest and hottest pack temperature sensors ("batt_tmin_c" / "batt_tmax_c") alongside the
+    existing average. The battery derates on its hottest sensor, so charging-curve analysis
+    should use the maximum rather than the average — the two differ by around 3 degrees C even
+    on a gentle AC charge. The new columns are added at the end of each row, so existing
+    tooling that reads the file is unaffected.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): per-cell battery voltages are now read during
     AC charging (every 60 seconds), so the BMS cell monitor keeps updating and per-cell deviation
     alerts stay active through a charge. Previously cell voltages were only read while driving and

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -818,7 +818,8 @@ The CSV is streamed to disk one row per second during active charging (``CHARGE_
     pack_v, pack_a, batt_temp_c, ambient_c, state,
     station_max_kw, station_max_a, station_max_v,
     car_perm_kw, car_target_a,
-    station_grid_kw, station_present_v, station_present_a, obc_kw
+    station_grid_kw, station_present_v, station_present_a, obc_kw,
+    batt_tmin_c, batt_tmax_c
 
 Grouped by what each column represents:
 
@@ -833,6 +834,12 @@ Grouped by what each column represents:
 * **Pack** — ``pack_v``, ``pack_a``, ``batt_temp_c``, plus ``ambient_c`` (empty, not
   ``0.0``, until the first in-charge reading arrives roughly 30 s in — an empty field is
   distinguishable from a genuine 0 °C).
+* **Pack temperature spread** — ``batt_tmin_c`` and ``batt_tmax_c``, the coolest and
+  hottest of the pack's temperature sensors.  ``batt_temp_c`` is their **mean**, and the
+  spread is not negligible: roughly 3 °C between coolest and hottest even during a gentle
+  AC charge.  A BMS derates on its **hottest** sensor, so a charging curve should be keyed
+  to ``batt_tmax_c`` rather than the mean.  Both read ``0.0`` until the first temperature
+  reply of the session arrives.
 * **``state``** — ``AC`` or ``DC``.
 * **The station's caps** — ``station_max_kw`` / ``_a`` / ``_v``.
 * **The car's asks** — ``car_perm_kw`` (DID ``0x16A1``) and ``car_target_a``

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -386,10 +386,16 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
         //   actuals         : station_kw (from EVSE), battery_kw (into battery), hvac_kw (into cabin),
         //                     plus raw station_grid_kw / station_present_v / station_present_a
         //   obc_kw          : diagnostic — raw 0x10D4 (under-reads on DC, issue #109)
+        //   pack temps      : batt_temp_c is the MEAN of all sensors; batt_tmin_c/_tmax_c are
+        //                     the coolest/hottest. The BMS derates on the hottest sensor, so a
+        //                     charging curve must be keyed to batt_tmax_c, not the mean (#155).
+        // New columns are APPENDED — never inserted. Nothing in-tree parses these files, but
+        // external decoders read them positionally, and `phase` was already prepended once.
         m_charge_session.csv_buf =
             "phase,elapsed_s,soc_pct,bms_soc_pct,station_kw,battery_kw,hvac_kw,pack_v,pack_a,"
             "batt_temp_c,ambient_c,state,station_max_kw,station_max_a,station_max_v,"
-            "car_perm_kw,car_target_a,station_grid_kw,station_present_v,station_present_a,obc_kw\n";
+            "car_perm_kw,car_target_a,station_grid_kw,station_present_v,station_present_a,obc_kw,"
+            "batt_tmin_c,batt_tmax_c\n";
         m_charge_session.csv_started = true;
     }
 
@@ -400,7 +406,7 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
     char amb[16] = "";
     if (StandardMetrics.ms_v_env_temp->IsDefined())
         snprintf(amb, sizeof(amb), "%.1f", StandardMetrics.ms_v_env_temp->AsFloat());
-    char row[320];
+    char row[384];
     float present_v = StandardMetrics.ms_v_charge_voltage->AsFloat();
     float present_a = StandardMetrics.ms_v_charge_current->AsFloat();
     float grid_kw   = m_v_charge_grid_power->AsFloat();
@@ -408,7 +414,7 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
     int phase_no = (m_charge_session.cur >= 0) ? (m_charge_session.cur + 1) : 0;
     snprintf(row, sizeof(row),
         "%d,%d,%.0f,%.1f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%s,%s,"
-        "%.2f,%.0f,%.0f,%.2f,%.0f,%.3f,%.0f,%.0f,%.3f\n",
+        "%.2f,%.0f,%.0f,%.2f,%.0f,%.3f,%.0f,%.0f,%.3f,%.1f,%.1f\n",
         phase_no,
         elapsed,
         StandardMetrics.ms_v_bat_soc->AsFloat(),
@@ -424,7 +430,11 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
         m_v_charge_sta_max_p->AsFloat(), m_v_charge_sta_max_i->AsFloat(), m_v_charge_sta_max_v->AsFloat(),
         m_v_charge_perm->AsFloat(), m_v_charge_tgti->AsFloat(),
         grid_kw, present_v, present_a,
-        m_charge_obc_kw);
+        m_charge_obc_kw,
+        // Populated by BmsSetCellTemperature on every 0x1814 reply, so no new poll is
+        // needed. Both read 0 until the first reply of the session arrives.
+        StandardMetrics.ms_v_bat_pack_tmin->AsFloat(),
+        StandardMetrics.ms_v_bat_pack_tmax->AsFloat());
     m_charge_session.csv_buf += row;
 
     // Flush at most every 30 s (or ~4 KB): a 1 Hz open/append/close per row would put


### PR DESCRIPTION
Closes #155.

**Stacked on #177** (the CSV schema documentation correction) — base will retarget to
`master` automatically when that merges. It has to be: this change updates the column list
#177 fixes, so basing it on `master` would just conflict.

### The change

`batt_temp_c` is the arithmetic mean of all 24 temperature sensors, but a BMS derates on its
**hottest** sensor — so the one quantity a charging curve needs is the one column the CSV
didn't record. Measured spread is ~3 °C coolest-to-hottest during a *gentle* AC charge, the
hottest sensor ~1.5 °C above the mean. Under a 100 kW DC session it's likely wider, and until
now unmeasurable after the fact.

Adds `batt_tmin_c` / `batt_tmax_c` from `ms_v_bat_pack_tmin` / `tmax`. **No new poll or
decode** — `BmsSetCellTemperature` already populates these on every `0x1814` reply; the row
emitter simply never read them.

### Placement — appended, deliberately

The issue asked this to be checked first, so I did. **Nothing in-tree parses these files:**
the HTML report is built from in-memory session state (`m_charge_session.phases[]`, `.svg`),
and `WebChargeReport` only streams bytes. The sole `.csv` references are write, prune, and
basename validation. So the only positional readers are **external** decoders.

They still argue for appending rather than inserting next to `batt_temp_c` where these belong
logically: `phase` was already inserted at the **front** in `0e6f06ed`, shifting every column
once. A second shift would be gratuitous. Upstream's convention for emitted records is
append-only (openvehicles#1409, #1416).

### Verification

- Column list checked against the code's header string: **23 header columns, 23 documented,
  23 format specifiers.**
- Row buffer `320 → 384`, keeping the previous headroom (worst-case row ≈150 chars).
- Docs build passes with the CI flags.
- **Not validated on the vehicle** — needs one charge session to confirm the columns populate
  with sane values. Both read `0.0` until the session's first temperature reply arrives.

### Deliberately not included

The issue's second item — the session summary's `temp_min`/`temp_max` currently track the
range of the **mean** rather than of the sensors, so the summary's "peak temperature" isn't
the peak sensor. Fixing that changes reported summary values, so it belongs in its own change
rather than riding along here.