### PR TITLE
bZ4X: shorten the log tag to v-toybz4x

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -42,10 +42,11 @@ Open Vehicle Monitor System v3 - Change log
     on DC fast charge, leaving the cell display frozen for the whole of an AC session.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): the log tags have been shortened for
     consistency with other vehicles. If you set log levels for diagnostics, use the new names:
-    "v-etnga" (was "v-toyota-etnga") and "v-subsol" (was "v-subaru-solterra"). Almost all
-    messages come from the shared platform, so "log level verbose v-etnga" is the one to set
-    on any of these cars. The separate "v-toyota-etnga-charging" telemetry tag is gone — the
-    same per-second charging data is recorded in the charge-session report CSV.
+    "v-etnga" (was "v-toyota-etnga"), "v-subsol" (was "v-subaru-solterra") and "v-toybz4x"
+    (was "v-toyota-bz4x"). Almost all messages come from the shared platform, so
+    "log level verbose v-etnga" is the one to set on any of these cars. The separate
+    "v-toyota-etnga-charging" telemetry tag is gone — the same per-second charging data is
+    recorded in the charge-session report CSV.
 - Toyota e-TNGA (Subaru Solterra / Toyota bZ4X): v.e.awake now reflects the vehicle being
     switched on (AWAKE/DRIVING) rather than raw CAN2 bus activity, so it no longer reads true
     during a charge — the module no longer sends the periodic "Vehicle is idling / stopped

--- a/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/docs/index.rst
@@ -15,7 +15,7 @@ Vehicle identity
 
 :Short type code: TOYBZ4X
 :Vehicle name: Toyota bZ4X
-:Log tag: ``v-toyota-bz4x`` (wrapper only). Nearly all logging comes from the shared
+:Log tag: ``v-toybz4x`` (wrapper only). Nearly all logging comes from the shared
    e-TNGA platform under ``v-etnga`` — set that one to collect diagnostics, e.g.
    ``log level verbose v-etnga``.
 :Config namespace: ``xte`` (inherited from the e-TNGA base; the bZ4X registers no

--- a/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/src/vehicle_toyota_bz4x.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_bz4x/src/vehicle_toyota_bz4x.h
@@ -34,7 +34,7 @@ class OvmsVehicleToyotaBz4x : public OvmsVehicleToyotaETNGA
   public:
     OvmsVehicleToyotaBz4x();  // Constructor for the Toyota Bz4x vehicle module
     ~OvmsVehicleToyotaBz4x();  // Destructor for the Toyota Bz4x vehicle module
-    static constexpr const char* TAG = "v-toyota-bz4x";
+    static constexpr const char* TAG = "v-toybz4x";
 
   };
 


### PR DESCRIPTION
## What

Renames the Toyota bZ4X wrapper's log tag from `v-toyota-bz4x` to `v-toybz4x`.

## Why

The e-TNGA family shortened its log tags to `v-` plus the lowercased registered short type code, but the bZ4X wrapper was missed and kept the old long form. The precedent is in the source: the Solterra wrapper registers as `SUBSOL` and tags as `v-subsol`, so the bZ4X, which registers as `TOYBZ4X`, should tag as `v-toybz4x`. The e-TNGA base itself is `v-etnga`.

## Changes

- `components/vehicle_toyota_bz4x/src/vehicle_toyota_bz4x.h` - the `TAG` constant.
- `components/vehicle_toyota_bz4x/docs/index.rst` - the log tag in the "Vehicle identity" block.
- `changes.txt` - the existing (still unreleased) bullet about the shortened e-TNGA log tags listed only `v-etnga` and `v-subsol`; it now lists `v-toybz4x` too. Extending that bullet rather than adding a second one keeps the release notes for this release a single coherent statement. This is user-facing: anyone who sets `log level verbose v-toyota-bz4x` has to change what they type.

No functional change beyond the tag string. The e-TNGA base and the Solterra wrapper are untouched.

## Verification

- Docs built locally with Sphinx: exit 0, zero `WARNING:` / `ERROR:` lines.
- Firmware build dispatched on this branch. `build.yml`'s `ENABLE_VEHICLES` includes `CONFIG_OVMS_VEHICLE_TOYOTA_BZ4X`, so the compile gate does cover the changed header.
- Repo-wide grep confirms no remaining occurrence of the old tag string.
