### PR TITLE
e-TNGA docs: keep platform detail on the platform page

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_subaru_solterra/docs/index.rst
@@ -3,9 +3,9 @@ Subaru Solterra
 ===============
 
 The Subaru Solterra is built on the :doc:`Toyota e-TNGA platform </components/vehicle_toyota_etnga/docs/index>`.
-The e-TNGA module provides the CAN polling, charging state machine, and the common support baseline shared by
-all e-TNGA vehicles. This page documents only what is specific to the Solterra; see the e-TNGA module for
-everything else.
+The e-TNGA module provides the CAN polling, charging state machine, BMS handling, web UI and the
+common support baseline shared by all e-TNGA vehicles. This page documents only what is specific
+to the Solterra; see the e-TNGA platform page for everything else.
 
 ----------------
 Vehicle identity
@@ -16,48 +16,17 @@ Vehicle identity
 :Log tag: ``v-subsol`` (wrapper only). Nearly all logging comes from the shared
    e-TNGA platform under ``v-etnga`` — set that one to collect diagnostics, e.g.
    ``log level verbose v-etnga``.
+:Config namespace: ``xte`` (inherited from the e-TNGA base; the Solterra registers no
+   namespace of its own)
 
--------------
-Battery / BMS
--------------
-
-The pack arrangement is owned by the **e-TNGA base**, not by the Solterra: the base declares it
-for every e-TNGA vehicle and derives the actual cell and temperature-sensor counts from the
-``0x182E`` / ``0x1814`` reply length at runtime.  The Solterra therefore adds no BMS code of its
-own — per-cell history, deviation flags and pack statistics come from the shared platform.
-
-The Solterra is the pack the platform defaults to and the only one validated on hardware:
-
-* Pack: 96S CATL, Toyota EM "Type B" cells, 24 temperature sensors
-* Cell arrangement: 96 voltages in 4 modules of 24; 24 temperatures, 6 per module
-* Accept limits: 2.5 to 4.3 V per cell; -30 to +60 °C
-* Deviation thresholds: 20 mV warn / 30 mV alert; 4 °C warn / 8 °C alert
-
-These values live in the e-TNGA base constructor; see the
-:doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the pack variants the
-same code covers.
-
---------------------------------
-Differences from e-TNGA baseline
---------------------------------
+------------------------
+Vehicle-specific support
+------------------------
 
 The Solterra adds no behavioural overrides on top of the e-TNGA platform — the vehicle class is
-a registration wrapper.  Its whole support baseline is the platform's.
+a registration wrapper, and its whole support baseline is the platform's.
 
-Config namespace
-----------------
-
-The Solterra inherits the ``xte`` config namespace from the e-TNGA base.  All
-configuration parameters (e.g. TPMS alert thresholds) use the ``[xte]`` instance::
-
-    config set xte tpms.pressure.warn 240
-
-Web UI
-------
-
-All e-TNGA web UI pages are available on the Solterra; see the
-:doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the
-full list.  ``/bms/cellmon`` is fully populated — per-cell voltage and
-temperature history, deviation flags, and pack statistics are all enabled —
-because the e-TNGA base declares the BMS pack arrangement for every e-TNGA
-vehicle.
+The Solterra is the platform's reference vehicle: e-TNGA is developed against one, and it is the
+only e-TNGA vehicle whose behaviour has been confirmed on real hardware. Which platform
+behaviours that covers, and which remain inferred, is recorded in the validation status table on
+the :doc:`e-TNGA platform page </components/vehicle_toyota_etnga/docs/index>`.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
@@ -3,9 +3,9 @@ Toyota bZ4X
 ===========
 
 The Toyota bZ4X is built on the :doc:`Toyota e-TNGA platform </components/vehicle_toyota_etnga/docs/index>`.
-The e-TNGA module provides the CAN polling, charging state machine, and the common support baseline shared by
-all e-TNGA vehicles. This page documents only what is specific to the bZ4X; see the e-TNGA module for
-everything else.
+The e-TNGA module provides the CAN polling, charging state machine, BMS handling, web UI and the
+common support baseline shared by all e-TNGA vehicles. This page documents only what is specific
+to the bZ4X; see the e-TNGA platform page for everything else.
 
 Supported model years: 2023 and 2024.
 
@@ -15,29 +15,22 @@ Vehicle identity
 
 :Short type code: TOYBZ4X
 :Vehicle name: Toyota bZ4X
-:Log tag: ``v-toyota-bz4x``
-:Config namespace prefix: ``xte`` (inherited from e-TNGA base; bZ4X registers no namespace of its own)
+:Log tag: ``v-toyota-bz4x`` (wrapper only). Nearly all logging comes from the shared
+   e-TNGA platform under ``v-etnga`` — set that one to collect diagnostics, e.g.
+   ``log level verbose v-etnga``.
+:Config namespace: ``xte`` (inherited from the e-TNGA base; the bZ4X registers no
+   namespace of its own)
 
 ------------------------
 Vehicle-specific support
 ------------------------
 
-The bZ4X adds no behavioural overrides on top of the e-TNGA platform; all of its support — including
-per-cell BMS voltage/temperature monitoring — comes from the shared e-TNGA base, which owns the HV
-pack arrangement for every e-TNGA vehicle and derives the actual cell/sensor counts from the battery
-replies at runtime.
+The bZ4X adds no behavioural overrides on top of the e-TNGA platform — the vehicle class is a
+registration wrapper, and its whole support baseline is the platform's.
 
 .. note::
 
-   Per-cell BMS has been validated on the 96-cell Solterra. The e-TNGA base also supports the
-   2025/26 refresh packs (78-cell FWD, 104-cell AWD) by deriving the count from the bus, but those
-   are reasoned from spec and **not yet validated on bZ4X hardware**.
-
-Web UI
-------
-
-All e-TNGA web UI pages are available on the bZ4X; see the
-:doc:`e-TNGA index </components/vehicle_toyota_etnga/docs/index>` for the
-full list.  The per-cell ``/bms/cellmon`` page is populated because the e-TNGA base declares a BMS
-pack arrangement for all e-TNGA vehicles (see above).  The charging pages (``/xte/charge``, ``/xte/reports``) and the TPMS
-configuration page (``/xte/config``) work normally.
+   **No e-TNGA behaviour has been confirmed on bZ4X hardware.**  Every status in the validation
+   table on the :doc:`e-TNGA platform page </components/vehicle_toyota_etnga/docs/index>` was
+   established on a Subaru Solterra, so on a bZ4X even the entries marked vehicle-validated
+   should be read as unvalidated until someone confirms them on a car.

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -56,6 +56,17 @@ Others                      VIN
    per-cell history, deviation flags, and pack statistics work across pack variants (96-cell
    2022-24; 78-cell and 104-cell 2025/26 refresh). Only the 96-cell pack is on-vehicle validated.
 
+   The pack variant follows the **model year and drivetrain**, not the badge — the 2025/26
+   refresh is 78-cell FWD or 104-cell AWD — which is why the count is derived at runtime rather
+   than declared per vehicle.  The pack itself, and the platform-wide limits and alert
+   thresholds the base constructor declares, are:
+
+   * Cells: CATL
+   * Cell arrangement (96-cell pack): 96 voltages in 4 modules of 24; 24 temperature sensors,
+     6 per module
+   * Accept limits: 2.5 to 4.3 V per cell; -30 to +60 °C
+   * Deviation thresholds: 20 mV warn / 30 mV alert; 4 °C warn / 8 °C alert
+
 Validation status
 =================
 


### PR DESCRIPTION
Follow-up to #195. The two vehicle wrapper pages restated material that belongs to the e-TNGA base. The Solterra page was the worse offender, but the bZ4X page did it too. Both classes are registration wrappers with no behaviour of their own, so their pages should carry identity and vehicle-specific caveats and nothing else.

## Solterra page: 63 lines -> 32

Dropped three sections, all of which described the base rather than the Solterra:

- **Battery / BMS** - the base's pack arrangement, its runtime cell-count derivation, and how per-cell readings get routed through the BMS API.
- **Config namespace** - restated the shared `xte` instance and gave a `config set` example. Survives as a one-line field in the identity block, matching how the bZ4X page already did it.
- **Web UI** - restated the base's page list and re-explained why `/bms/cellmon` is populated.

What remains is genuinely Solterra-specific: type code, name, the log tag with the `v-etnga` tip, and the fact that it is the platform's reference vehicle and the only one confirmed on hardware.

## bZ4X page

Dropped the paragraph explaining that the base owns the pack arrangement and derives cell counts at runtime, and the Web UI section restating the base's page list.

Its validation note was rewritten from a BMS-specific caveat into the broader and more useful point: no e-TNGA behaviour at all has been confirmed on bZ4X hardware, so every vehicle-validated status on the platform page was established on a Solterra and should be read as unvalidated on a bZ4X. It also picks up the same `v-etnga` logging tip the Solterra page has, since it applies equally.

## Nothing was deleted outright

The pack values that existed only on the Solterra page are base constructor values, so they moved to the platform page's BMS note rather than being dropped: the CATL cells, the 96-cell arrangement, the accept limits (2.5-4.3 V, -30 to +60 C) and the deviation thresholds (20/30 mV, 4/8 C). All four re-checked against `vehicle_toyota_etnga.cpp`.

Added there as well: the pack variant follows **model year and drivetrain**, not badge - the 2025/26 refresh is 78-cell FWD or 104-cell AWD. That is both the reason the count is derived at runtime instead of declared per vehicle, and the reason neither wrapper page should be claiming a pack at all. The old Solterra page effectively did, by listing the 96-cell specs under a Solterra heading.

Both pages now have the same three-part shape: intro, Vehicle identity, Vehicle-specific support.

## Verification

- Docs build exits 0 with zero `WARNING:` / `ERROR:` lines.
- Re-ran both scripted checks from #195 against this branch: poll table machine-diffed against the parsed source arrays gives 53 PIDs and 0 discrepancies, and 0 of the 37 `xte.*` metrics are undocumented. Neither was touched here, but the base page was edited, so they were re-checked rather than assumed.

`Firmware build` does not run and should not: every changed file is a `*.rst` under `vehicle/**/docs/**`, inside its `paths-ignore`.
