### PR TITLE
e-TNGA: stop the 0x29 charge-fault DID dump firing on scheduled charges

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -537,10 +537,12 @@ void OvmsVehicleToyotaETNGA::SetHvacPower(float kw)
 }
 
 int OvmsVehicleToyotaETNGA::CalculateChargeOutcome(const std::string& data)  { return GetRxBByte(data, 0); }  // 0x1688 26-state enum; RETAINED between sessions (does not reset on plug-in) — report must scope it per-session
-void OvmsVehicleToyotaETNGA::SetChargeOutcome(int v)
+bool OvmsVehicleToyotaETNGA::SetChargeOutcome(int v)
 {
-    if (m_v_charge_outcome->SetValue(v))
+    bool changed = m_v_charge_outcome->SetValue(v);
+    if (changed)
         ESP_LOGD(TAG, "Charge Outcome changed: 0x%02X (%d)", v, v);
+    return changed;
 }
 
 int OvmsVehicleToyotaETNGA::CalculateChargeStopReq(const std::string& data)  { return GetRxBByte(data, 0); }  // 0x1667 enum (partial)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_processor.cpp
@@ -405,9 +405,20 @@ void OvmsVehicleToyotaETNGA::IncomingPlugInControlSystem(uint16_t pid)
         }
         case PID_CHARGE_HISTORY: {
             int outcome_code = CalculateChargeOutcome(m_rxbuf);
-            SetChargeOutcome(outcome_code);
+            bool outcome_changed = SetChargeOutcome(outcome_code);
             // INC-3: flag a diagnostic dump on a genuine charge fault (consumed on CHARGE_WAIT entry).
-            if (IsChargeFaultCode(outcome_code)) {
+            //
+            // 0x1688 RETAINS the last stop reason across sessions and does not reset on plug-in, so
+            // the raw code is NOT evidence of a live fault: on a scheduled (timer-delayed) charge the
+            // module wakes, reads the retained code, and would fire a 30-DID burst at a perfectly
+            // healthy car still waiting for its start time. Two gates are needed, and neither alone
+            // is sufficient:
+            //   - outcome_changed: only a transition INTO a fault code counts, not every re-read.
+            //   - m_charge_engaged: the metric can start at 0 after a boot, which makes the first
+            //     read of a retained fault code look like a genuine transition. Requiring that this
+            //     session actually reached CHARGE_AC/CHARGE_DC rules that out. A real mid-charge
+            //     abnormal stop always satisfies it, because charging was by definition running.
+            if (outcome_changed && IsChargeFaultCode(outcome_code) && m_charge_engaged.load()) {
                 m_charge_fault_pending = true;
                 m_dump_trigger_outcome = outcome_code;                          // the code that IS the fault
                 m_dump_trigger_phase   = (m_charge_session.cur >= 0)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_poll_states.cpp
@@ -546,6 +546,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeHandshakeState()
         m_dump_outcome = -1;
         m_dump_remaining = 0;
         m_charge_fault_pending = false;
+        m_charge_engaged = false;   // no charge has engaged yet this session — see PID_CHARGE_HISTORY
         LogChargeEvent("Plugged in — handshake");
         ESP_LOGI(TAG, "Charge session opened (SOC %d%%)", m_charge_session.start_soc);
     }
@@ -567,6 +568,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeAcState()
 {
     m_charge_state_entry = StandardMetrics.ms_m_monotonic->AsInt();
     m_charge_wait_slept = false;   // real charge engaged — end the wait
+    m_charge_engaged = true;       // ...and from here a 0x1688 fault code can be believed
     SetPollState(PollState::CHARGE_AC);
     SetChargingStatus(true);
     SetChargeState(PollState::CHARGE_AC);
@@ -579,6 +581,7 @@ void OvmsVehicleToyotaETNGA::TransitionToChargeDcState()
 {
     m_charge_state_entry = StandardMetrics.ms_m_monotonic->AsInt();
     m_charge_wait_slept = false;   // real charge engaged — end the wait
+    m_charge_engaged = true;       // ...and from here a 0x1688 fault code can be believed
     SetPollState(PollState::CHARGE_DC);
     SetChargingStatus(true);
     SetChargeState(PollState::CHARGE_DC);

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -190,6 +190,9 @@ protected:
 
     // INC-3: charge-fault diagnostic DID dump (raw one-shot snapshot of OBC DIDs on a fault).
     std::atomic<bool> m_charge_fault_pending{false};   // set on poller task (0x1688 fault), consumed on Events task
+    std::atomic<bool> m_charge_engaged{false};         // true once this session actually reached CHARGE_AC/CHARGE_DC;
+                                                       // gates the fault flag so a RETAINED 0x1688 code read while
+                                                       // waiting for a scheduled charge cannot fake a fault
     std::atomic<int>  m_dump_remaining{0};             // OnceOffPolls still outstanding
     std::map<uint16_t,std::string> m_dump_results;     // pid -> raw response bytes ("" = no reply)
     OvmsMutex         m_dump_mutex;                     // guards m_dump_results (poller task writes, Events task reads)
@@ -439,7 +442,7 @@ private:
     void SetAcUsable(float v);
     void SetMyRoom(bool active);
     void SetHvacPower(float kw);
-    void SetChargeOutcome(int v);
+    bool SetChargeOutcome(int v);   // returns true if the 0x1688 code actually changed
     void SetChargeStopReq(int v);
     void SetThrottle(float pct);
     void SetDriveMode(int mode);


### PR DESCRIPTION
## Problem

`0x1688` "Charging History Information" on the Plug-In Control System / OBC (tx `0x745` / rx `0x74D`) retains the last stop reason across sessions and does not reset on plug-in. The charge-fault dump trigger treated any read of a fault-set code as a live fault, so a timer-delayed AC charge fired a 30-DID `OnceOffPoll` burst every time the module woke and found the car plugged in but still waiting for its start time.

This happened 6 times in one week on a perfectly healthy car.

## Evidence

From session `charge-reports/20260818T213109Z` (found while mining the 08-17..08-21 logs):

- All three dumps fired in `CHARGE_WAIT`, before the module had ever entered `CHARGE_AC`. Log sequence: 17:31:10 handshake -> 17:32:10 CHARGE_WAIT (dump 1) -> sleep -> 17:44:19 CHARGE_WAIT (dump 2) -> sleep -> 23:00:40 CHARGE_WAIT (dump 3) -> 23:00:42 charging starts normally.
- The dump's own snapshot of `0x1688`, taken 3 seconds after the trigger, read `0x20` "Default (AC Charging)". The triggering `0x29` was never the live state.
- Every electrical channel in the dump was idle-normal: `0x10D4` 0.00 kW, `0x1654` AC input current 0, `0x165E` PFC boost 0 V, battery 26.0 C, PFC and DC/DC 30 C, connector connected, lid closed.
- The session then charged 42 to 100 percent and ended `0x21` "AC Charging Complete (Full Charge)", yet its report still carried a "Phase 0 fault (outcome 0x29)" DID-dump section.
- Control cases: the two sessions whose retained code was not in the fault set produced no dump at all (07-27 ended `0x21`, 08-11 ended `0x26`).

The retention hazard was already documented in the comment on `CalculateChargeOutcome()` and handled on the report path, which scopes the outcome per session. Only the dump trigger missed it.

## Fix

Gate the fault flag on two conditions. Neither is sufficient alone, so please do not collapse them:

- **The code actually changed.** A re-read of an unchanged value can no longer re-fire. This needs `SetChargeOutcome()` to return the change bool it was already computing and discarding.
- **The session actually reached `CHARGE_AC`/`CHARGE_DC`.** The outcome metric starts at 0 after a boot, which makes the first read of a retained fault code look like a genuine transition. A real mid-charge abnormal stop always satisfies this gate, because charging was by definition running.

`m_charge_engaged` is `std::atomic<bool>`, matching the existing `m_charge_fault_pending` pattern: the poller task reads it, the Events task writes it on the state transitions. Reading `m_charge_session` from the poller task instead would have been a data race, since that struct is Events-task-owned.

4 files, +24/-5, all under `vehicle_toyota_etnga/src`.

## Testing

Build: `build.yml` green on `6242d4f09` (run 32542782457, dispatched by hand since build.yml only auto-runs on master).

Logic: replayed the recorded 08-18 event sequence through the patched gate conditions. All three false dumps are suppressed, while a genuine mid-charge AC fault, a DC `0x39` fault, and a repeated identical `0x29` in a later session all still fire. The repeat case works because `0x1688` passes through `0x20` while charging, so the next fault is a real edge.

To be clear about what that is: a desk simulation of the gate logic plus a compile. It is not a run of the firmware.

## Not yet validated on the vehicle

Needs one scheduled / timer-delayed AC charge to confirm: expect zero `Charge fault (0x29)` log lines and no "Diagnostic DID dump" section in the resulting report.

No `changes.txt` entry: per CLAUDE.md, plain bug fixes that require no user action are omitted.
