### PR TITLE
webserver: stream the file editor's response too

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -1188,7 +1188,18 @@ void OvmsWebServer::HandleFile(PageEntry_t& p, PageContext_t& c)
   } else {
     c.head(200);
     if (c.method == "GET") {
-      c.print(content);
+      // Stream the file instead of appending the whole body to the connection buffer.
+      // The editor will open any readable path on /store or /sd, so the body is
+      // arbitrarily large; buffering it whole held the load_file target and the mbuf
+      // copy alive at once. Ownership of the body passes to the sender, which frees it
+      // and itself once the transfer completes and emits the terminating chunk — so
+      // this path deliberately does not fall through to c.done().
+      // An empty body (a directory path, which loads nothing) is handled correctly:
+      // the sender sends the terminating chunk on its first event and retires.
+      extram::string* body = new extram::string();
+      body->swap(content);
+      new HttpExtRamStringSender(c.nc, body);
+      return;
     }
   }
 


### PR DESCRIPTION
Closes #170 — properly this time.

### Why this was reopened

#175 fixed the mechanism and one consumer, but left the place a reviewer would look first:

```cpp
// web_cfg.cpp HandleEditor — before
load_file(path, content);   // arbitrary user-selected file, any size
...
c.print(content);           // entire body appended to the connection mbuf
```

That is the same defect the issue describes, reachable in **core code with no vehicle module
involved**, on any path the editor can open under `/store` or `/sd`. The `const&` change from
#175 did help — three concurrent copies became two — but the whole-file mbuf append was
untouched, and `HttpExtRamStringSender` had exactly **one** caller in the tree (ours).

### The change

Streams via the sender, identical in shape to the charge-report handler. Ownership of the
body passes to the sender, which frees the body and itself and emits the terminating chunk —
so this path `return`s rather than falling through to `c.done()`.

Empty bodies are handled: a directory path loads nothing, and the sender emits the
terminating chunk on its first event and retires. Verified against the class: with
`m_sent == m_msg->size() == 0` the first `MG_EV_SEND` takes the done branch.

### After this

`HttpExtRamStringSender` has two callers — one core, one vehicle — and no whole-file
`c.print()` remains after any `load_file()` in the tree. (The TLS cert loads in
`web_cfg_server_v3.cpp` / `web_cfg_webserver.cpp` populate form fields rather than response
bodies, and are inherently small.)

### Honesty about scope

Exposure here is **milder** than the charge-report case that produced the crash evidence:
config files and TLS certs are small, so it takes a genuinely large file on `/store` or `/sd`
to feel it. The measured 23-files-to-crash → 72-files/20 MB/0-crashes result came from the
vehicle workload, not this one. What this buys is that the core defect is actually fixed in
core, and the mechanism has a consumer that is not a vehicle module.

Not exercised on hardware — the check is opening a large file in the web editor.