### PR TITLE
core: abort with a diagnostic when ExtRamAllocator can't allocate

### DIFF
--- a/vehicle/OVMS.V3/main/ovms.h
+++ b/vehicle/OVMS.V3/main/ovms.h
@@ -41,6 +41,8 @@
 #include <sstream>
 #include "ovms_malloc.h"
 #include "esp_idf_version.h"
+#include "esp_log.h"      // ESP_EARLY_LOGE in ExtRamAllocator's failure path (writes via
+                          // ets_printf, so it does not itself allocate while out of memory)
 
 #if ESP_IDF_VERSION_MAJOR >= 4
 #define CONFIG_CONSOLE_UART_NUM CONFIG_ESP_CONSOLE_UART_NUM
@@ -117,6 +119,19 @@ struct ExtRamAllocator
   T* allocate(std::size_t n)
     {
     auto p = static_cast<T*>(ExternalRamMalloc(n*sizeof(T)));
+    if (p == NULL)
+      {
+      // The C++ allocator contract is "valid storage or throw". Returning NULL breaks it:
+      // libstdc++ containers assume success and write through the pointer immediately, so
+      // an exhausted SPIRAM heap surfaces as a StoreProhibited panic at address 0, several
+      // frames away inside <bits/basic_string.h> — which points investigation at string
+      // handling rather than at the allocation that actually failed.
+      // CONFIG_CXX_EXCEPTIONS is off, so throwing bad_alloc is not available; abort with a
+      // diagnostic instead, which is what libstdc++ itself does under -fno-exceptions.
+      ESP_EARLY_LOGE("extram", "ExtRamAllocator: allocation of %u bytes failed (SPIRAM exhausted)",
+        (unsigned)(n * sizeof(T)));
+      abort();
+      }
     return p;
     }
   void deallocate(T* p, std::size_t) noexcept { std::free(p); }


### PR DESCRIPTION
Closes #184.

```cpp
// before
T* allocate(std::size_t n)
  {
  auto p = static_cast<T*>(ExternalRamMalloc(n*sizeof(T)));
  return p;                       // no null check, no throw, no abort
  }
```

The C++11 allocator contract is *valid storage or throw*. Returning NULL breaks it:
libstdc++ containers assume success and write through the pointer immediately, so an
exhausted SPIRAM heap surfaces as a `StoreProhibited` panic at address 0, several frames
deep inside `<bits/basic_string.h>`.

### Why it matters beyond tidiness

That backtrace is actively misleading. Investigating #182 I read it as a string-handling
problem and fixed the wrong allocation in the wrong memory pool, because nothing in it named
the allocation that had actually failed:

```
char_traits::assign          <- writes to NULL
_S_copy
basic_string<..., ExtRamAllocator<char>>::reserve()
PageContext::encode_html()
```

### The change

`CONFIG_CXX_EXCEPTIONS` is unset, so `throw std::bad_alloc` is unavailable — under
`-fno-exceptions` libstdc++ turns that into `abort()` anyway. This aborts with a message
naming the requested size. `ESP_EARLY_LOGE` writes via `ets_printf`, so it does not itself
allocate while out of memory.

### Scope and limits

**24 files** use `extram::string` / `extram::ostringstream` — web page generation, charge
reports, `load_file()` — so this is not editor-specific.

It does **not** make any allocation succeed, and it does not fix #182. Callers that can bound
their own demand still must. What changes is that the failure becomes a legible
out-of-memory abort naming the size, instead of a NULL write pointing at libstdc++.

Adds `#include "esp_log.h"` to `ovms.h` for the log macro.

Not exercised on hardware yet — the check is reproducing #182 and confirming the panic now
names the allocation rather than address 0.