### PR TITLE
webserver: refuse to open oversized files in the editors

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -34,6 +34,20 @@
 #define _attr(text) (c.encode_html(text).c_str())
 #define _html(text) (c.encode_html(text).c_str())
 
+// Largest file the text editor will open.
+//
+// Rendering a file costs roughly TWICE its size in SPIRAM at peak: the body is held in
+// `content`, and the HTML-escaped copy is appended to the connection's send buffer, which
+// mongoose only drains from mg_mgr_poll() — i.e. after the page handler has returned. Both
+// therefore exist at once, and neither can be streamed away mid-page.
+//
+// Opening a 2.67 MB file on a module with ~3.2 MB of SPIRAM free crashed it outright
+// (issue #182): the second allocation failed and, since ExtRamAllocator returned NULL
+// rather than aborting, libstdc++ wrote to address 0. Refuse up front instead. 512 kB is
+// far above any config file, script or plugin the editor is meant for, and leaves ample
+// headroom at ~1 MB peak.
+#define EDITOR_MAX_FILE_SIZE  (512 * 1024)
+
 /**
  * HandleCommand: execute command, stream output
  */
@@ -557,11 +571,22 @@ static void OutputPluginEditor(PageEntry_t& p, PageContext_t& c)
   }
 
   // read plugin content:
+  // Same size ceiling as the text editor, for the same reason (see EDITOR_MAX_FILE_SIZE):
+  // rendering costs roughly twice the file in SPIRAM at peak. A plugin should never come
+  // close, but the file is on writable storage and nothing else bounds it.
   std::string path = "/store/plugin/" + key;
   std::ifstream file(path, std::ios::in | std::ios::binary | std::ios::ate);
   if (file.is_open()) {
     auto size = file.tellg();
-    if (size > 0) {
+    if (size > EDITOR_MAX_FILE_SIZE) {
+      char msg[200];
+      snprintf(msg, sizeof(msg),
+        "<p class=\"lead\">Plugin not loaded</p><p>It is %lu bytes, over the %lu editor "
+        "limit. Saving from here would overwrite it with an empty file.</p>",
+        (unsigned long) size, (unsigned long) EDITOR_MAX_FILE_SIZE);
+      c.alert("danger", msg);
+    }
+    else if (size > 0) {
       content.resize(size, '\0');
       file.seekg(0);
       file.read(&content[0], size);
@@ -865,7 +890,15 @@ void OvmsWebServer::HandleEditor(PageEntry_t& p, PageContext_t& c)
       std::ifstream file(path, std::ios::in | std::ios::binary | std::ios::ate);
       if (file.is_open()) {
         auto size = file.tellg();
-        if (size > 0) {
+        if (size > EDITOR_MAX_FILE_SIZE) {
+          char msg[160];
+          snprintf(msg, sizeof(msg),
+            "<li>File is too large to edit: %lu bytes, limit %lu. "
+            "Use <code>/api/file</code> to download it instead.</li>",
+            (unsigned long) size, (unsigned long) EDITOR_MAX_FILE_SIZE);
+          error += msg;
+        }
+        else if (size > 0) {
           content.resize(size, '\0');
           file.seekg(0);
           file.read(&content[0], size);


### PR DESCRIPTION
Closes #182 (reopened after #183 turned out not to fix it).

### The actual defect

Rendering a file in the editor costs roughly **twice its size in SPIRAM** at peak:

| | |
|---|---|
| body held in `content` | 1× file |
| HTML-escaped copy appended to the connection mbuf | 1× file |

Both exist simultaneously — mongoose only drains `send_mbuf` from `mg_mgr_poll()`, which
cannot run while the page handler is still executing.

On a 2.67 MB file with ~3.2 MB free the second allocation failed, and because
`ExtRamAllocator` returns NULL rather than aborting (#184), libstdc++ wrote to address 0 —
`StoreProhibited`, module down. Reproduced on hardware, **identical before and after #183**.

### Approaches that don't work

Recording these so they aren't retried:

- **Escaping in bounded slices** — moves the second copy from `encode_html` into the mbuf.
  Same peak. I costed this before writing it: 5,375,364 B against 3,196,560 B free.
- **The chunked sender** used for `/api/file` — it owns the entire response lifecycle and
  emits the terminating chunk itself, so it cannot be used for a body embedded mid-page.

### The fix

Refuse up front, with a message naming the actual size and the limit, pointing at
`/api/file` for downloading instead. **512 kB** is far above any config file, script or
plugin the editor exists for, and caps peak at ~1 MB.

Applied to **both** editors — the text editor, and the plugin editor, which loads from
`/store/plugin/<key>` and had the same unbounded read. The plugin case surfaces a `danger`
alert rather than silently rendering an empty textarea, since saving from that state would
overwrite the plugin with nothing.

### Relationship to the other PRs

- **#183** (merged) — moved the body out of `vasprintf`. Real, separate, internal-RAM.
- **#185** — makes `ExtRamAllocator` abort with a diagnostic instead of returning NULL.
  Complementary: this PR stops the editor asking for too much; #185 makes any *other*
  over-ask legible instead of a NULL write.

### Verification

Not yet exercised on hardware. The check is opening the same 2.67 MB CSV at `/edit` and
seeing the error page instead of a dead module, then confirming a normal config file still
opens and saves.