### PR TITLE
e-TNGA: publish v.b.cac / v.b.soh / v.b.capacity from 0x1D3E

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,33 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): battery capacity and state of health are now
+    published. v.b.cac reports the pack's full-charge capacity as measured by the BMS, and
+    v.b.soh / v.b.capacity are derived from it against the pack's nominal capacity. Only the
+    96-cell pack (2022-24) has an established nominal, so on other pack variants v.b.soh and
+    v.b.capacity stay empty until you set the nominal yourself — an incorrect nominal produces a
+    believable but wrong percentage, so no value is published rather than a guessed one. Note
+    that state of health is NOT clamped at 100%: a reading above 100% means the configured
+    nominal does not match the pack, and is reported as-is so the misconfiguration is visible.
+    Third-party app percentages are not comparable unless they use the same nominal.
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge report's implied-capacity estimate
+    is now computed from BMS state of charge instead of the displayed percentage. The displayed
+    percentage spans only the usable part of the pack and stops at 100% once the BMS reaches
+    about 95%, so the old estimate read roughly 10% low and was wrong entirely for any session
+    ending at a full charge. The report also now shows the BMS-measured capacity next to the
+    implied one for comparison.
+- Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge-session CSV records three further
+    columns ("lifetime_min", "lifetime_acc", "delivered_ah") holding two lifetime counters read
+    from the battery ECU alongside the module's own charge integral. The counters' units are not
+    yet established, so they are logged raw for analysis. As before the columns are appended at
+    the end of each row, so existing tooling is unaffected.
+
+New configs:
+- [xte] bat.nominal.ah: pack nominal full-charge capacity in Ah, used as the denominator for
+    v.b.soh. Default 0 = derive from the detected pack (96-cell only).
+- [xte] bat.nominal.volt: pack nominal voltage in V, used to convert capacity to kWh for
+    v.b.capacity. Default 0 = derive from the detected pack (96-cell only).
+
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge-session CSV now also records the
     coolest and hottest pack temperature sensors ("batt_tmin_c" / "batt_tmax_c") alongside the
     existing average. The battery derates on its hottest sensor, so charging-curve analysis

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -8,10 +8,17 @@ Open Vehicle Monitor System v3 - Change log
     v.b.capacity stay empty until you set the nominal yourself under "Battery capacity reference"
     on the vehicle configuration page — an incorrect nominal produces a believable but wrong
     percentage, so no value is published rather than a guessed one. That page also shows the
-    detected pack and the reference currently in use. Note
-    that state of health is NOT clamped at 100%: a reading above 100% means the configured
-    nominal does not match the pack, and is reported as-is so the misconfiguration is visible.
-    Third-party app percentages are not comparable unless they use the same nominal.
+    detected pack and the reference currently in use. Note that state of health is NOT clamped
+    at 100%: a reading above 100% means the configured nominal does not match the pack, and is
+    reported as-is so the misconfiguration is visible. Third-party app percentages are not
+    comparable unless they use the same nominal.
+  New configs:
+    - [xte] bat.nominal.ah                  -- Pack nominal full-charge capacity in Ah, the
+                                               denominator for v.b.soh (default 0 = derive
+                                               from the detected pack, 96-cell only)
+    - [xte] bat.nominal.volt                -- Pack nominal voltage in V, used to convert the
+                                               capacity to kWh for v.b.capacity (default 0 =
+                                               derive from the detected pack, 96-cell only)
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge report's implied-capacity estimate
     is now computed from BMS state of charge instead of the displayed percentage. The displayed
     percentage spans only the usable part of the pack and stops at 100% once the BMS reaches
@@ -23,13 +30,6 @@ Open Vehicle Monitor System v3 - Change log
     from the battery ECU alongside the module's own charge integral. The counters' units are not
     yet established, so they are logged raw for analysis. As before the columns are appended at
     the end of each row, so existing tooling is unaffected.
-
-New configs:
-- [xte] bat.nominal.ah: pack nominal full-charge capacity in Ah, used as the denominator for
-    v.b.soh. Default 0 = derive from the detected pack (96-cell only).
-- [xte] bat.nominal.volt: pack nominal voltage in V, used to convert capacity to kWh for
-    v.b.capacity. Default 0 = derive from the detected pack (96-cell only).
-
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the charge-session CSV now also records the
     coolest and hottest pack temperature sensors ("batt_tmin_c" / "batt_tmax_c") alongside the
     existing average. The battery derates on its hottest sensor, so charging-curve analysis

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -5,8 +5,10 @@ Open Vehicle Monitor System v3 - Change log
     published. v.b.cac reports the pack's full-charge capacity as measured by the BMS, and
     v.b.soh / v.b.capacity are derived from it against the pack's nominal capacity. Only the
     96-cell pack (2022-24) has an established nominal, so on other pack variants v.b.soh and
-    v.b.capacity stay empty until you set the nominal yourself — an incorrect nominal produces a
-    believable but wrong percentage, so no value is published rather than a guessed one. Note
+    v.b.capacity stay empty until you set the nominal yourself under "Battery capacity reference"
+    on the vehicle configuration page — an incorrect nominal produces a believable but wrong
+    percentage, so no value is published rather than a guessed one. That page also shows the
+    detected pack and the reference currently in use. Note
     that state of health is NOT clamped at 100%: a reading above 100% means the configured
     nominal does not match the pack, and is reported as-is so the misconfiguration is visible.
     Third-party app percentages are not comparable unless they use the same nominal.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_charge_report.cpp
@@ -395,7 +395,7 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
             "phase,elapsed_s,soc_pct,bms_soc_pct,station_kw,battery_kw,hvac_kw,pack_v,pack_a,"
             "batt_temp_c,ambient_c,state,station_max_kw,station_max_a,station_max_v,"
             "car_perm_kw,car_target_a,station_grid_kw,station_present_v,station_present_a,obc_kw,"
-            "batt_tmin_c,batt_tmax_c\n";
+            "batt_tmin_c,batt_tmax_c,lifetime_min,lifetime_acc,delivered_ah\n";
         m_charge_session.csv_started = true;
     }
 
@@ -406,7 +406,7 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
     char amb[16] = "";
     if (StandardMetrics.ms_v_env_temp->IsDefined())
         snprintf(amb, sizeof(amb), "%.1f", StandardMetrics.ms_v_env_temp->AsFloat());
-    char row[384];
+    char row[448];   // grown with the 0x1D70 columns: lifetime_acc alone is up to 10 digits
     float present_v = StandardMetrics.ms_v_charge_voltage->AsFloat();
     float present_a = StandardMetrics.ms_v_charge_current->AsFloat();
     float grid_kw   = m_v_charge_grid_power->AsFloat();
@@ -414,7 +414,7 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
     int phase_no = (m_charge_session.cur >= 0) ? (m_charge_session.cur + 1) : 0;
     snprintf(row, sizeof(row),
         "%d,%d,%.0f,%.1f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%s,%s,"
-        "%.2f,%.0f,%.0f,%.2f,%.0f,%.3f,%.0f,%.0f,%.3f,%.1f,%.1f\n",
+        "%.2f,%.0f,%.0f,%.2f,%.0f,%.3f,%.0f,%.0f,%.3f,%.1f,%.1f,%d,%lld,%.4f\n",
         phase_no,
         elapsed,
         StandardMetrics.ms_v_bat_soc->AsFloat(),
@@ -434,7 +434,14 @@ void OvmsVehicleToyotaETNGA::AppendChargeCsvRow()
         // Populated by BmsSetCellTemperature on every 0x1814 reply, so no new poll is
         // needed. Both read 0 until the first reply of the session arrives.
         StandardMetrics.ms_v_bat_pack_tmin->AsFloat(),
-        StandardMetrics.ms_v_bat_pack_tmax->AsFloat());
+        StandardMetrics.ms_v_bat_pack_tmax->AsFloat(),
+        // 0x1D70 raw counters paired with the module's OWN coulomb integral on the same row.
+        // That pairing is the whole point: regressing d(lifetime_acc) against d(delivered_ah)
+        // over a steady AC session is what resolves the accumulator's unknown scale, and
+        // whether it counts charge as well as discharge.
+        m_v_bat_lifetime_min->AsInt(),
+        (long long) m_v_bat_lifetime_acc->AsInt(),
+        m_charge_session.delivered_ah);
     m_charge_session.csv_buf += row;
 
     // Flush at most every 30 s (or ~4 KB): a 1 Hz open/append/close per row would put
@@ -802,10 +809,31 @@ void OvmsVehicleToyotaETNGA::GenerateChargeReport()
             loss >= 0.0f ? "loss" : "gain?");
         f << "<dt>Charging efficiency</dt><dd>" << b << "</dd>\n";
     }
-    if (start_soc >= 0 && end_soc > start_soc && m_charge_session.delivered_ah > 0.5f) {
-        float cap = m_charge_session.delivered_ah / ((end_soc - start_soc) / 100.0f);
-        snprintf(b, sizeof(b), "%.0f Ah implied (~%.0f%% of 201 Ah nominal)", cap, cap/201.1f*100.0f);
+    // Implied full-charge capacity, computed against BMS SOC rather than display SOC.
+    // Display SOC is the wrong denominator twice over: it is defined across the usable window
+    // (display ~ 1.1145 x BMS - 4.673), so it understates capacity by ~10%; and it clamps at
+    // exactly 100 once BMS >= 95.0%, so any session ending at a full charge has a truncated
+    // span. BMS SOC is the true fraction of full charge, which makes this number directly
+    // comparable to the 0x1D3E-derived v.b.cac shown alongside it.
+    const float start_bms = m_charge_session.start_soc_bms;
+    const float end_bms   = m_v_bat_soc_bms->AsFloat();
+    if (start_bms >= 0.0f && end_bms > start_bms + 1.0f && m_charge_session.delivered_ah > 0.5f) {
+        float cap = m_charge_session.delivered_ah / ((end_bms - start_bms) / 100.0f);
+        float nominal = PackNominalAh();
+        if (nominal > 0.0f)
+            snprintf(b, sizeof(b), "%.0f Ah implied (~%.0f%% of %.0f Ah nominal), BMS SOC %.1f%% &rarr; %.1f%%",
+                     cap, cap / nominal * 100.0f, nominal, start_bms, end_bms);
+        else
+            snprintf(b, sizeof(b), "%.0f Ah implied, BMS SOC %.1f%% &rarr; %.1f%% (no pack nominal configured)",
+                     cap, start_bms, end_bms);
         f << "<dt>Implied capacity</dt><dd>" << b << "</dd>\n";
+
+        float cac = StandardMetrics.ms_v_bat_cac->AsFloat();
+        if (cac > 0.0f) {
+            snprintf(b, sizeof(b), "%.2f Ah reported by the BMS (0x1D3E), %+.1f%% vs implied",
+                     cac, (cac - cap) / cap * 100.0f);
+            f << "<dt>Measured capacity</dt><dd>" << b << "</dd>\n";
+        }
     }
     f << "</dl>\n";
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -24,6 +24,7 @@
    THE SOFTWARE.
 */
 
+#include "ovms_config.h"
 #include "vehicle_toyota_etnga.h"
 #include <algorithm>
 #include <cmath>
@@ -54,6 +55,10 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     m_v_charge_stopreq = MyMetrics.InitInt("xte.v.c.stoprequest", SM_STALE_MID);
     m_v_bat_cap_full = MyMetrics.InitVector<float>("xte.v.b.cap.full", SM_STALE_HIGH, 0, AmpHours);  // 0x1D3E 8x per-module full-charge capacity (data collection)
     m_v_bat_cap_alt  = MyMetrics.InitVector<float>("xte.v.b.cap.alt",  SM_STALE_HIGH, 0, AmpHours);  // 0x1D3F 8x parallel capacity array, function unconfirmed (data collection)
+    // 0x1D70 raw counters. Deliberately Int (not Float+scale): the accumulator's units are
+    // unresolved, so applying any scale here would invent precision we do not have.
+    m_v_bat_lifetime_min = MyMetrics.InitInt  ("xte.v.b.lifetime.min", SM_STALE_MAX, 0, Other);  // 0x1D70 b0-3  ~1/min tick
+    m_v_bat_lifetime_acc = MyMetrics.InitInt64("xte.v.b.lifetime.acc", SM_STALE_MAX, 0, Other);  // 0x1D70 b12-15 load-proportional accumulator
     m_v_bat_heater_status = MyMetrics.InitBool("xte.v.b.heater", SM_STALE_MID);  // This variable stores the status of the battery coolant heater relay
     m_v_bat_soc_bms = MyMetrics.InitFloat("xte.v.b.soc.bms", SM_STALE_MID, 0.0f, Percentage, true);  // This variable stores the SOC as reported by the BMS
     m_v_bat_temp_coolant = MyMetrics.InitFloat("xte.v.b.temp.coolant", SM_STALE_MID, 0.0f, Celcius);  // This variable stores the temperature of the battery coolant
@@ -179,6 +184,94 @@ int OvmsVehicleToyotaETNGA::PackModuleCount(int cellCount)
     }
 }
 
+float OvmsVehicleToyotaETNGA::PackNominalAh()
+{
+    // Explicit override wins: the only way a non-96-cell car gets v.b.soh at all.
+    float cfg = MyConfig.GetParamValueFloat("xte", "bat.nominal.ah", 0.0f);
+    if (cfg > 0.0f)
+        return cfg;
+
+    // Auto only for packs whose nominal is actually established. A wrong nominal is silent --
+    // it yields a plausible percentage -- so an unknown variant gets nothing, not a guess.
+    switch (m_pack_cells) {
+        case 96:  return 201.1f;   // 2022-24: 71.4 kWh / 355 V
+        default:  return 0.0f;     // 78 / 104 / unread: nominal not established
+    }
+}
+
+float OvmsVehicleToyotaETNGA::PackNominalVolt()
+{
+    float cfg = MyConfig.GetParamValueFloat("xte", "bat.nominal.volt", 0.0f);
+    if (cfg > 0.0f)
+        return cfg;
+
+    switch (m_pack_cells) {
+        case 96:  return 355.0f;   // 2022-24 nominal pack voltage
+        default:  return 0.0f;
+    }
+}
+
+void OvmsVehicleToyotaETNGA::UpdateBatteryHealth(const std::vector<float>& caps)
+{
+    if (caps.size() < 8)
+        return;
+
+    // Mean of the 8 slots. The slots are ONE measurement plus fixed per-slot offsets, not 8
+    // independent sensor chains: across a 7-week series the per-slot offsets held to
+    // 0.003-0.034 Ah while the mean moved 0.644 Ah. So the mean is the low-noise estimator.
+    float sum = 0.0f;
+    for (size_t i = 0; i < 8; i++)
+        sum += caps[i];
+    float cac = sum / 8.0f;
+
+    StandardMetrics.ms_v_bat_cac->SetValue(cac);
+
+    float nominal = PackNominalAh();
+    if (nominal <= 0.0f) {
+        // No trustworthy denominator -> publish nothing rather than a plausible wrong number.
+        // Only worth telling the user about once we know the pack is one we have no nominal
+        // for; m_pack_cells == 0 just means 0x182E has not replied yet, which resolves itself.
+        if (m_pack_cells != 0 && !m_nominal_warned) {
+            m_nominal_warned = true;
+            ESP_LOGI(TAG, "v.b.cac = %.2f Ah, but no pack nominal for a %d-cell pack: "
+                          "v.b.soh and v.b.capacity suppressed. Set [xte] bat.nominal.ah "
+                          "(and bat.nominal.volt) to enable them.", cac, m_pack_cells);
+        }
+        return;
+    }
+
+    float soh = cac / nominal * 100.0f;
+    StandardMetrics.ms_v_bat_soh->SetValue(soh);
+
+    // Published unclamped on purpose: an SOH over 100% is a configuration bug (a nominal that
+    // does not match the pack), and clamping would hide exactly the misconfiguration worth
+    // seeing. Warn once per nominal -- keying on the value rather than a bool means correcting
+    // the config re-arms the warning without needing a reboot.
+    if (soh > 102.0f && m_soh_warned_nominal != nominal) {
+        m_soh_warned_nominal = nominal;
+        ESP_LOGW(TAG, "v.b.soh = %.1f%% (%.2f Ah / %.1f Ah nominal). Over 100%% means the "
+                      "nominal does not match this pack, not a healthy battery -- check "
+                      "[xte] bat.nominal.ah against the actual variant.", soh, cac, nominal);
+    }
+
+    // v.b.capacity is defined as USABLE kWh, so scale the full-charge Ah by the usable window
+    // before converting. Display SOC spans BMS [4.19, 93.92] (fitted over 8,901 unclamped
+    // sample pairs), i.e. 89.73% of full charge is reachable by the driver.
+    float volt = PackNominalVolt();
+    if (volt > 0.0f)
+        StandardMetrics.ms_v_bat_capacity->SetValue(cac * PACK_USABLE_FRACTION * volt / 1000.0f);
+}
+
+void OvmsVehicleToyotaETNGA::SetBatteryLifetimeCounters(uint32_t minutes, uint32_t accumulator)
+{
+    // Raw counts, no scale: bytes 12-15 are load-proportional but their units are unresolved
+    // (a passive capture bounds them to roughly 0.5-1.0 A.s per count, and a factor of two is
+    // fatal for any capacity derived from them). Logged so a charge session with a known
+    // integrated Ah can settle it -- see the charge CSV.
+    m_v_bat_lifetime_min->SetValue(static_cast<int>(minutes));
+    m_v_bat_lifetime_acc->SetValue(static_cast<int64_t>(accumulator));
+}
+
 std::vector<float> OvmsVehicleToyotaETNGA::CalculateBatteryCellVoltages(const std::string& data)
 {
     // 0x182E payload (Hybrid Battery ECU): N cells x uint16 BE; each LSB = 5/65535 V (~76 uV).
@@ -198,8 +291,11 @@ std::vector<float> OvmsVehicleToyotaETNGA::CalculateBatteryCellVoltages(const st
 std::vector<float> OvmsVehicleToyotaETNGA::CalculateBatteryCapacityArray(const std::string& data)
 {
     // 0x1D3E / 0x1D3F payload: 8 × uint16 BE, each LSB = 0.01 Ah.
-    // The 8 elements are believed to be per-module (pack = 8 modules); collecting all
-    // 8 raw for study rather than reducing to a scalar. No semantic commitment here.
+    // The 8 elements are NOT 8 independent measurements: over a 7-week series the per-slot
+    // offsets from each reading's own mean held to 0.003-0.034 Ah while the mean itself moved
+    // 0.644 Ah, so this is one measurement plus fixed per-slot offsets. Kept as a vector for
+    // the raw series (two slots do drift relative to the rest, the only per-stack aging signal
+    // we have); UpdateBatteryHealth takes the mean for v.b.cac.
     std::vector<float> caps;
     caps.reserve(8);
 
@@ -827,6 +923,7 @@ void OvmsVehicleToyotaETNGA::SetBatteryCellVoltages(const std::vector<float>& vo
             return;
         }
         m_bms_modules = modules;
+        m_pack_cells = cells;   // observed count: the pack-nominal resolver keys off this
         // Align the arrangement total + per-module grouping with the detected pack.
         // No-op (returns false) when both already match, e.g. the 96-cell pack (4x24).
         BmsCheckChangeCellArrangementVoltage(cells, cells / modules);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -476,6 +476,7 @@ void OvmsVehicleToyotaETNGA::IncomingHybridBatterySystem(uint16_t pid)
             if (m_rxbuf.size() < 16) { ESP_LOGW(TAG, "Short reply for PID %04X (%d bytes)", pid, (int)m_rxbuf.size()); break; }
             std::vector<float> caps = CalculateBatteryCapacityArray(m_rxbuf);
             SetBatteryCapacityFull(caps);
+            UpdateBatteryHealth(caps);   // v.b.cac / v.b.soh / v.b.capacity derive from this DID only
             if (caps.size() >= 8)
                 ESP_LOGD(TAG, "Battery capacity 0x1D3E (Ah): %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f",
                          caps[0], caps[1], caps[2], caps[3], caps[4], caps[5], caps[6], caps[7]);
@@ -489,6 +490,21 @@ void OvmsVehicleToyotaETNGA::IncomingHybridBatterySystem(uint16_t pid)
             if (caps.size() >= 8)
                 ESP_LOGD(TAG, "Battery capacity 0x1D3F (Ah): %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f",
                          caps[0], caps[1], caps[2], caps[3], caps[4], caps[5], caps[6], caps[7]);
+            break;
+        }
+
+        case PID_BATTERY_LIFETIME: {
+            // 244-byte sparse block; only bytes 0-3 and 12-15 are believed populated. Guard on
+            // 16 so a short/truncated reply cannot index past the buffer.
+            if (m_rxbuf.size() < 16) { ESP_LOGW(TAG, "Short reply for PID %04X (%d bytes)", pid, (int)m_rxbuf.size()); break; }
+            uint32_t minutes = GetRxBUint32(m_rxbuf, 0);
+            uint32_t accum   = GetRxBUint32(m_rxbuf, 12);
+            SetBatteryLifetimeCounters(minutes, accum);
+            // Bytes 4-11 are recorded as always-zero from a single 38-sample capture, and that
+            // capture's own notes disagree on whether the first counter starts at byte 0 or 1.
+            // Dump the head so both claims can be settled from module logs rather than re-run.
+            ESP_LOGD(TAG, "0x1D70 len=%d min=%u acc=%u head=%s", (int)m_rxbuf.size(), minutes, accum,
+                     hexencode(m_rxbuf.substr(0, 16)).c_str());
             break;
         }
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -493,6 +493,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
         m_charge_session.start_monotonic = StandardMetrics.ms_m_monotonic->AsInt();
         m_charge_session.start_utc = StandardMetrics.ms_m_timeutc->AsInt();
         m_charge_session.start_soc = (int) StandardMetrics.ms_v_bat_soc->AsFloat();
+        m_charge_session.start_soc_bms = m_v_bat_soc_bms->IsDefined() ? m_v_bat_soc_bms->AsFloat() : -1.0f;
         // Session energy counters reset HERE (session open), NOT in NotifyChargeStart:
         // the framework fires that hook on every ms_v_charge_state change to "charging",
         // including a CHARGE_WAIT pause/resume mid-session, which wiped the energy

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_web.cpp
@@ -121,8 +121,9 @@ void OvmsVehicleToyotaETNGA::WebDeInit()
     MyWebServer.DeregisterPage("/xte/config");
 }
 
-// WebCfgFeatures: configure the e-TNGA TPMS alert thresholds (config namespace "xte").
-// These are otherwise only settable from the shell `config` command.
+// WebCfgFeatures: configure the e-TNGA TPMS alert thresholds and the battery capacity
+// reference (config namespace "xte"). These are otherwise only settable from the shell
+// `config` command.
 void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
 {
     std::string error;
@@ -133,6 +134,13 @@ void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
         float p_alert = atof(c.getvar("tpms_p_alert").c_str());
         float t_warn  = atof(c.getvar("tpms_t_warn").c_str());
         float t_alert = atof(c.getvar("tpms_t_alert").c_str());
+        // Blank means "derive from the detected pack", stored as 0. Read the raw strings so a
+        // cleared field is distinguishable from a typed 0 -- both mean auto, but only a blank
+        // field should stay blank on redisplay.
+        std::string nom_ah_s   = c.getvar("bat_nominal_ah");
+        std::string nom_volt_s = c.getvar("bat_nominal_volt");
+        float nom_ah   = nom_ah_s.empty()   ? 0.0f : atof(nom_ah_s.c_str());
+        float nom_volt = nom_volt_s.empty() ? 0.0f : atof(nom_volt_s.c_str());
 
         // Validate: pressures positive; alert at/below warn (low pressure is worse),
         // temperature alert at/above warn (high temperature is worse).
@@ -142,11 +150,13 @@ void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
             error += "<li>Pressure alert should be at or below the warning threshold (lower pressure is worse).</li>";
         if (t_alert < t_warn)
             error += "<li>Temperature alert should be at or above the warning threshold (higher temperature is worse).</li>";
+        if (nom_ah < 0 || nom_volt < 0)
+            error += "<li>Battery nominal capacity and voltage cannot be negative. Leave a field empty to derive it from the detected pack.</li>";
 
         if (error == "") {
-            // Hold the config lock across all four writes. OvmsConfig::Transaction is a
+            // Hold the config lock across all writes. OvmsConfig::Transaction is a
             // recursive lock that commits only as the OUTERMOST lock is released, so the
-            // four Save() operations coalesce into a single config-store write instead of
+            // Save() operations coalesce into a single config-store write instead of
             // one per setter. Scoped so the lock is released before the response is built.
             {
                 auto lock = MyConfig.Lock();
@@ -154,6 +164,8 @@ void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
                 MyConfig.SetParamValueFloat("xte", "tpms.pressure.alert", p_alert);
                 MyConfig.SetParamValueFloat("xte", "tpms.temp.warn",      t_warn);
                 MyConfig.SetParamValueFloat("xte", "tpms.temp.alert",     t_alert);
+                MyConfig.SetParamValueFloat("xte", "bat.nominal.ah",      nom_ah);
+                MyConfig.SetParamValueFloat("xte", "bat.nominal.volt",    nom_volt);
             }
 
             c.head(200);
@@ -192,6 +204,61 @@ void OvmsVehicleToyotaETNGA::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     snprintf(buf, sizeof(buf), "%.0f", t_alert);
     c.input("number", "Temperature alert", "tpms_t_alert", buf, "Default: 100",
         "<p>Alert when a tyre reaches this temperature (at or above the warning level).</p>", "step=\"1\"", "&deg;C");
+
+    c.fieldset_end();
+
+    c.fieldset_start("Battery capacity reference");
+
+    // What the module is actually using right now, and where it came from. Worth showing:
+    // the whole state-of-health figure hangs on this number matching the pack, and a wrong
+    // value fails silently -- it just produces a believable percentage.
+    OvmsVehicleToyotaETNGA* v = (OvmsVehicleToyotaETNGA*) MyVehicleFactory.ActiveVehicle();
+    int   cells    = v ? v->m_pack_cells : 0;
+    float eff_ah   = v ? v->PackNominalAh()   : 0.0f;
+    float eff_volt = v ? v->PackNominalVolt() : 0.0f;
+
+    std::string status;
+    if (cells == 0) {
+        status = "<p>Pack not identified yet &mdash; the cell count is read from the battery ECU, "
+                 "which only answers while the car is on or charging.</p>";
+    } else {
+        snprintf(buf, sizeof(buf), "%d", cells);
+        status = std::string("<p>Detected pack: <strong>") + buf + " cells</strong>. ";
+        if (eff_ah > 0.0f) {
+            snprintf(buf, sizeof(buf), "%.1f", eff_ah);
+            status += std::string("In use: <strong>") + buf + " Ah</strong>";
+            if (eff_volt > 0.0f) {
+                snprintf(buf, sizeof(buf), "%.0f", eff_volt);
+                status += std::string(" / <strong>") + buf + " V</strong>";
+            }
+            status += ".</p>";
+        } else {
+            status += "No reference capacity is known for this pack, so <code>v.b.soh</code> and "
+                      "<code>v.b.capacity</code> are not published. Set the values below to enable "
+                      "them.</p>";
+        }
+    }
+    c.print(status.c_str());
+
+    // Blank rather than "0" when unset, so the field reads as "automatic" rather than as a
+    // real zero.
+    float nom_ah   = MyConfig.GetParamValueFloat("xte", "bat.nominal.ah",   0.0f);
+    float nom_volt = MyConfig.GetParamValueFloat("xte", "bat.nominal.volt", 0.0f);
+    if (nom_ah > 0.0f) snprintf(buf, sizeof(buf), "%.1f", nom_ah); else buf[0] = 0;
+    c.input("number", "Nominal capacity", "bat_nominal_ah", buf, "Automatic",
+        "<p>The as-new capacity of this pack, used as the reference for state of health "
+        "(<code>v.b.soh</code> = measured &divide; this). Leave empty to derive it from the "
+        "detected pack &mdash; only the 96-cell pack is known, so other packs must set it here.</p>"
+        "<p><strong>This must match your actual pack.</strong> A wrong value still produces a "
+        "believable percentage: reading the same battery against a 195 Ah reference instead of "
+        "201.1 Ah moves state of health by 3 points. A result above 100% means this value is "
+        "wrong, not that the battery is better than new &mdash; it is shown unclamped so the "
+        "mismatch is visible.</p>", "min=\"0\" step=\"0.1\"", "Ah");
+    if (nom_volt > 0.0f) snprintf(buf, sizeof(buf), "%.0f", nom_volt); else buf[0] = 0;
+    c.input("number", "Nominal voltage", "bat_nominal_volt", buf, "Automatic",
+        "<p>Nominal pack voltage, used only to express capacity in kWh "
+        "(<code>v.b.capacity</code>). Leave empty to derive it from the detected pack.</p>",
+        "min=\"0\" step=\"1\"", "V");
 
     c.fieldset_end();
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.cpp
@@ -66,9 +66,10 @@ static const OvmsPoller::poll_pid_t obdii_polls_base[] = {
   { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_TEMPERATURES,       { 0,  0, 10, 0}, 0, ISOTP_STD }, // 0x1814 cell-temp array: DRIVING @10s
   { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CELL_VOLTAGES,      { 0,  0,  5, 0}, 0, ISOTP_STD }, // 0x182E cell voltages: DRIVING @5s
 
-    // Capacity arrays (data-collection only) — also polled in charge (block B)
-  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY,           { 0, 60,120, 0}, 0, ISOTP_STD }, // 0x1D3E 8x per-module full-charge capacity (Ah)
+    // Capacity arrays — also polled in charge (block B)
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY,           { 0, 60,120, 0}, 0, ISOTP_STD }, // 0x1D3E 8x full-charge capacity (Ah) -> v.b.cac/soh/capacity
   { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY_ALT,       { 0, 60,120, 0}, 0, ISOTP_STD }, // 0x1D3F 8x parallel capacity array, function unconfirmed
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_LIFETIME,           { 0,  0, 60, 0}, 0, ISOTP_STD }, // 0x1D70 lifetime counters: DRIVING @60s (data collection, units unresolved)
 
     // Driving polls
   { HYBRID_CONTROL_SYSTEM_TX,  HYBRID_CONTROL_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_VEHICLE_SPEED,              { 0,  0,  1, 0}, 0, ISOTP_STD }, // 0x1F0D speed: DRIVING only
@@ -159,6 +160,7 @@ static const OvmsPoller::poll_pid_t obdii_polls_charge[] = {
   { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CELL_VOLTAGES,      { 0,  0, 60, 30}, 0, ISOTP_STD }, // 0x182E cell voltages: AC @60s, DC @30s
   { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY,           { 0,  0, 60, 60}, 0, ISOTP_STD }, // 0x1D3E per-module capacity: AC+DC @60s
   { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_CAPACITY_ALT,       { 0,  0, 60, 60}, 0, ISOTP_STD }, // 0x1D3F parallel capacity array: AC+DC @60s
+  { HYBRID_BATTERY_SYSTEM_TX,  HYBRID_BATTERY_SYSTEM_RX,  VEHICLE_POLL_TYPE_READDATA, PID_BATTERY_LIFETIME,           { 0,  0, 30, 30}, 0, ISOTP_STD }, // 0x1D70 lifetime counters: AC+DC @30s (244B ~36 frames; steady AC current is what resolves the accumulator scale)
 
     POLL_LIST_END
 };

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -39,6 +39,13 @@
 #include "ovms_webserver.h"
 #endif
 
+// Fraction of full-charge capacity the driver can actually reach, used to convert the
+// full-charge Ah of 0x1D3E into the USABLE kWh that v.b.capacity is defined as.
+// Display SOC spans BMS SOC [4.19, 93.92] -> [0, 100] (least-squares fit over 8,901
+// unclamped display/BMS sample pairs), so 89.73% of full charge is reachable. Sanity check:
+// 197.9 Ah x 0.8973 x 355 V = 63.0 kWh against ~64 kWh advertised usable / 71.4 kWh gross.
+#define PACK_USABLE_FRACTION 0.8973f
+
 // Control states
 enum ControlState {
     CS_NONE = 0,
@@ -113,6 +120,9 @@ protected:
         bool  in_session = false;
         int   start_monotonic = 0;
         int   start_soc = -1;
+        float start_soc_bms = -1.0f;   // BMS SOC at session open. The implied-capacity estimate
+                                       // must use this, not display SOC: display SOC is defined
+                                       // over the USABLE window and clamps at 100 once BMS >= 95%.
         time_t start_utc = 0;
         bool  is_dc = false;
         float peak_power = 0.0f;
@@ -214,8 +224,11 @@ protected:
     OvmsMetricFloat* m_v_env_hvac_kwh_drive;  // Driving cabin/HVAC energy (kWh): per-trip time-integral of m_v_env_hvac_power while DRIVING (reset in NotifyVehicleOn)
     OvmsMetricInt*   m_v_charge_outcome;  // 0x1688 charging history / outcome enum
     OvmsMetricInt*   m_v_charge_stopreq;  // 0x1667 charge seq stop request (enum, partial)
-    OvmsMetricVector<float>* m_v_bat_cap_full;  // 0x1D3E 8x u16 x0.01 Ah — per-module full-charge capacity (data collection)
-    OvmsMetricVector<float>* m_v_bat_cap_alt;   // 0x1D3F 8x u16 x0.01 Ah — parallel array, function unconfirmed (data collection)
+    OvmsMetricVector<float>* m_v_bat_cap_full;  // 0x1D3E 8x u16 x0.01 Ah — full-charge capacity array (data collection; mean drives v.b.cac)
+    OvmsMetricVector<float>* m_v_bat_cap_alt;   // 0x1D3F 8x u16 x0.01 Ah — noisy parallel array, function unconfirmed (data collection)
+    OvmsMetricInt*   m_v_bat_lifetime_min;   // xte.v.b.lifetime.min 0x1D70 bytes 0-3, raw u32 — ticks ~1/min, load-independent
+    OvmsMetricInt64* m_v_bat_lifetime_acc;   // xte.v.b.lifetime.acc 0x1D70 bytes 12-15, raw u32 — load-proportional accumulator, UNITS UNKNOWN.
+                                             // int64 because the u32 is already at 3.15e8 and climbs ~36/s: it passes INT32_MAX in ~1.6 years.
     OvmsMetricBool* m_v_bat_heater_status;
     OvmsMetricFloat* m_v_bat_soc_bms;
     OvmsMetricFloat* m_v_bat_temp_coolant;
@@ -232,6 +245,13 @@ protected:
     bool  m_trip_start_valid = false; // false until the baseline is seeded; reset on transition to DRIVING
     OvmsMetricInt* m_v_e_awd;   // 0x1087 b2 AWD / X-MODE status (custom; no standard OVMS metric)
     int m_bms_modules = 4;   // resolved HV pack module count (bootstrap = 96-cell / 4 modules)
+    int m_pack_cells = 0;    // cell count as actually OBSERVED on 0x182E; 0 until the first reply.
+                             // Deliberately not read back from the BMS API: the ctor bootstraps the
+                             // arrangement to 96 cells, so that would report a 96-cell pack on every
+                             // car until 0x182E lands — silently picking the wrong pack nominal.
+    bool  m_nominal_warned = false;      // one-shot: "no pack nominal, v.b.soh suppressed"
+    float m_soh_warned_nominal = 0.0f;   // nominal the "SOH > 100%" warning last fired for, so
+                                         // correcting the config re-arms it without a reboot
     
     void NotifyVehicleOn() override;
     // NotifyChargeStart deliberately not overridden — see vehicle_toyota_etnga.cpp;
@@ -312,6 +332,10 @@ private:
     // Known packs: 96 (2022-24, 4x24), 78 (2025/26 FWD, 3x26), 104 (2025/26 AWD, 4x26).
     // Returns 0 for an unrecognised count so callers keep the last good arrangement.
     int PackModuleCount(int cellCount);
+    // Pack nominal full-charge capacity (Ah) and nominal pack voltage (V) for the detected
+    // variant, or 0.0f when unknown. Config [xte] bat.nominal.ah / bat.nominal.volt override.
+    float PackNominalAh();
+    float PackNominalVolt();
     std::vector<float> CalculateBatteryCellVoltages(const std::string& data);
     std::vector<float> CalculateBatteryCapacityArray(const std::string& data);
     float CalculateBatteryChargingPower(const std::string& data);
@@ -375,6 +399,10 @@ private:
     void SetBatteryCellVoltages(const std::vector<float>& voltages);
     void SetBatteryCapacityFull(const std::vector<float>& caps);
     void SetBatteryCapacityAlt(const std::vector<float>& caps);
+    // Derive v.b.cac / v.b.soh / v.b.capacity from a fresh 0x1D3E array. Called from the
+    // 0x1D3E handler only, so the standard metrics never outrun their source.
+    void UpdateBatteryHealth(const std::vector<float>& caps);
+    void SetBatteryLifetimeCounters(uint32_t minutes, uint32_t accumulator);
     void SetBatteryCellVoltageStatistics(const std::vector<float>& voltages);
     void SetBatteryTemperatures(const std::vector<float>& temperatures);
     void SetBatteryTemperatureStatistics(const std::vector<float>& temperatures);
@@ -496,8 +524,11 @@ enum CANPID
     PID_AC_INPUT_CURRENT = 0x1654,
     PID_AMBIENT_TEMPERATURE = 0x1002,
     PID_AMBIENT_TEMPERATURE_EV = 0x1F46,
-    PID_BATTERY_CAPACITY = 0x1D3E,        // 8x u16 BE x0.01 Ah — per-module full-charge capacity (data-collection only)
-    PID_BATTERY_CAPACITY_ALT = 0x1D3F,    // 8x u16 BE x0.01 Ah — parallel array ~4.5% lower, function unconfirmed (data-collection only)
+    PID_BATTERY_CAPACITY = 0x1D3E,        // 8x u16 BE x0.01 Ah — full-charge capacity; drives v.b.cac (see CalculateBatteryCapacityArray)
+    PID_BATTERY_CAPACITY_ALT = 0x1D3F,    // 8x u16 BE x0.01 Ah — same update events as 0x1D3E but ~20x noisier; raw estimate to 0x1D3E's
+                                          // filtered output (data-collection only, NOT a health source)
+    PID_BATTERY_LIFETIME = 0x1D70,        // 244B sparse block; u32 BE at 0..3 (~1/min) and 12..15 (load-proportional accumulator).
+                                          // Units unresolved — logged as raw counts, no scale applied.
     PID_BATTERY_CELL_VOLTAGES = 0x182E,
     PID_BATTERY_CHARGING_POWER = 0x10D4,
     PID_BATTERY_COOLANT_TEMPERATURE = 0x1848,


### PR DESCRIPTION
Publishes battery capacity and state of health for the e-TNGA platform from `0x1D3E` on the Hybrid Battery System ECU, plus the data collection needed to resolve the `0x1D70` lifetime counters.

## What lands

- `v.b.cac` from the mean of the eight `0x1D3E` slots. Across a 7-week series the per-slot offsets from each reading's own mean held to 0.003-0.034 Ah while the mean itself moved 0.644 Ah, so the slots are one measurement plus fixed offsets, not eight independent chains, and the mean is the low-noise estimator. The raw vector is kept for the per-stack aging signal.
- `v.b.soh` and `v.b.capacity` derived against the pack nominal, with `[xte] bat.nominal.ah` / `bat.nominal.volt` overrides and a web UI panel showing the detected pack and the reference in use.
- `0x1D70` polled for the two lifetime counters, stored as raw `xte.v.b.lifetime.min` / `.acc` with no scale applied, and logged in the charge CSV alongside `delivered_ah`.
- Charge report implied-capacity now computed from BMS SOC rather than display SOC, which spans only the usable window and clamps at 100 once BMS reaches about 95 percent.

## Deliberate design calls

- **Unknown pack publishes nothing.** Only the 96-cell pack has an established nominal. A wrong nominal yields a believable percentage, so an unrecognised variant gets no `v.b.soh` at all rather than a guess, with a one-shot log explaining how to set it.
- **SOH is not clamped at 100 percent.** Over 100 means the configured nominal does not match the pack. Clamping would hide exactly the misconfiguration worth seeing. Warned once per nominal value, so correcting the config re-arms the warning without a reboot.
- **Lifetime counters carry no scale.** A passive capture bounds them to roughly 0.5-1.0 A.s per count, and a factor of two is fatal for anything derived from them. Logged raw so a charge session with a known integrated Ah settles it.
- `m_pack_cells` is the count observed on `0x182E`, not read back from the BMS API, because the constructor bootstraps the arrangement to 96 cells and reading it back would report a 96-cell pack on every car until `0x182E` lands.

## Validation status

Compile only. **Nothing here has run on a vehicle.** Everything is derived from offline analysis of logged captures.

Specific gaps:

- `0x1D70` units are unresolved by design. Resolving them needs one steady-current AC charge with a known integrated Ah.
- `v.b.soh` only publishes on the 96-cell pack. The 78-cell and 104-cell paths are untested, the same gap as the multi-variant BMS work.
- `PACK_USABLE_FRACTION 0.8973` is a least-squares fit over 8,901 unclamped display/BMS sample pairs. Sanity check: 197.9 Ah x 0.8973 x 355 V = 63.0 kWh against roughly 64 kWh advertised usable and 71.4 kWh gross.

## Note on the poll table

`PID_BATTERY_LIFETIME` appears twice on purpose, once per offset block: block A at DRIVING @60s and block B at AC+DC @30s, matching how `PID_BATTERY_CAPACITY` is already split.
