### PR TITLE
e-TNGA: add the missing CMakeLists.txt and drop three dead metrics

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(srcs)
+set(include_dirs)
+
+# The e-TNGA platform is a shared base, not a directly selectable vehicle: it builds
+# whenever any vehicle derived from it is selected. Mirrors the condition in component.mk.
+if (CONFIG_OVMS_VEHICLE_SUBARU_SOLTERRA OR CONFIG_OVMS_VEHICLE_TOYOTA_BZ4X)
+  list(APPEND srcs "src/etnga_can_processor.cpp" "src/etnga_charge_dump.cpp" "src/etnga_charge_io.cpp" "src/etnga_charge_report.cpp" "src/etnga_metrics.cpp" "src/etnga_poll_processor.cpp" "src/etnga_poll_states.cpp" "src/etnga_tpms.cpp" "src/etnga_web.cpp" "src/vehicle_toyota_etnga.cpp")
+  list(APPEND include_dirs "src")
+endif ()
+
+# requirements can't depend on config
+idf_component_register(SRCS ${srcs}
+                       INCLUDE_DIRS ${include_dirs}
+                       PRIV_REQUIRES "main"
+                       WHOLE_ARCHIVE)

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/docs/index.rst
@@ -487,7 +487,7 @@ OVMS metrics:
      - AC grid energy delivered this session and lifetime (AC only; reads 0 during DC)
    * - ``v.b.cac``
      - HV Battery ECU ``0x747``, ``0x1D3E``
-     - Pack full-charge capacity (Ah) as measured by the BMS, summed from eight per-module slots
+     - Pack full-charge capacity (Ah) as measured by the BMS: the mean of eight per-module slots
    * - ``v.b.soh`` / ``v.b.capacity``
      - derived from ``v.b.cac``
      - State of health (%) and usable capacity (kWh) against the pack nominal.  Only the
@@ -600,16 +600,10 @@ HV battery internals:
      - HV Battery ECU ``0x747``, ``0x1F5B``
      - SOC as the BMS reports it, which differs from the displayed ``v.b.soc``: the displayed
        figure spans only the usable part of the pack and reaches 100 % at roughly 95 % BMS
-   * - ``xte.v.b.temp.coolant`` / ``xte.v.b.temp.heater`` /
-       ``xte.v.b.heater``
-     - not currently populated
-     - Battery coolant and coolant-heater temperatures (°C) and the coolant heater relay
-       state.  The metrics are registered so the names are stable, but no DID has been
-       identified for them yet, so they never leave their initial value.  Do not read them
    * - ``xte.v.b.cap.full`` / ``xte.v.b.cap.alt``
      - HV Battery ECU ``0x747``, ``0x1D3E`` / ``0x1D3F``
      - The raw eight-slot per-module capacity arrays.  ``cap.full`` is what ``v.b.cac`` is
-       summed from; ``cap.alt`` is collected for analysis only, its function unconfirmed
+       averaged from; ``cap.alt`` is collected for analysis only, its function unconfirmed
    * - ``xte.v.b.lifetime.acc`` / ``xte.v.b.lifetime.min``
      - HV Battery ECU ``0x747``, ``0x1D70``
      - The two lifetime counters, logged raw because their units are unresolved

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/etnga_metrics.cpp
@@ -59,10 +59,7 @@ void OvmsVehicleToyotaETNGA::InitializeMetrics()
     // unresolved, so applying any scale here would invent precision we do not have.
     m_v_bat_lifetime_min = MyMetrics.InitInt  ("xte.v.b.lifetime.min", SM_STALE_MAX, 0, Other);  // 0x1D70 b0-3  ~1/min tick
     m_v_bat_lifetime_acc = MyMetrics.InitInt64("xte.v.b.lifetime.acc", SM_STALE_MAX, 0, Other);  // 0x1D70 b12-15 load-proportional accumulator
-    m_v_bat_heater_status = MyMetrics.InitBool("xte.v.b.heater", SM_STALE_MID);  // This variable stores the status of the battery coolant heater relay
     m_v_bat_soc_bms = MyMetrics.InitFloat("xte.v.b.soc.bms", SM_STALE_MID, 0.0f, Percentage, true);  // This variable stores the SOC as reported by the BMS
-    m_v_bat_temp_coolant = MyMetrics.InitFloat("xte.v.b.temp.coolant", SM_STALE_MID, 0.0f, Celcius);  // This variable stores the temperature of the battery coolant
-    m_v_bat_temp_heater = MyMetrics.InitFloat("xte.v.b.temp.heater", SM_STALE_MID, 0.0f, Celcius);  // This variable stores the temperature of the battery coolant
     m_v_bat_12v_voltage_pid = MyMetrics.InitFloat("xte.v.b.12v.voltage", SM_STALE_MID, 0.0f, Volts);  // 0x15EE EV-ECU PID 12V voltage (compare vs hardware v.b.12v.voltage)
     m_v_bat_12v_temp = MyMetrics.InitFloat("xte.v.b.12v.temp", SM_STALE_MID, 0.0f, Celcius);   // 0x15F8 12V aux battery temperature
     m_v_bat_12v_cac  = MyMetrics.InitFloat("xte.v.b.12v.cac",  SM_STALE_MID, 0.0f, AmpHours);  // 0x15E5 12V aux full-charge capacity

--- a/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyota_etnga/src/vehicle_toyota_etnga.h
@@ -232,10 +232,7 @@ protected:
     OvmsMetricInt*   m_v_bat_lifetime_min;   // xte.v.b.lifetime.min 0x1D70 bytes 0-3, raw u32 — ticks ~1/min, load-independent
     OvmsMetricInt64* m_v_bat_lifetime_acc;   // xte.v.b.lifetime.acc 0x1D70 bytes 12-15, raw u32 — load-proportional accumulator, UNITS UNKNOWN.
                                              // int64 because the u32 is already at 3.15e8 and climbs ~36/s: it passes INT32_MAX in ~1.6 years.
-    OvmsMetricBool* m_v_bat_heater_status;
     OvmsMetricFloat* m_v_bat_soc_bms;
-    OvmsMetricFloat* m_v_bat_temp_coolant;
-    OvmsMetricFloat* m_v_bat_temp_heater;
     OvmsMetricFloat* m_v_bat_12v_voltage_pid;  // xte.v.b.12v.voltage 0x15EE EV-ECU PID read (compare vs hardware v.b.12v.voltage)
     OvmsMetricFloat* m_v_bat_12v_temp;     // xte.v.b.12v.temp 0x15F8 12V aux temperature (C)
     OvmsMetricFloat* m_v_bat_12v_cac;      // xte.v.b.12v.cac 0x15E5 12V aux full-charge capacity (Ah)


### PR DESCRIPTION
Two items from the e-TNGA upstream-prep list. Both are self-contained and neither changes behaviour on a working module.

## The missing CMakeLists.txt

`vehicle_toyota_etnga` was the only one of the **48** vehicle components without a `CMakeLists.txt` - both of its own wrappers, `vehicle_subaru_solterra` and `vehicle_toyota_bz4x`, already had theirs.

The legacy `make` build reads `component.mk` and was unaffected, which is why this went unnoticed. Under the CMake build, though, the platform base's ten source files were simply absent - and since the base is where essentially all of the e-TNGA implementation lives, that is not a subtle failure.

Modelled on the sibling components and on `vehicle_vweup`, the closest analogue in having several source files. The condition is the same either-or `component.mk` already uses, because the e-TNGA base is a shared platform rather than a directly selectable vehicle: it builds whenever a vehicle derived from it is selected.

Verified by script rather than by eye: the CMakeLists source list matches the ten `.cpp` files on disk exactly (nothing missing, nothing listed that does not exist), and its two `CONFIG_OVMS_VEHICLE_*` symbols are the same pair `component.mk` conditions on.

## Three dead metrics

`xte.v.b.temp.coolant`, `xte.v.b.temp.heater` and `xte.v.b.heater` were created in `InitializeMetrics()` and assigned **nowhere** in the module. No DID was ever identified for them, so they were registered at boot and then sat at their initial values forever. No setters, no readers.

Registering a metric that is never written is worse than not having it: it appears in the metrics list, in the web UI and over the server protocol as a real reading of `0.0` degrees C or `false`, which is indistinguishable from a genuine measurement. Removed, along with their member declarations and the documentation row that had been added to describe them as unpopulated.

A scan now reports **zero** registered-but-never-written `xte` metrics, and all 31 remaining registered metrics are documented.

## One correction picked up along the way

The docs described `v.b.cac` as "summed from" the eight per-module slots of `0x1D3E` on the HV Battery ECU. `UpdateBatteryHealth()` divides by eight - it is the **mean**, not the sum. The distinction matters: a sum would be roughly 1581 Ah against the mean's 197.656 Ah, so the wrong word makes the published figure look like an entirely different quantity. Fixed in both places it appeared.

## Deliberately not in scope

The two data-collection metric groups also destined for removal before upstreaming - the raw capacity arrays (`xte.v.b.cap.full` / `cap.alt`) and the `0x1D70` lifetime counters - are **not** touched here. They are still collecting data for open questions: `0x1D3F`'s function is unconfirmed, and `0x1D70`'s accumulator scale needs a drive to resolve. They stay on fork master and get stripped on the upstream branch, which is where that removal belongs.

Note that `0x1D3E`'s poll must survive that eventual strip regardless, since it now feeds `v.b.cac`.

## Verification

Docs build exits 0 with zero `WARNING:` / `ERROR:` lines. The code change is compile-gated by CI, which builds with Solterra and bZ4X enabled and therefore compiles both edited files. Not flashed to hardware; the removed metrics had no readers, so there is no runtime behaviour to observe.
