### PR TITLE
e-TNGA docs: resync the reference docs with the shipped code

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
@@ -21,25 +21,28 @@ Vehicle identity
 Battery / BMS
 -------------
 
-The Solterra declares its pack-specific BMS configuration, which lets the e-TNGA platform route the
-per-cell voltage and temperature readings (polled from ``0x182E``) through the BMS API — enabling per-cell
-history, deviation flags, and pack statistics. Without this configuration (as on the bare e-TNGA baseline)
-only the raw cell-voltage metric is published.
+The pack arrangement is owned by the **e-TNGA base**, not by the Solterra: the base declares it
+for every e-TNGA vehicle and derives the actual cell and temperature-sensor counts from the
+``0x182E`` / ``0x1814`` reply length at runtime.  The Solterra therefore adds no BMS code of its
+own — per-cell history, deviation flags and pack statistics come from the shared platform.
+
+The Solterra is the pack the platform defaults to and the only one validated on hardware:
 
 * Pack: 96S CATL, Toyota EM "Type B" cells, 24 temperature sensors
 * Cell arrangement: 96 voltages in 4 modules of 24; 24 temperatures, 6 per module
 * Accept limits: 2.5 to 4.3 V per cell; -30 to +60 °C
 * Deviation thresholds: 20 mV warn / 30 mV alert; 4 °C warn / 8 °C alert
 
+These values live in the e-TNGA base constructor; see the
+:doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the pack variants the
+same code covers.
+
 --------------------------------
 Differences from e-TNGA baseline
 --------------------------------
 
-=========================== ==============
-Function                    Support Status
-=========================== ==============
-BMS v+t Display             Yes
-=========================== ==============
+The Solterra adds no behavioural overrides on top of the e-TNGA platform — the vehicle class is
+a registration wrapper.  Its whole support baseline is the platform's.
 
 Config namespace
 ----------------
@@ -54,6 +57,7 @@ Web UI
 
 All e-TNGA web UI pages are available on the Solterra; see the
 :doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the
-full list.  Notably, ``/bms/cellmon`` is fully populated for the Solterra
-because it declares the BMS pack arrangement — per-cell voltage and
-temperature history, deviation flags, and pack statistics are all enabled.
+full list.  ``/bms/cellmon`` is fully populated — per-cell voltage and
+temperature history, deviation flags, and pack statistics are all enabled —
+because the e-TNGA base declares the BMS pack arrangement for every e-TNGA
+vehicle.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -31,13 +31,22 @@ Temperature Display         Yes
 BMS v+t Display             Yes (see note below)
 TPMS Display                Yes
 Charge Status Display       Yes
-Charge Interruption Alerts  No
+Charge Interruption Alerts  Yes (see note below)
 Charge Control              No
 Cabin Pre-heat/cool Control No
 Lock/Unlock Vehicle         No
 Valet Mode Control          No
 Others                      VIN
 =========================== ==============
+
+.. note::
+
+   **Charge Interruption Alerts** are produced by the OVMS framework, not by this module:
+   e-TNGA writes ``ms_v_charge_state = "stopped"`` whenever a charge phase ends, and the
+   ``OvmsVehicle`` base turns that into a ``charge.stopped`` notification.  The module does
+   not set ``ms_v_charge_substate``, so the notification is raised at **alert** priority
+   rather than **info** — including at an ordinary phase boundary, such as a scheduled
+   charge pausing and resuming, which is not a fault.
 
 .. note::
 
@@ -73,7 +82,7 @@ Unvalidated
    Reasoned from a specification, an analogous DID, or another platform.  Never
    exercised on hardware.
 
-Last reviewed: 2026-07-26.
+Last reviewed: 2026-08-22.
 
 State machine and sleep
 -----------------------
@@ -138,9 +147,12 @@ Charging
      - Energy reconciliation on 2026-06-24: 88% efficiency, station 0.17 kWh ≈
        battery 0.15 kWh, replacing earlier 52%/158% garbage.
    * - Charge-fault diagnostic DID dump
-     - Vehicle-validated
+     - Vehicle-validated (partial)
      - A real ``0x29`` fault on 2026-06-24 fired the dump, labelled the triggering
-       outcome correctly, and rendered decoded values.
+       outcome correctly, and rendered decoded values.  The trigger also fired on
+       *healthy* scheduled AC charges, because it read the retained ``0x1688``
+       value rather than a live fault; that false positive was fixed on
+       2026-08-22 and the fix awaits one scheduled charge to confirm.
    * - CAN-stale logging/accounting suspend
      - Vehicle-validated
      - A real lock produced an 85 s CSV gap with no stale rows, 2026-06-24.
@@ -193,11 +205,25 @@ Battery and 12V
        resolved from this reply and drives temperature grouping, so a module
        booting straight into an AC charge previously kept its constructor default
        for the whole session — harmless on the 96-cell pack, wrong on 78/104.
-   * - Capacity arrays ``0x1D3E`` / ``0x1D3F`` (HV Battery ECU ``0x747``/``0x74F``)
+   * - ``v.b.cac`` / ``v.b.soh`` / ``v.b.capacity`` from ``0x1D3E``
+       (HV Battery ECU ``0x747``/``0x74F``)
+     - Vehicle-validated
+     - Five weeks of logs showed ``0x1D3E`` declining monotonically; it is now
+       summed into ``v.b.cac``, with ``v.b.soh`` and ``v.b.capacity`` derived
+       against the pack nominal.  Confirmed on-module 2026-08-22: the live
+       metrics reproduce exactly from the eight raw per-module slots
+       (197.656 Ah / 98.2875 % / 62.96 kWh).  Only the 96-cell pack has an
+       established nominal; on any other pack ``v.b.soh`` and ``v.b.capacity``
+       stay empty until ``[xte] bat.nominal.ah`` is set by hand.
+   * - Capacity array ``0x1D3F`` (HV Battery ECU ``0x747``/``0x74F``)
      - Log-inferred
-     - Five weeks of logs show ``0x1D3E`` declining monotonically — a good
-       ``v.b.cac`` candidate — while ``0x1D3F`` re-latches each cycle with no trend.
-       Semantics unconfirmed, which is why neither is exposed as ``v.b.cac``.
+     - Re-latches each cycle with no trend; semantics unconfirmed, so it is
+       collected (``xte.v.b.cap.alt``) but not exposed as a standard metric.
+   * - Lifetime counters ``0x1D70`` (HV Battery ECU ``0x747``/``0x74F``)
+     - Unvalidated
+     - Collected raw into ``xte.v.b.lifetime.acc`` / ``.min`` and the charge CSV;
+       the accumulator's scale is unresolved.  It is frozen across a whole AC
+       charge, so resolving it needs a **drive**, not a charge session.
    * - ``v.e.charging12v`` union rule
      - Vehicle-validated
      - The 2026-07-16→20 road trip closed the last two gaps: the ``CHARGE_DC``
@@ -264,10 +290,11 @@ each column is the poll interval in seconds (``0`` = not polled in that state). 
      - 1
      - 1
      - 1
+     - 10
      - 1
      - 1
-     - 1
-     - Control mode (CS_NONE / CS_DRIVING / CS_CHARGING); all active states @1 s
+     - Control mode (CS_NONE / CS_DRIVING / CS_CHARGING); @1 s except WAIT@10 s
+       (slowed to protect the 12 V battery during a scheduled wait)
    * - ``PID_CHARGING_LID`` (``0x1625``)
      - Plug-In Control
      - 0
@@ -325,9 +352,9 @@ each column is the poll interval in seconds (``0`` = not polled in that state). 
      - 10
      - 0
      - 0
-     - 0
+     - 30
      - 20
-     - Cell-temperature array; DRIVING@10 s, DC@20 s
+     - Cell-temperature array; DRIVING@10 s, AC@30 s, DC@20 s
    * - ``PID_BATTERY_CELL_VOLTAGES`` (``0x182E``)
      - HV Battery
      - 0
@@ -347,7 +374,8 @@ each column is the poll interval in seconds (``0`` = not polled in that state). 
      - 0
      - 60
      - 60
-     - 8× per-module full-charge capacity (Ah); data collection
+     - 8× per-module full-charge capacity (Ah) → ``v.b.cac``, and ``v.b.soh`` /
+       ``v.b.capacity`` derived from it against the pack nominal
    * - ``PID_BATTERY_CAPACITY_ALT`` (``0x1D3F``)
      - HV Battery
      - 0
@@ -453,11 +481,13 @@ each column is the poll interval in seconds (``0`` = not polled in that state). 
      - 0
      - 0
      - 0
-     - 0
-     - 0
-     - 0
-     - 0
-     - Not polled in any state; deferred until confirmed useful
+     - 30
+     - 30
+     - 30
+     - 30
+     - Ambient temperature during charging; all four charge states @30 s.  The
+       A/C ECU (``0x7C4``) sleeps while charging, so its ``0x1002`` ambient is
+       DRIVING-only and this is the in-charge source (``ambient_c`` in the CSV)
    * - ``PID_PISW_STATUS`` (``0x1669``)
      - Plug-In Control
      - 0
@@ -484,20 +514,22 @@ each column is the poll interval in seconds (``0`` = not polled in that state). 
      - 0
      - 0
      - 1
-     - 30
+     - 10
      - 1
      - 1
-     - AC charger operation status; drives HANDSHAKE→AC transition
+     - AC charger operation status; drives HANDSHAKE→AC transition.  WAIT@10 s
+       (slowed from 1 s for 12 V; an AC engage is still caught within 10 s)
    * - ``PID_HLC_STATE`` (``0x1666``)
      - Plug-In Control
      - 0
      - 0
      - 0
      - 1
-     - 30
+     - 10
      - 0
      - 1
-     - DC HLC state; drives HANDSHAKE→DC / DC→WAIT transitions
+     - DC HLC state; drives HANDSHAKE→DC / DC→WAIT transitions.  WAIT@10 s
+       (slowed from 1 s for 12 V; a DC re-engage is still caught within 10 s)
    * - ``PID_MIN_PERMISSION_POWER`` (``0x16A1``)
      - Plug-In Control
      - 0
@@ -777,8 +809,9 @@ Solterra" or "Toyota bZ4X").
      - Serves one stored report or CSV by filename (linked from ``/xte/reports``).
    * - ``/xte/config``
      - Vehicle
-     - TPMS alert threshold configuration — sets ``[xte] tpms.*`` config parameters via a
-       form rather than the shell ``config set`` command.
+     - Vehicle configuration — TPMS alert thresholds and the battery capacity reference,
+       i.e. all six ``[xte]`` parameters, via a form rather than the shell ``config set``
+       command.  Also displays the detected pack and the nominal currently in use.
 
 Charge session report
 =====================
@@ -885,6 +918,14 @@ odometer, temperature, and VIN):
   valid for both AC and DC charging
 * ``v.c.kwh.grid`` / ``v.c.kwh.grid.total`` — AC grid energy delivered this session /
   lifetime, integrated from ``0x161D`` (AC only; reads 0 during DC)
+* ``v.b.cac`` — Pack full-charge capacity (Ah) as measured by the BMS, summed from the
+  eight per-module slots of ``0x1D3E`` on the HV Battery ECU (``0x747``)
+* ``v.b.soh`` / ``v.b.capacity`` — State of health (%) and usable capacity (kWh), derived
+  from ``v.b.cac`` against the pack nominal.  Only the 96-cell pack has a built-in nominal;
+  on other variants both stay empty until ``[xte] bat.nominal.ah`` / ``bat.nominal.volt``
+  are set, since a wrong nominal yields a believable but wrong percentage.  ``v.b.soh`` is
+  deliberately **not** clamped at 100 % — a reading above 100 % means the configured
+  nominal does not match the pack
 
 Key custom metrics (``xte.*`` namespace, 18 total ``xte.v.c.*`` plus supporting metrics):
 

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -266,9 +266,28 @@ Driver inputs and TPMS
 PID Polling Logic
 =================
 
-The poll list uses seven columns corresponding to the seven ``PollState`` values.  The number in
-each column is the poll interval in seconds (``0`` = not polled in that state).  All rows use
-``ISOTP_STD`` addressing unless noted.
+The table below shows seven columns, one per ``PollState`` value.  The number in each column is
+the poll interval in seconds (``0`` = not polled in that state).  All rows use ``ISOTP_STD``
+addressing unless noted.
+
+The seven columns are a **merged view**.  A poll list supports only ``VEHICLE_POLL_NSTATES`` (4)
+states, so the implementation splits the seven states across two poll series in
+``vehicle_toyota_etnga.cpp``:
+
+* ``obdii_polls_base`` at state offset 0, whose four columns map to
+  ``SLEEP`` / ``AWAKE`` / ``DRIVING`` / (unused);
+* ``obdii_polls_charge`` registered at offset ``CHARGE_HANDSHAKE`` (3), whose four columns map to
+  ``CHARGE_HANDSHAKE`` / ``CHARGE_WAIT`` / ``CHARGE_AC`` / ``CHARGE_DC``.
+
+A PID polled in both a non-charge and a charge state therefore appears in **both** arrays, each
+carrying only its own side's cadences; the row below is the union of the two.  The fourth column
+of ``obdii_polls_base`` must stay ``0`` in every row — it aliases ``CHARGE_HANDSHAKE``, which
+block B owns, and a nonzero value there would double-poll during handshake.
+
+Within ``obdii_polls_charge`` the row order is also load-bearing: the poller services the list
+top-down each cycle and may not finish before the next tick, so the per-second power and SOC
+channels are listed first and the heavy multiframe arrays last, which makes a cut-short cycle
+defer the slow arrays rather than the live readings.
 
 .. list-table::
    :header-rows: 1
@@ -386,6 +405,18 @@ each column is the poll interval in seconds (``0`` = not polled in that state). 
      - 60
      - 60
      - 8× parallel capacity array; function unconfirmed; data collection
+   * - ``PID_BATTERY_LIFETIME`` (``0x1D70``)
+     - HV Battery
+     - 0
+     - 0
+     - 60
+     - 0
+     - 0
+     - 30
+     - 30
+     - Lifetime counters (244 B, ~36 frames) → ``xte.v.b.lifetime.acc`` / ``.min``;
+       units unresolved, logged raw for analysis (``xte.v.b.lifetime.min`` is the
+       second counter in the same reply)
    * - ``PID_VEHICLE_SPEED`` (``0x1F0D``)
      - Hybrid Control
      - 0
@@ -426,6 +457,59 @@ each column is the poll interval in seconds (``0`` = not polled in that state). 
      - 0
      - 0
      - HVAC power while driving @1 s; feeds cabin-energy integrator
+   * - ``PID_THROTTLE`` (``0x1060``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 0
+     - 0
+     - Accelerator position (byte 1) → ``v.e.throttle``; DRIVING only
+   * - ``PID_DRIVE_MODE_SELECT`` (``0x1004``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 5
+     - 0
+     - 0
+     - 0
+     - 0
+     - Drive mode Eco/Normal/Power (byte 1) → ``v.e.drivemode``; DRIVING only.
+       Note this DID number is ``0x1004`` **on the Hybrid Control ECU**; the same
+       number on the TPMS gateway is tyre temperatures
+   * - ``PID_AWD_MODE`` (``0x1087``)
+     - Hybrid Control
+     - 0
+     - 0
+     - 5
+     - 0
+     - 0
+     - 0
+     - 0
+     - AWD / X-MODE status (byte 2) → ``xte.v.e.awd``; DRIVING only
+   * - ``PID_BRAKE_PEDAL_STROKE`` (``0x104C``)
+     - Brake/EPB (``0x7B0``)
+     - 0
+     - 0
+     - 1
+     - 0
+     - 0
+     - 0
+     - 0
+     - Brake pedal stroke (byte 1) → ``v.e.footbrake``; DRIVING only
+   * - ``PID_EPB_STATUS`` (``0x1045``)
+     - Brake/EPB (``0x7B0``)
+     - 0
+     - 5
+     - 5
+     - 0
+     - 0
+     - 0
+     - 0
+     - Electric parking brake actuator status (byte 1) → ``v.e.handbrake``.
+       Polled in AWAKE too: the EPB stays alive in the parked body tail
    * - ``PID_AMBIENT_TEMPERATURE`` (``0x1002``)
      - Air Conditioner
      - 0
@@ -852,7 +936,8 @@ The CSV is streamed to disk one row per second during active charging (``CHARGE_
     station_max_kw, station_max_a, station_max_v,
     car_perm_kw, car_target_a,
     station_grid_kw, station_present_v, station_present_a, obc_kw,
-    batt_tmin_c, batt_tmax_c
+    batt_tmin_c, batt_tmax_c,
+    lifetime_min, lifetime_acc, delivered_ah
 
 Grouped by what each column represents:
 
@@ -882,6 +967,11 @@ Grouped by what each column represents:
   ``station_present_a`` (zero when not applicable).
 * **``obc_kw``** — diagnostic only: the raw DID ``0x10D4`` reading, which under-reads on
   DC charging.  Use ``battery_kw`` for real power.
+* **Lifetime counters and delivered charge** — ``lifetime_min`` and ``lifetime_acc`` are the
+  two counters read from DID ``0x1D70`` on the HV Battery ECU, logged raw because their units
+  are not established; ``delivered_ah`` is the module's own charge integral for the session.
+  The three are recorded together so the counters can be calibrated against a known
+  ampere-hour figure offline.
 
 .. note::
 
@@ -897,6 +987,42 @@ Grouped by what each column represents:
    ``hvac_kw`` measurements, ``obc_kw`` was added at the end, and ``target_a`` / ``grid_kw``
    / ``present_v`` / ``present_a`` were renamed to their ``car_`` and ``station_``
    prefixed forms.
+
+Configuration
+=============
+
+All e-TNGA vehicles share the ``xte`` config instance, registered by the base module.  Every
+parameter can be set from the shell with ``config set xte <param> <value>`` or from the
+``/xte/config`` web page.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 12 60
+
+   * - Parameter
+     - Default
+     - Meaning
+   * - ``tpms.pressure.warn``
+     - 240
+     - Tyre pressure (kPa) below which a warning is raised
+   * - ``tpms.pressure.alert``
+     - 220
+     - Tyre pressure (kPa) below which an alert is raised
+   * - ``tpms.temp.warn``
+     - 90
+     - Tyre temperature (°C) above which a warning is raised
+   * - ``tpms.temp.alert``
+     - 100
+     - Tyre temperature (°C) above which an alert is raised
+   * - ``bat.nominal.ah``
+     - 0
+     - Pack nominal full-charge capacity (Ah), the denominator for ``v.b.soh``.
+       ``0`` means derive it from the detected pack, which is only established for
+       the 96-cell pack; on other variants ``v.b.soh`` stays empty until this is set
+   * - ``bat.nominal.volt``
+     - 0
+     - Pack nominal voltage (V), used to convert the capacity to kWh for
+       ``v.b.capacity``.  ``0`` derives it from the detected pack, 96-cell only
 
 Metrics
 =======
@@ -927,7 +1053,8 @@ odometer, temperature, and VIN):
   deliberately **not** clamped at 100 % — a reading above 100 % means the configured
   nominal does not match the pack
 
-Key custom metrics (``xte.*`` namespace, 18 total ``xte.v.c.*`` plus supporting metrics):
+Custom metrics (``xte.*`` namespace; 18 ``xte.v.c.*`` charge metrics plus the battery,
+12 V and climate metrics below):
 
 * ``xte.v.c.gridpower`` — Grid input power (kW) from DID ``0x161D``; AC charging only
   (the grid-side companion to ``v.c.power``)
@@ -938,6 +1065,35 @@ Key custom metrics (``xte.*`` namespace, 18 total ``xte.v.c.*`` plus supporting 
   both AC and DC
 * ``xte.v.e.hvac.kwh.drive`` — Per-trip driving cabin/HVAC energy (kWh); time-integral of
   HVAC power while in the DRIVING state, reset at trip start
+* ``xte.v.c.hlcstate`` / ``xte.v.c.piswraw`` — The two raw charge-protocol signals the state
+  machine runs on: the DC HLC state from ``0x1666`` and the PISW cable-seated signal from
+  ``0x1669``, both on the Plug-In Control ECU.  Exposed unmodified so a session can be
+  followed, or a stuck handshake diagnosed, from the metrics alone.  See
+  :doc:`state_machine` for the values each transition tests
+
+HV battery internals (``0x747`` unless noted):
+
+* ``xte.v.b.soc.bms`` — SOC as the BMS reports it (``0x1F5B``), which differs from the
+  displayed ``v.b.soc``: the displayed figure spans only the usable part of the pack and
+  reaches 100 % at roughly 95 % BMS
+* ``xte.v.b.temp.coolant`` / ``xte.v.b.temp.heater`` — Battery coolant and coolant-heater
+  temperatures (°C)
+* ``xte.v.b.heater`` — Battery coolant heater relay engaged
+* ``xte.v.b.cap.full`` / ``xte.v.b.cap.alt`` — The raw eight-slot per-module capacity arrays
+  from ``0x1D3E`` and ``0x1D3F``.  ``cap.full`` is what ``v.b.cac`` is summed from; ``cap.alt``
+  is collected for analysis only, its function unconfirmed
+* ``xte.v.b.lifetime.acc`` / ``xte.v.b.lifetime.min`` — The two lifetime counters from
+  ``0x1D70``, logged raw because their units are unresolved
+
+12 V auxiliary battery (EV ECU ``0x7D2``; see the poll table for the DIDs and scaling):
+
+* ``xte.v.b.12v.voltage`` — Hi-res aux voltage from ``0x15EE``, alongside the module's own
+  ADC reading in ``v.b.12v.voltage``
+* ``xte.v.b.12v.temp`` — Aux battery temperature (°C) from ``0x15F8``
+* ``xte.v.b.12v.cac`` — Aux battery full-charge capacity (Ah) from ``0x15E5``
+* ``xte.v.b.12v.charge.ah`` / ``xte.v.b.12v.discharge.ah`` / ``xte.v.b.12v.readyon.h`` —
+  Lifetime charge and discharge integrals (Ah) and integrated Ready-ON time (h), all from
+  ``0x15E8``
 
 .. toctree::
    :maxdepth: 1

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -87,8 +87,9 @@ Transition diagram
           └─────────────────┘                      │       │
               │     ▲                              │       │
    CAN traffic│     │ bus idle (~120 s)             │       │
-   OR 12V >   │     │ OR 5-min / 15-min watchdog    │       │
-   ref+0.2 V  │     │ (arms escalating cooldown)    │       │
+   OR 12V ↑   │     │ OR 5-min / 15-min watchdog    │       │
+   past       │     │ (arms escalating cooldown)    │       │
+   ref+0.2 V  │     │                               │       │
               ▼     │                              │       │
           ┌─────────────────┐                      │       │
           │      AWAKE      │◄──────────────────┐  │       │
@@ -193,9 +194,12 @@ All edges live in ``etnga_poll_states.cpp``.
      - ``m_last_can2_time`` updated by ``IncomingFrameCan2()`` on any
        CAN2 frame, gated by the cooldown latch (see below).
    * - ``SLEEP → AWAKE``
-     - 12 V > 12 V-ref + 0.2 V
-     - Issues ``m_can2->Reset()`` first to recover from a stuck bus.
-       **Not** gated by the cooldown latch.
+     - 12 V **rising edge** past 12 V-ref + 0.2 V
+     - Edge-triggered, not level-triggered: the latch sets above ref + 0.2 V and
+       clears only below ref + 0.1 V, and is seeded from the current reading on
+       sleep entry, so a level that is merely high does not wake the driver.
+       Issues ``m_can2->Reset()`` first to recover from a stuck bus.  **Not**
+       gated by the cooldown latch, and resets the backoff index.
    * - ``AWAKE → SLEEP``
      - ``IsBusAlive() == false``
      - Triggered when ``m_last_can2_time`` goes stale (~120 s of no
@@ -608,9 +612,10 @@ activity event — drive start, charge start, charge-door open, or 12 V
 bump — calls ``ResetSleepBackoff()`` which returns the index to 0 so the
 next sleep uses the shortest (10 s) window again.
 
-The 12 V-based wake path is **not** gated by ``m_allow_wake`` — high aux
-voltage will pull the driver out of ``SLEEP`` even mid-cooldown, and also
-resets the backoff index.
+The 12 V-based wake path is **not** gated by ``m_allow_wake`` — a rising
+edge on aux voltage will pull the driver out of ``SLEEP`` even mid-cooldown,
+and also resets the backoff index.  It lifts the cooldown gate as it goes, so
+incoming CAN frames can then hold the driver awake.
 
 ``CHARGE_WAIT → SLEEP`` also arms the cooldown latch (using the current
 backoff window) to prevent immediate re-wake from bus noise after the OBC
@@ -663,6 +668,14 @@ Notes and quirks
   ``HandleSleepState`` compares against
   ``ms_v_bat_12v_voltage_ref + 0.2``; on an uncalibrated module the
   CAN-frame path is the reliable wake mechanism.
+* **The 12 V wake is a rising edge, deliberately.**  An earlier
+  level-triggered version oscillated: post-drive and post-charge surface
+  charge holds 12 V above ``ref + 0.2`` for a long time with a dead bus, so
+  every ``SLEEP`` tick reset the backoff, reset the CAN controller and bounced
+  to ``AWAKE`` — a ~2 s SLEEP/AWAKE loop with one CAN reset per cycle, whose
+  sleep re-entry also restarted the cooldown so frame-wake never re-enabled
+  until 12 V decayed.  The ``m_12v_was_high`` latch and its 0.1 V hysteresis
+  band exist to prevent that; do not simplify them back to a level test.
 * **Driving-state exit clears more than charge-state exit.**
   ``HandleDrivingState`` clears speed, gear, and temperatures; charge
   states clean up via ``SetChargingStatus(false)`` and ``SetChargeState``

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/state_machine.rst
@@ -132,8 +132,14 @@ Transition diagram
                      (DRIVING → AWAKE)
 
 There is no direct ``DRIVING → SLEEP`` or charge-state → ``SLEEP`` edge
-(except ``CHARGE_WAIT`` on bus-dead) — most paths pass through ``AWAKE``.
+except from ``CHARGE_WAIT`` — most paths pass through ``AWAKE``.
 There is also no direct edge between ``DRIVING`` and any charge state.
+
+Two edges are deliberately left out of the diagram above to keep it readable,
+both belonging to the ``CHARGE_WAIT`` 12 V-drain cycle described in
+`Sleeping through a charge wait`_: ``CHARGE_WAIT → SLEEP`` on an idle timer
+(not only on a dead bus), and the ``AWAKE → CHARGE_WAIT`` edge that resumes an
+open session on the next wake.  Both appear in the transition table below.
 
 The polling feedback loop
 =========================
@@ -215,6 +221,12 @@ All edges live in ``etnga_poll_states.cpp``.
      - **Changed from old model** (was ``controlstate == CS_CHARGING``).
        Opens the in-RAM charge session if not already open.  Calls
        ``RequestVIN()``.  Sets ``ms_v_charge_state = "prepared"``.
+   * - ``AWAKE → CHARGE_WAIT``
+     - PISW ``≥ 0x02`` AND a charge session is already open
+     - Resume path, not a new plug-in: the module slept during a charge wait and
+       the cable is still seated, so it returns to ``CHARGE_WAIT`` rather than
+       re-running the handshake.  ``m_charge_session.in_session`` is what
+       distinguishes the two.  See `Sleeping through a charge wait`_.
    * - ``AWAKE → SLEEP`` (forced, door watch)
      - ``monotonic - m_awake_entered > 300`` AND charge door never opened
      - 5-minute watchdog when awake with no ``CS_DRIVING`` and charge
@@ -259,6 +271,13 @@ All edges live in ``etnga_poll_states.cpp``.
      - ``IsBusAlive() == false``
      - Bus went dead during scheduled wait (OBC slept or gateway isolated
        OBD).  Arms the escalating cooldown latch.
+   * - ``CHARGE_WAIT → SLEEP`` (12 V drain)
+     - 600 s in ``CHARGE_WAIT`` without charge engaging — or 15 s if this wait
+       was re-entered after a previous wait-sleep
+     - Stops polling so the bus idles and 12 V recovers.  The charge session is
+       **preserved** across the sleep and resumes via ``AWAKE → CHARGE_WAIT``.
+       Arms the escalating cooldown latch.  See
+       `Sleeping through a charge wait`_.
    * - ``CHARGE_AC → CHARGE_WAIT``
      - ``ac_op == 0x00`` (Stop) OR PISW ``== 0x00``
      - Phase ended cleanly or cable pulled.  Sets
@@ -586,6 +605,46 @@ OBC, ``0x745``) **and** in ``DRIVING`` (from the hybrid control ECU,
    exactly this bug; fixed 2026-06-03 — a real DC session that tapered
    from 61.8 → 51.3 kW under a 100 kW station was wrongly reported
    "station 60.6 kW" before the fix.)
+
+Sleeping through a charge wait
+==============================
+
+A scheduled or delayed charge can leave the module sitting in ``CHARGE_WAIT``
+for hours with the cable seated and nothing happening.  Polling through that
+window at the handshake cadence drained the 12 V battery far enough to miss the
+charge it was waiting for, so ``CHARGE_WAIT`` sleeps instead of waiting awake.
+
+Two thresholds govern it (``etnga_poll_states.cpp``)::
+
+    CHARGE_WAIT_SLEEP_SECS   = 600   // first wait with no charge -> sleep
+    CHARGE_WAIT_RESLEEP_SECS = 15    // wait re-entered after a wait-sleep -> sleep fast
+
+The first wait of a session gets a responsive 10-minute window.  Once the
+module has slept out of a wait at least once (``m_charge_wait_slept``), every
+later wait re-sleeps after 15 s, which keeps the duty cycle of the
+wake/check/sleep oscillation low over a long delay.
+
+The cycle is:
+
+#. ``CHARGE_WAIT`` idles past its threshold → ``TransitionToSleepState()``.
+   The in-RAM charge session is **not** reset — ``in_session`` stays true and
+   the streamed CSV stays open.
+#. ``SLEEP`` wakes normally, on CAN traffic or a 12 V rising edge, subject to
+   the escalating cooldown.
+#. ``HandleAwakeState`` sees PISW ``≥ 0x02`` with a session already open and
+   takes ``AWAKE → CHARGE_WAIT`` rather than ``AWAKE → CHARGE_HANDSHAKE``, so
+   the handshake is not re-run and the session is not reopened.
+#. From ``CHARGE_WAIT`` the ordinary engage checks apply: ``ac_op`` of ``0x01``
+   or ``0x02`` enters ``CHARGE_AC``, an HLC state of ``0x0A``–``0x12`` enters
+   ``CHARGE_DC``.  Both are polled at 10 s in ``CHARGE_WAIT``, so a charge that
+   starts during a waking window is caught within 10 s.
+
+The consequence to keep in mind when changing any of this: while the module is
+asleep mid-wait it is not watching the cable.  A cable removed during the sleep
+gap is detected on the next wake by the PISW reconcile in ``HandleAwakeState``,
+which needs two consecutive fresh ``0x00`` reads before it finalizes the
+session — that debounce is what stops the ~30 s post-wake OBC transient from
+closing a session that is still plugged in.
 
 Cooldown latch
 ==============


### PR DESCRIPTION
A doc-vs-code review of the e-TNGA family: both platform docs (`index.rst`, `state_machine.rst`) and the two vehicle pages, checked against all ~6,700 lines of source. Docs only, no code touched.

Split into two commits because the two halves carry different risk: the first fixes statements that are actively wrong, the second fills in behaviour that was simply never written down.

## 60f2ba5f7 - correct statements that no longer match the code

Seven places where the reference docs asserted something the shipped code contradicts.

**Poll table.** `0x1F46` on the Hybrid Control ECU was listed as "not polled in any state", but it is polled at 30s in all four charge states and is the in-charge ambient source. The same page already described it that way in the validation table, so the document contradicted itself. `0x1814` on the HV Battery ECU now shows AC@30s (was 0). Three WAIT-column cadences corrected to what the 12V-drain fix left behind: `0x10D1` 1s to 10s, `0x1684` 30s to 10s, `0x1666` 30s to 10s, all on the Plug-In Control ECU. `0x1D3E` on the HV Battery ECU is no longer labelled "data collection".

**v.b.cac.** The validation table still said the capacity arrays were unconfirmed "which is why neither is exposed as `v.b.cac`". `v.b.cac`, `v.b.soh` and `v.b.capacity` have since shipped from `0x1D3E`. The row is split into three: the exposed `0x1D3E` metrics (vehicle-validated 2026-08-22), `0x1D3F` (still log-inferred, collected only), and `0x1D70` (unvalidated, and its scale needs a drive rather than a charge to resolve). The three standard metrics are added to the Metrics section.

**Charge interruption alerts.** The support table said "No". The module writes `ms_v_charge_state = "stopped"` at every phase end and the `OvmsVehicle` base turns that into a `charge.stopped` notification, so alerts do fire. Set to Yes, with a note recording that the module never sets `ms_v_charge_substate`, so the notification is raised at alert rather than info priority even at an ordinary phase boundary. See the note at the bottom of this description.

**12V wake.** Documented as a level condition ("12V > ref + 0.2V"), which is precisely the behaviour that caused the ~2s SLEEP/AWAKE oscillation. It is a rising edge with a hysteresis latch, seeded on sleep entry. Corrected in the transition table, the diagram and the cooldown section, plus a note explaining why it must not be simplified back.

**Solterra page.** Claimed the Solterra declares its own BMS configuration and that the bare e-TNGA baseline publishes only a raw cell-voltage metric. The pack arrangement moved into the base and the Solterra class is now a registration wrapper with no BMS code. The bZ4X page already says this correctly, so the two sibling pages disagreed with each other.

Also: `/xte/config` was described as TPMS thresholds only when it also sets the battery capacity reference; the validation table review date moved to 2026-08-22; and the `0x29` charge-fault row now records the false positive on healthy scheduled charges and its fix.

## d660d2f69 - document the parts of the module that were missing

**Poll table.** Six polled PIDs had no row at all: `0x1060` throttle, `0x1004` drive-mode-select and `0x1087` AWD (all on the Hybrid Control ECU `0x7D2`), `0x104C` brake pedal stroke and `0x1045` EPB status (both on the Brake/EPB ECU `0x7B0`), and `0x1D70` lifetime counters (HV Battery ECU `0x747`). Five of the six were already discussed by behaviour in the validation table, with change-event counts, so only the rows were missing. The drive-mode row notes that `0x1004` means drive mode on the Hybrid Control ECU and tyre temperatures on the TPMS gateway, since the bare number appears in both places.

**Poll list structure.** The seven-column table is a merged view of two four-column poll series, because a poll list supports only `VEHICLE_POLL_NSTATES` states. Now documented: the split, the offset registration, the fact that a PID polled on both sides appears in both arrays, the invariant that block A's fourth column must stay 0, and the load-bearing row ordering in block B that defers heavy multiframe arrays rather than live readings when a cycle is cut short.

**CHARGE_WAIT 12V drain.** The entire sleep-and-resume cycle was undocumented, including both of its state edges. New "Sleeping through a charge wait" section covers the two thresholds, why a re-entered wait sleeps after 15s instead of 600s, the four steps of the cycle, and the consequence that the cable is unwatched during the sleep gap and reconciled on wake by a two-read PISW debounce. Two transition-table rows added: `AWAKE -> CHARGE_WAIT` on resume with an open session, and `CHARGE_WAIT -> SLEEP` on the idle timer as distinct from the dead-bus edge. Both are noted as deliberately absent from the ASCII diagram, which is left alone.

**Charge CSV.** The documented header was missing its last three columns. Added `lifetime_min`, `lifetime_acc` and `delivered_ah`, plus a bullet explaining they are recorded together so the raw `0x1D70` counters can be calibrated offline against a known ampere-hour figure. The section already warned readers to parse by header name because the column set grows, while the header it printed was itself out of date.

**Configuration.** New section. Six `[xte]` parameters exist and only `tpms.*` was mentioned in passing, on a web UI table row. All six are now listed with defaults and meaning, including what a 0 nominal means for `v.b.soh`.

**Metrics.** Thirteen `xte.*` metrics were never named in either document, among them two of the eighteen `xte.v.c.*` the page claims to maintain. Added `xte.v.c.hlcstate` and `xte.v.c.piswraw`, an HV battery internals group, and a 12V auxiliary battery group.

## Verification

Sphinx was installed in a venv so this was actually built, not just assumed to be CI's problem:

- Docs build exits 0 with zero `WARNING:` / `ERROR:` lines.
- The poll table was machine-diffed against the parsed source arrays: 53 PIDs, 0 discrepancies across all seven state columns. Hand-transcribed numbers are not trustworthy at this size.
- All 37 `xte.*` metric names now appear in the docs, verified by script.
- Every polled PID is documented; `0x1689` is correctly the only doc-only entry, and the page already flags it as declared-but-deferred.
- All `list-table` rows match their `:widths:` counts.

`Docs build` is green on the branch (run 32577436185). `Firmware build` does not run and should not: every changed file is a `*.rst` under `vehicle/**/docs/**`, which its `paths-ignore` excludes.

## One thing deliberately not fixed here

The charge-interruption alert may be a real bug rather than only a doc error. A healthy multi-phase AC session looks like it would raise an alert at every phase boundary, which is the same shape as the `0x29` false positive fixed in #194. That was derived from reading the code path only and has not been checked against a log, so this PR documents the behaviour as it stands rather than changing it. Worth a look at retained logs before deciding whether to set `ms_v_charge_substate` on the pause path.

Separately, `vehicle_toyota_etnga` is the only one of 48 vehicle components with no `CMakeLists.txt`. That is a code change and out of scope for a docs PR, but it is worth fixing before the family goes upstream.
