### PR TITLE
webserver: keep editor file bodies out of vasprintf

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -659,9 +659,18 @@ static void OutputPluginEditor(PageEntry_t& p, PageContext_t& c)
             "</div>\n"
             "<textarea class=\"form-control fullwidth font-monospace\" rows=\"20\"\n"
               "autocapitalize=\"none\" autocorrect=\"off\" autocomplete=\"off\" spellcheck=\"false\"\n"
-              "id=\"input-content\" name=\"content\">%s</textarea>\n"
-          "</div>\n"
-          , c.encode_html(content).c_str());
+              "id=\"input-content\" name=\"content\">");
+
+  // Emit the body separately rather than as a printf argument: PageContext::printf formats
+  // through vasprintf(), which allocates the entire formatted result with plain malloc() --
+  // internal 8-bit RAM, of which a running module has only tens of kB free. Feeding the
+  // plugin source through it made that allocation scale with the file. print() hands the
+  // (SPIRAM-resident) escaped string straight to mg_send_http_chunk instead.
+  c.print(c.encode_html(content));
+
+  c.print(
+            "</textarea>\n"
+          "</div>\n");
 
   c.print(
           "<div class=\"text-center\">\n"
@@ -927,7 +936,16 @@ void OvmsWebServer::HandleEditor(PageEntry_t& p, PageContext_t& c)
             "</div>\n"
             "<textarea class=\"form-control fullwidth font-monospace\" rows=\"20\"\n"
               "autocapitalize=\"none\" autocorrect=\"off\" autocomplete=\"off\" spellcheck=\"false\"\n"
-              "id=\"input-content\" name=\"content\">%s</textarea>\n"
+              "id=\"input-content\" name=\"content\">");
+
+  // Same reason as the plugin editor above: keep the file body out of vasprintf(), which
+  // would allocate the whole formatted page -- template plus file -- from internal 8-bit RAM
+  // and fail outright on a large file. The escaped copy already lives in SPIRAM; print()
+  // passes it straight to mg_send_http_chunk.
+  c.print(c.encode_html(content));
+
+  c.printf(
+            "</textarea>\n"
           "</div>\n"
           "<div class=\"row action-group\">\n"
             "<div class=\"col-sm-6\">\n"
@@ -957,7 +975,6 @@ void OvmsWebServer::HandleEditor(PageEntry_t& p, PageContext_t& c)
           "Use a second session to test a web plugin.</p>\n"
       "</div>\n"
     "</div>\n"
-    , c.encode_html(content).c_str()
     , isECUEnabled ? "<button type=\"button\" class=\"btn btn-default action-script-ecu\">Reload ECU Settings</button>\n" : ""
     );
 


### PR DESCRIPTION
Closes #182.

`PageContext::printf` formats through `vasprintf()`, which allocates the entire formatted
result with plain `malloc()`. `CONFIG_SPIRAM_USE_MALLOC` is **unset** in the hardware presets,
so that allocation comes from **internal 8-bit RAM** — a running module has tens of kB free,
against 3.2 MB of SPIRAM.

Both editors passed the file body through it as a `%s` argument, making the allocation scale
with file size:

| function | page |
|---|---|
| `HandleEditor` | `/edit`, the text file editor |
| `OutputPluginEditor` | the plugin editor — same pattern, same file |

The issue named only `/edit`; the plugin editor has the identical defect and is fixed here too.

### The change

The body is emitted separately with `print()`, which hands the escaped string — already
SPIRAM-resident, since `encode_html(const extram::string&)` returns `extram::string` —
straight to `mg_send_http_chunk`. Internal RAM no longer scales with the file.

### Distinct from #170

That issue buffered whole bodies in the connection mbuf, which mongoose allocates from
**SPIRAM** (`mg_locals.h:83-85`). This one landed in **internal RAM**, the scarce pool. Same
symptom shape, different pool, different severity.

The response is still accumulated whole in the mbuf, as every other page in the webserver is.
Bounding that would need the chunked sender, which cannot be used mid-page — it owns the
response lifecycle and emits the terminating chunk itself. Out of scope.

### Correction carried over from #182

I wrote there that `content` was interpolated raw and a file containing `</textarea>` could
break out of the element. **That was wrong** — the `%s` received
`c.encode_html(content).c_str()`. The content was already escaped, and still is. No escaping
behaviour changes here.

### Verification

- Every `c.printf` call in the file re-checked programmatically: **format specifiers match
  argument counts** throughout (this change removes a `%s` and its argument, so a mismatch
  was the obvious risk).
- Same bytes in the same order; the split is purely about which allocator carries the body.
- **Not exercised on hardware.** The check is opening a sizeable file at `/edit` and a plugin
  in the plugin editor, and confirming both render.