### PR TITLE
12V protection: fix the deep sleep wake/boot/alert loop and the alert metric lifecycle

### DIFF
--- a/docs/source/userguide/installation.rst
+++ b/docs/source/userguide/installation.rst
@@ -287,11 +287,20 @@ no components). This is by default done every 60 seconds. If you use the auto sh
 the vehicle operational state, consider lowering this to e.g. 15 seconds to get a quick detection
 of the vehicle being switched on.
 
+The wakeup test runs before any peripherals are powered up, so it measures the unloaded battery
+voltage, while the shutdown test measures the battery under the module's own load. On a weak
+battery the difference can be more than a volt, so the wakeup level needs to sit above the
+shutdown level by a margin, or the module boots straight into another shutdown and keeps cycling.
+If you do not configure ``12v.wakeup`` explicitly, the wakeup level is derived from the shutdown
+level plus ``12v.wakeup_margin`` (1.5V by default). An explicitly configured ``12v.wakeup`` is
+used as-is if it is higher than that.
+
 Configuration can be done via the web UI or by these config variables::
 
   config set vehicle 12v.shutdown <voltage>
   config set vehicle 12v.shutdown_delay <minutes>
   config set vehicle 12v.wakeup <voltage>
+  config set vehicle 12v.wakeup_margin <voltage>
   config set vehicle 12v.wakeup_interval <seconds>
 
 

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,17 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- 12V protection: the deep sleep wakeup level is now derived from the shutdown level when it has
+    not been configured explicitly. The wakeup test runs before the peripherals are powered up and
+    therefore reads the unloaded battery voltage, while the shutdown test reads it under the
+    module's load — so a wakeup level at or near the shutdown level made the module boot straight
+    into another shutdown and cycle on an already depleted battery. Previously the vehicle
+    framework did not set a wakeup level at all, so with the default (unset) 12v.wakeup the boot
+    check was skipped entirely and every wakeup became a full boot. An explicitly configured
+    12v.wakeup is still honoured if it is higher than the derived level.
+  New configs:
+    - [vehicle] 12v.wakeup_margin           -- Volts added to 12v.shutdown to derive the deep
+                                               sleep wakeup level (default 1.5)
 - Server V2 & V3: suspend periodic reconnect attempts on authentication failures (incorrect credentials)
     to avoid blocking of shared public IP addresses (mobile network proxies/gateways). A new reconnect
     attempt is triggered by changing the configuration. Changing the server configuration now also

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -999,6 +999,15 @@ void OvmsVehicle::VehicleTicker1(std::string event, void* data)
         int shutdown_delay = MyConfig.GetParamValueInt("vehicle", "12v.shutdown_delay", 2);
         if (m_12v_low_ticker > shutdown_delay)
           {
+          // Set the wakeup level for the boot check: Boot::Boot() reads the ADC before any
+          //  peripherals are powered up, so it sees the unloaded battery voltage, while the
+          //  shutdown check above sees the battery under the module's own load. Waking at the
+          //  bare shutdown threshold would boot into another shutdown, looping the module on an
+          //  already depleted battery, so add a margin covering the loaded/unloaded difference.
+          //  An explicitly configured wakeup level is never lowered by this:
+          float wakeup_margin = MyConfig.GetParamValueFloat("vehicle", "12v.wakeup_margin", 1.5);
+          float wakeup_level = MyConfig.GetParamValueFloat("vehicle", "12v.wakeup", 0);
+          MyBoot.SetMin12VLevel(std::max(wakeup_level, shutdown_threshold + wakeup_margin));
           MyEvents.SignalEvent("vehicle.alert.12v.shutdown", NULL);
           if (m_autonotifications) Notify12vShutdown();
           // shutdown in 10 seconds to allow for scripts & notifications:

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -974,16 +974,20 @@ void OvmsVehicle::VehicleTicker1(std::string event, void* data)
     float alert_threshold = MyConfig.GetParamValueFloat("vehicle", "12v.alert", 1.6);
     if (!alert_on && volt > 0 && vref > 0 && vref-volt > alert_threshold)
       {
-      StandardMetrics.ms_v_bat_12v_voltage_alert->SetValue(true);
+      alert_on = true;
       MyEvents.SignalEvent("vehicle.alert.12v.on", NULL);
       if (m_autonotifications) Notify12vCritical();
       }
     else if (alert_on && volt > 0 && vref > 0 && vref-volt < alert_threshold*0.6)
       {
-      StandardMetrics.ms_v_bat_12v_voltage_alert->SetValue(false);
+      alert_on = false;
       MyEvents.SignalEvent("vehicle.alert.12v.off", NULL);
       if (m_autonotifications) Notify12vRecovered();
       }
+    // …publish on every check, not only on transitions, so the metric is defined as soon as a
+    //  12V reading is available and does not go stale while the state is simply unchanged:
+    if (volt > 0)
+      StandardMetrics.ms_v_bat_12v_voltage_alert->SetValue(alert_on);
 
     // Check for shutdown level:
     if (!m_12v_shutdown_ticker && !MyBoot.IsShuttingDown())

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
@@ -944,8 +944,8 @@ void OvmsVehicleFactory::vehicle_aux(int verbosity, OvmsWriter* writer, OvmsComm
 
   if (StdMetrics.ms_v_bat_12v_voltage_alert->IsDefined())
     {
-    const std::string &auxBattI = StdMetrics.ms_v_bat_12v_voltage_alert->AsUnitString("-", Volts, 2);
-    writer->printf("  Voltage Alert: %s\n", auxBattI.c_str());
+    const std::string &auxBattAlert = StdMetrics.ms_v_bat_12v_voltage_alert->AsUnitString("-");
+    writer->printf("  Voltage Alert: %s\n", auxBattAlert.c_str());
     }
   }
 

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -105,7 +105,7 @@ MetricsStandard::MetricsStandard()
   ms_v_bat_12v_voltage = new OvmsMetricFloat(MS_V_BAT_12V_VOLTAGE, SM_STALE_HIGH, Volts, true);
   ms_v_bat_12v_current = new OvmsMetricFloat(MS_V_BAT_12V_CURRENT, SM_STALE_HIGH, Amps);
   ms_v_bat_12v_voltage_ref = new OvmsMetricFloat(MS_V_BAT_12V_VOLTAGE_REF, SM_STALE_HIGH, Volts, true);
-  ms_v_bat_12v_voltage_alert = new OvmsMetricBool(MS_V_BAT_12V_VOLTAGE_ALERT, SM_STALE_MID);
+  ms_v_bat_12v_voltage_alert = new OvmsMetricBool(MS_V_BAT_12V_VOLTAGE_ALERT, SM_STALE_MID, Other, true);
 
   ms_v_bat_pack_level_min = new OvmsMetricFloat(MS_V_BAT_PACK_LEVEL_MIN, SM_STALE_HIGH, Percentage);
   ms_v_bat_pack_level_max = new OvmsMetricFloat(MS_V_BAT_PACK_LEVEL_MAX, SM_STALE_HIGH, Percentage);


### PR DESCRIPTION
Fixes #187.

Three defects in the framework 12V protection path, all surfaced by a real deep discharge event on the Solterra between 2026-08-01 and 2026-08-09. Detection itself was correct; everything downstream of the shutdown decision was not.

Based on upstream/master so the series can go upstream as-is.

## 1. The vehicle shutdown path never set a boot wakeup level

`OvmsVehicle::Ticker1()` called `MyBoot.DeepSleep()` without calling `Boot::SetMin12VLevel()`, unlike the powermgmt shutdown path which derives one. `Boot::Boot()` therefore gated on the raw `12v.wakeup` config value, which defaults to 0 - and 0 disables the boot check entirely, so every wakeup became a full boot with modem and WiFi brought up on the battery the shutdown was meant to protect. The user guide documents these as "short wakeups of ~3 seconds (only CPU, no components)".

Even with `12v.wakeup` set, the two checks read different things: `Boot::Boot()` samples the ADC before any peripheral is initialised (unloaded voltage), while the Ticker1 shutdown check samples it under the module's own load. A depleted lead-acid battery recovers well above its loaded voltage within a minute of rest, so any wakeup level below shutdown plus the loaded/unloaded gap passes the boot gate and fails the shutdown check again immediately.

Observed with `12v.shutdown=10.5`, `12v.wakeup=11`: consecutive deep sleep shutdowns 324 s apart with ~192 s uptime each, a 59% duty cycle sustained for eight days.

Fix: derive the wakeup level from `12v.shutdown` plus a new `12v.wakeup_margin` (default 1.5V), taking the maximum with `12v.wakeup` so an explicit setting is never lowered. Set at the point the shutdown is decided, which also makes the `batt.12v.shutdown` notification accurate, since it prints `Boot::GetMin12VLevel()` verbatim.

## 2. `v.b.12v.voltage.alert` was not persisted

It is the only 12V related bool without persistence, so it reset to false on every deep sleep wakeup, the `!alert_on` guard passed again and `Notify12vCritical()` re-fired. The event above produced 1378 "12V Battery critical" notifications for one unresolved condition.

RTC slow memory survives deep sleep and soft reset and is cleared on power cycle, which is the right lifetime here. `OvmsMetricBool`'s constructor only calls `SetModified()` when the restored value differs from the false initialiser, so a persisted false still leaves the metric undefined and the boot state of a healthy module is unchanged. Only an active alert survives. Costs one of the 100 persistent value slots.

## 3. The alert metric went stale two minutes after any transition

`SetValue()` was only called inside the transition guards, so the metric was undefined until the first real transition and stale 120 s (`SM_STALE_MID`) after any transition. It is now published on every 60 s check once a 12V reading exists. `SetModified()` refreshes `m_lastmodified` and clears `m_stale` on both branches of `OvmsMetricBool::SetValue()`, so an unchanged value stays fresh without emitting a change notification; the events and notify calls stay inside the guards, unchanged.

Side effect: `stat aux` now shows the Voltage Alert line on a healthy module, where it was previously omitted as undefined. That line passed `Volts` and a precision to a bool, which `OvmsMetricBool::AsString` ignores, and reused `auxBattI` from the current block; both tidied since the line is now reachable.

## New config

    [vehicle] 12v.wakeup_margin    Volts added to 12v.shutdown to derive the deep
                                   sleep wakeup level (default 1.5)

## Validation status

Compile only so far. The behaviour change is on a path that needs a discharged 12V battery to exercise end to end, so the loop fix is not yet confirmed on vehicle. The persistence and freshness changes are observable without a discharge (`metrics persist`, `stat aux`, metric staleness) and will be checked on the module.
